### PR TITLE
adds register/unregister session menu item

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -64,7 +64,7 @@ class MenuFactory extends Component {
   // intercepts click events; calls callback and toggles Menu open state
   menuItemClick = (itemClick) => {
     itemClick();
-    this.props.toggleMenu();
+    this.menuClick();
   }
 
   render() {

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { sessionMenuIsOpen } from '../selectors/session';
+import { isCordova, isElectron } from '../utils/Environment';
 import { Menu } from '../components';
 
 /**
@@ -13,11 +14,9 @@ import { Menu } from '../components';
   */
 class SessionMenu extends Component {
   onQuit = () => {
-    if (navigator.app) {
+    if (isCordova()) {
       // cordova
       navigator.app.exitApp();
-    } else if (navigator.device) {
-      navigator.device.exitApp();
     } else {
       // note: this will only close windows opened by the app, not a new tab the user opened
       window.close();
@@ -30,15 +29,25 @@ class SessionMenu extends Component {
 
   render() {
     const {
-      hideButton, isOpen, toggleMenu,
+      customItems, hideButton, isOpen, toggleMenu,
     } = this.props;
 
     const menuType = 'settings';
 
     const items = [
-      { id: 'reset', menuType, title: 'Reset Session', interfaceType: 'menu-purge-data', isActive: false, onClick: this.onReset },
-      { id: 'quit', menuType, title: 'Quit Network Canvas', interfaceType: 'menu-quit', isActive: false, onClick: this.onQuit },
-    ];
+      { id: 'reset', title: 'Reset Session', interfaceType: 'menu-purge-data', onClick: this.onReset },
+      ...customItems,
+      { id: 'quit', title: 'Quit Network Canvas', interfaceType: 'menu-quit', onClick: this.onQuit },
+    ].map((item) => {
+      const temp = item;
+      if (!temp.menuType) {
+        temp.menuType = 'settings';
+      }
+      if (!temp.interfaceType) {
+        temp.interfaceType = 'menu-custom-interface';
+      }
+      return temp;
+    });
 
     return (
       <Menu
@@ -54,6 +63,7 @@ class SessionMenu extends Component {
 }
 
 SessionMenu.propTypes = {
+  customItems: PropTypes.array.isRequired,
   hideButton: PropTypes.bool,
   isOpen: PropTypes.bool,
   resetState: PropTypes.func.isRequired,
@@ -67,6 +77,7 @@ SessionMenu.defaultProps = {
 
 function mapStateToProps(state) {
   return {
+    customItems: state.menu.customMenuItems,
     isOpen: sessionMenuIsOpen(state),
   };
 }

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { sessionMenuIsOpen } from '../selectors/session';
-import { isCordova, isElectron } from '../utils/Environment';
+import { isCordova } from '../utils/Environment';
 import { Menu } from '../components';
 
 /**

--- a/src/ducks/modules/menu.js
+++ b/src/ducks/modules/menu.js
@@ -1,9 +1,12 @@
+const REGISTER_MENU_ITEM = 'REGISTER_MENU_ITEM';
 const RESET_STATE = 'RESET_STATE';
 const TOGGLE_SESSION_MENU = 'TOGGLE_SESSION_MENU';
 const TOGGLE_STAGE_MENU = 'TOGGLE_STAGE_MENU';
 const UPDATE_STAGE_SEARCH = 'UPDATE_STAGE_SEARCH';
+const UNREGISTER_MENU_ITEM = 'UNREGISTER_MENU_ITEM';
 
 const initialState = {
+  customMenuItems: [],
   sessionMenuIsOpen: false,
   stageMenuIsOpen: false,
   stageSearchTerm: '',
@@ -11,6 +14,12 @@ const initialState = {
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
+    case REGISTER_MENU_ITEM: {
+      return {
+        ...state,
+        customMenuItems: state.customMenuItems.concat(action.menuItem),
+      };
+    }
     case TOGGLE_SESSION_MENU: {
       return {
         ...state,
@@ -29,9 +38,22 @@ export default function reducer(state = initialState, action = {}) {
         stageSearchTerm: action.searchTerm,
       };
     }
+    case UNREGISTER_MENU_ITEM: {
+      return {
+        ...state,
+        customMenuItems: state.customMenuItems.filter(item => item.id !== action.id),
+      };
+    }
     default:
       return state;
   }
+}
+
+function registerMenuItem(menuItem) {
+  return {
+    type: REGISTER_MENU_ITEM,
+    menuItem,
+  };
 }
 
 function resetState() {
@@ -59,18 +81,29 @@ function updateStageSearch(searchTerm) {
   };
 }
 
+function unregisterMenuItem(id) {
+  return {
+    type: UNREGISTER_MENU_ITEM,
+    id,
+  };
+}
+
 const actionCreators = {
+  registerMenuItem,
   resetState,
   toggleSessionMenu,
   toggleStageMenu,
   updateStageSearch,
+  unregisterMenuItem,
 };
 
 const actionTypes = {
+  REGISTER_MENU_ITEM,
   RESET_STATE,
   TOGGLE_SESSION_MENU,
   TOGGLE_STAGE_MENU,
   UPDATE_STAGE_SEARCH,
+  UNREGISTER_MENU_ITEM,
 };
 
 export {


### PR DESCRIPTION
Adds a register and unregister session menu item. When you register an item, you pass in an object with an `id`, `title`, and `onClick` function. The `interfaceType` is optional, but currently defaults to `menu-custom-interface`. Session menu places it between `Reset` and `Quit` for now, in the order it is received.