### PR TITLE
Auto scale node text size

### DIFF
--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -2,29 +2,34 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const childOutOfBounds = (parentBounds, childBounds) =>
-  childBounds.height > parentBounds.height || childBounds.width > parentBounds.width;
+const textOutOfBounds = (parent, child) => {
+  const parentBounds = parent.getBoundingClientRect();
+  const childBounds = child.getBoundingClientRect();
+  return childBounds.height > parentBounds.height || childBounds.width > parentBounds.width;
+};
 
 const scaleIncrement = 1;
 
 // TODO move padding: 33% into stylesheet
-function scaleTextToFit(parent, child) {
-  let childBounds = { width: 10000, height: 10000 };
-  const parentBounds = parent.getBoundingClientRect();
-  parent.setAttribute('style', 'position: relative;');
+function scaleTextToFit(element) {
+  element.setAttribute('style', 'position: relative;');
+
+  const text = document.createElement('span');
+  text.append(element.textContent);
+  element.appendChild(text);
 
   const findFontSize = (size) => {
-    child.setAttribute('style', `position: absolute; height: auto; width: auto; padding: 33%; font-size: ${size}px;`);
-    childBounds = child.getBoundingClientRect();
-    return !childOutOfBounds(parentBounds, childBounds) ?
+    text.setAttribute('style', `position: absolute; font-size: ${size}px;`);
+
+    return !textOutOfBounds(element, text) ?
       findFontSize(size + scaleIncrement) :
       size - scaleIncrement;
   };
 
   const fontSize = findFontSize(8);
 
-  parent.removeAttribute('style');
-  child.setAttribute('style', `font-size: ${fontSize}px; padding: 33%; overflow: hidden;`);
+  element.removeChild(text);
+  element.setAttribute('style', `font-size: ${fontSize}px; overflow: hidden;`);
 }
 
 /**

--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -24,7 +24,7 @@ function scaleTextToFit(parent, child) {
   const fontSize = findFontSize(8);
 
   parent.removeAttribute('style');
-  child.setAttribute('style', `font-size: ${fontSize}px;`);
+  child.setAttribute('style', `font-size: ${fontSize}px; padding: 33%; overflow: hidden;`);
 }
 
 /**

--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -12,7 +12,7 @@ const scaleIncrement = 1;
 
 // TODO move padding: 33% into stylesheet
 function scaleTextToFit(element) {
-  element.setAttribute('style', 'position: relative;');
+  element.setAttribute('style', 'position: relative; margin: 33%; ');
 
   const text = document.createElement('span');
   text.append(element.textContent);
@@ -29,7 +29,7 @@ function scaleTextToFit(element) {
   const fontSize = findFontSize(8);
 
   element.removeChild(text);
-  element.setAttribute('style', `font-size: ${fontSize}px; overflow: hidden;`);
+  element.setAttribute('style', `margin: 33%; font-size: ${fontSize}px; overflow: hidden;`);
 }
 
 /**
@@ -37,12 +37,12 @@ function scaleTextToFit(element) {
   */
 class Node extends Component {
   componentDidMount() {
-    scaleTextToFit(this.node, this.node.querySelectorAll('.node__label')[0]);
+    scaleTextToFit(this.node.querySelectorAll('.node__label')[0]);
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.label !== this.props.label) {
-      scaleTextToFit(this.node, this.node.querySelectorAll('.node__label')[0]);
+      scaleTextToFit(this.node.querySelectorAll('.node__label')[0]);
     }
   }
 

--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -1,35 +1,38 @@
+/* eslint-disable */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const textOutOfBounds = (parent, child) => {
-  const parentBounds = parent.getBoundingClientRect();
-  const childBounds = child.getBoundingClientRect();
-  return childBounds.height > parentBounds.height || childBounds.width > parentBounds.width;
+const textOutOfBounds = (containerElement, textElement) => {
+  const containerBounds = containerElement.getBoundingClientRect();
+  const textBounds = textElement.getBoundingClientRect();
+  return textBounds.height > containerBounds.height || textBounds.width > containerBounds.width;
 };
 
 const scaleIncrement = 1;
 
 // TODO move padding: 33% into stylesheet
 function scaleTextToFit(element) {
-  element.setAttribute('style', 'position: relative; margin: 33%; ');
+  element.setAttribute('style', 'position: relative; width: 100%; height: 100%;');
+  const text = element.textContent;
+  element.innerHTML = '';
 
-  const text = document.createElement('span');
-  text.append(element.textContent);
-  element.appendChild(text);
+  const textElement = document.createElement('span');
+  textElement.innerHTML = text;
+  element.appendChild(textElement);
 
   const findFontSize = (size) => {
-    text.setAttribute('style', `position: absolute; font-size: ${size}px;`);
+    textElement.setAttribute('style', `position: absolute; font-size: ${size}px;`);
 
-    return !textOutOfBounds(element, text) ?
+    return !textOutOfBounds(element, textElement) ?
       findFontSize(size + scaleIncrement) :
       size - scaleIncrement;
   };
 
   const fontSize = findFontSize(8);
 
-  element.removeChild(text);
-  element.setAttribute('style', `margin: 33%; font-size: ${fontSize}px; overflow: hidden;`);
+  element.innerHTML = text;
+  element.setAttribute('style', `font-size: ${fontSize}px; width: 100%; height: 100%; overflow: hidden;display: flex;justify-content: center;align-items: center;flex-wrap: nowrap;`);
 }
 
 /**
@@ -37,13 +40,17 @@ function scaleTextToFit(element) {
   */
 class Node extends Component {
   componentDidMount() {
-    scaleTextToFit(this.node.querySelectorAll('.node__label')[0]);
+    scaleTextToFit(this.labelTextElement());
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.label !== this.props.label) {
-      scaleTextToFit(this.node.querySelectorAll('.node__label')[0]);
+      scaleTextToFit(this.labelTextElement());
     }
+  }
+
+  labelTextElement() {
+    return this.node.querySelectorAll('.node__label-text')[0];
   }
 
   render() {
@@ -84,7 +91,9 @@ class Node extends Component {
           />
           <circle vectorEffect="non-scaling-stroke" cx="0" cy="0" r="1" className="node__node-trim" />
         </svg>
-        <div className="node__label">{label}</div>
+        <div className="node__label" style={{ padding: '33%' }}>
+          <div className="node__label-text" style={{ width: '100%', height: '100%' }}>{label}</div>
+        </div>
       </div>
     );
   }

--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -1,0 +1,92 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const childOutOfBounds = (parentBounds, childBounds) =>
+  childBounds.height > parentBounds.height || childBounds.width > parentBounds.width;
+
+const scaleIncrement = 2;
+
+// TODO move padding: 33% into stylesheet
+function scaleTextToFit(parent, child) {
+  const styles = window.getComputedStyle(child, null);
+  let fontSize = parseInt(styles['font-size'], 10) + scaleIncrement;
+  let childBounds = { width: 1000, height: 1000 };
+  const parentBounds = parent.getBoundingClientRect();
+  parent.setAttribute('style', 'position: relative;');
+
+  while (fontSize > 0 && childOutOfBounds(parentBounds, childBounds)) {
+    fontSize -= scaleIncrement;
+    child.setAttribute('style', `position: absolute; height: auto; width: auto; padding: 33%; font-size: ${fontSize}px;`);
+    childBounds = child.getBoundingClientRect();
+  }
+
+  parent.removeAttribute('style');
+  child.setAttribute('style', `font-size: ${fontSize}px;`);
+}
+
+/**
+  * Renders a Node.
+  */
+class Node extends Component {
+  componentDidUpdate() {
+    scaleTextToFit(this.node, this.node.querySelectorAll('.node__label')[0]);
+  }
+
+  render() {
+    const {
+      selected,
+      placeholder,
+    } = this.props;
+
+    const classes = classNames(
+      'node',
+      {
+        'node--selected': selected,
+        'node--placeholder': placeholder,
+      },
+    );
+
+    const label = placeholder ? '+' : this.props.label;
+
+    return (
+      <div
+        className={classes}
+        ref={(node) => { this.node = node; }}
+      >
+        <svg
+          viewBox="-1.5 -1.5 3 3"
+          xmlns="http://www.w3.org/2000/svg"
+          width="100"
+          height="100"
+          className="node__node"
+        >
+          <circle vectorEffect="non-scaling-stroke" cx="0" cy="0" r="1" className="node__node-outer-trim" />
+          <circle cx="0" cy="0" r="1" fill="silver" className="node__node-base" />
+          <path
+            className="node__node-flash"
+            d="M -1 0 A 0.2,0.2 0 1,1 1,0"
+            fill="grey"
+            transform="rotate(135)"
+          />
+          <circle vectorEffect="non-scaling-stroke" cx="0" cy="0" r="1" className="node__node-trim" />
+        </svg>
+        <div className="node__label">{label}</div>
+      </div>
+    );
+  }
+}
+
+Node.propTypes = {
+  label: PropTypes.string,
+  selected: PropTypes.bool,
+  placeholder: PropTypes.bool,
+};
+
+Node.defaultProps = {
+  label: 'Node',
+  selected: false,
+  placeholder: false,
+};
+
+export default Node;

--- a/src/components/Elements/Node.js
+++ b/src/components/Elements/Node.js
@@ -5,21 +5,23 @@ import classNames from 'classnames';
 const childOutOfBounds = (parentBounds, childBounds) =>
   childBounds.height > parentBounds.height || childBounds.width > parentBounds.width;
 
-const scaleIncrement = 2;
+const scaleIncrement = 1;
 
 // TODO move padding: 33% into stylesheet
 function scaleTextToFit(parent, child) {
-  const styles = window.getComputedStyle(child, null);
-  let fontSize = parseInt(styles['font-size'], 10) + scaleIncrement;
-  let childBounds = { width: 1000, height: 1000 };
+  let childBounds = { width: 10000, height: 10000 };
   const parentBounds = parent.getBoundingClientRect();
   parent.setAttribute('style', 'position: relative;');
 
-  while (fontSize > 0 && childOutOfBounds(parentBounds, childBounds)) {
-    fontSize -= scaleIncrement;
-    child.setAttribute('style', `position: absolute; height: auto; width: auto; padding: 33%; font-size: ${fontSize}px;`);
+  const findFontSize = (size) => {
+    child.setAttribute('style', `position: absolute; height: auto; width: auto; padding: 33%; font-size: ${size}px;`);
     childBounds = child.getBoundingClientRect();
-  }
+    return !childOutOfBounds(parentBounds, childBounds) ?
+      findFontSize(size + scaleIncrement) :
+      size - scaleIncrement;
+  };
+
+  const fontSize = findFontSize(8);
 
   parent.removeAttribute('style');
   child.setAttribute('style', `font-size: ${fontSize}px;`);
@@ -29,8 +31,14 @@ function scaleTextToFit(parent, child) {
   * Renders a Node.
   */
 class Node extends Component {
-  componentDidUpdate() {
+  componentDidMount() {
     scaleTextToFit(this.node, this.node.querySelectorAll('.node__label')[0]);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.label !== this.props.label) {
+      scaleTextToFit(this.node, this.node.querySelectorAll('.node__label')[0]);
+    }
   }
 
   render() {

--- a/src/components/Elements/NodeList.js
+++ b/src/components/Elements/NodeList.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Node, animation } from 'network-canvas-ui';
+import { animation } from 'network-canvas-ui';
 import StaggeredTransitionGroup from '../../utils/StaggeredTransitionGroup';
 import { scrollable, droppable, draggable, selectable } from '../../behaviours';
+import Node from './Node';
 
 const EnhancedNode = draggable(selectable(Node));
 

--- a/src/other/demo.protocol.js
+++ b/src/other/demo.protocol.js
@@ -64,8 +64,8 @@ const fields = [
     placeholder: 'Name',
     validation: {
       required: true,
-      minLength: 2,
-      minLength: 8,
+      minLength: 1,
+      maxLength: 8,
     }
   },
   {
@@ -75,7 +75,7 @@ const fields = [
     placeholder: 'Nickname',
     validation: {
       required: true,
-      minLength: 2,
+      minLength: 1,
       maxLength: 8,
     },
   },


### PR DESCRIPTION
Request for review not merge.

This shrinks the text inside a node until it fits. It starts at the initial stylesheet size, and works down from there.

Known limitations: Is run every time props change on a component.

Any thoughts or feedback?

Things left to do:
- Extract scaleTextToFit into own util
- Move scaleTextToFit and Node back into UI