### PR TITLE
Feature/add toggle cards

### DIFF
--- a/src/behaviours/scrollable.js
+++ b/src/behaviours/scrollable.js
@@ -14,11 +14,15 @@ const scrollable = WrappedComponent =>
     }
 
     componentDidMount() {
-      this.scrollable.addEventListener('scroll', this.updateScrollState);
+      if (this.scrollable) {
+        this.scrollable.addEventListener('scroll', this.updateScrollState);
+      }
     }
 
     componentWillUnmount() {
-      this.scrollable.removeEventListener('scroll', this.updateScrollState);
+      if (this.scrollable) {
+        this.scrollable.removeEventListener('scroll', this.updateScrollState);
+      }
     }
 
     updateScrollState = () => {

--- a/src/behaviours/selectable.js
+++ b/src/behaviours/selectable.js
@@ -31,7 +31,7 @@ export default function selectable(WrappedComponent) {
 
       if (!allowSelect) { return <WrappedComponent {...rest} />; }
 
-      return <WrappedComponent {...rest} ref={() => { this.node = findDOMNode(this); }} />;
+      return <WrappedComponent {...rest} ref={(node) => { this.node = node; }} />;
     }
   }
 

--- a/src/behaviours/selectable.js
+++ b/src/behaviours/selectable.js
@@ -31,7 +31,7 @@ export default function selectable(WrappedComponent) {
 
       if (!allowSelect) { return <WrappedComponent {...rest} />; }
 
-      return <WrappedComponent {...rest} ref={(node) => { this.node = node; }} />;
+      return <WrappedComponent {...rest} ref={() => { this.node = findDOMNode(this); }} />;
     }
   }
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-import { ContextInput } from 'network-canvas-ui';
-
 /**
   * Renders a card with details.
   */
@@ -29,11 +27,6 @@ const Card = (props) => {
 
   return (
     <div className={classes}>
-      <ContextInput
-        name="indicator"
-        label="&#10003;"
-        checked={selected}
-      />
       <svg
         xmlns="http://www.w3.org/2000/svg"
         x="0px"

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,59 +1,61 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 /**
   * Renders a card with details.
   */
-const Card = (props) => {
-  const {
-    details,
-    label,
-    selected,
-  } = props;
+class Card extends PureComponent {
+  render() {
+    const {
+      details,
+      label,
+      selected,
+    } = this.props;
 
-  const attributes = details.map(
-    (detail, index) => {
-      const key = Object.keys(detail)[0];
-      return (
-        <h5 key={index} className="card__attribute">
-          {key}: {detail[key]}
-        </h5>
-      );
-    },
-  );
+    const attributes = details.map(
+      (detail, index) => {
+        const key = Object.keys(detail)[0];
+        return (
+          <h5 key={index} className="card__attribute">
+            {key}: {detail[key]}
+          </h5>
+        );
+      },
+    );
 
-  const classes = cx({
-    card: true,
-    'card--selected': selected,
-  });
+    const classes = cx({
+      card: true,
+      'card--selected': selected,
+    });
 
-  return (
-    <div className={classes}>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        x="0px"
-        y="0px"
-        viewBox="0 0 100 100"
-        className="card__indicator"
-      >
-        <g>
-          <path d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z" />
-          <polygon points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6" />
-        </g>
-      </svg>
+    return (
+      <div className={classes}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          x="0px"
+          y="0px"
+          viewBox="0 0 100 100"
+          className="card__indicator"
+        >
+          <g>
+            <path d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z" />
+            <polygon points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6" />
+          </g>
+        </svg>
 
-      <div>
-        <h1 className="card__label">
-          { label }
-        </h1>
-        <div className="card__attributes">
-          { attributes }
+        <div>
+          <h1 className="card__label">
+            { label }
+          </h1>
+          <div className="card__attributes">
+            { attributes }
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 Card.propTypes = {
   details: PropTypes.array,

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -12,12 +12,15 @@ const Card = (props) => {
     selected,
   } = props;
 
-  const attributes = Object.entries(details).map(
-    ([key, value]) => (
-      <h5 key={key} className="card__attribute">
-        {key}: {value}
-      </h5>
-    ),
+  const attributes = details.map(
+    (detail, index) => {
+      const key = Object.keys(detail)[0];
+      return (
+        <h5 key={index} className="card__attribute">
+          {key}: {detail[key]}
+        </h5>
+      );
+    },
   );
 
   const classes = cx({
@@ -53,13 +56,13 @@ const Card = (props) => {
 };
 
 Card.propTypes = {
-  details: PropTypes.object,
+  details: PropTypes.array,
   label: PropTypes.string,
   selected: PropTypes.bool,
 };
 
 Card.defaultProps = {
-  details: {},
+  details: [],
   label: '',
   selected: false,
 };

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import { ContextInput } from 'network-canvas-ui';
+
+/**
+  * Renders a card with details.
+  */
+const Card = (props) => {
+  const {
+    details,
+    label,
+    selected,
+  } = props;
+
+  const attributes = Object.entries(details).map(
+    ([key, value]) => (
+      <h5 key={key} className="card__attribute">
+        {key}: {value}
+      </h5>
+    ),
+  );
+
+  const classes = cx({
+    card: true,
+    'card--selected': selected,
+  });
+
+  return (
+    <div className={classes}>
+      <ContextInput
+        name="indicator"
+        label="&#10003;"
+        checked={selected}
+      />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        x="0px"
+        y="0px"
+        viewBox="0 0 100 100"
+        className="card__indicator"
+      >
+        <g>
+          <path d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z" />
+          <polygon points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6" />
+        </g>
+      </svg>
+
+      <div>
+        <h1 className="card__label">
+          { label }
+        </h1>
+        <div className="card__attributes">
+          { attributes }
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Card.propTypes = {
+  details: PropTypes.object,
+  label: PropTypes.string,
+  selected: PropTypes.bool,
+};
+
+Card.defaultProps = {
+  details: {},
+  label: '',
+  selected: false,
+};
+
+export default Card;
+

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -11,6 +11,10 @@ import { Card } from '.';
 
 const EnhancedCard = selectable(Card);
 
+/**
+  * Card List
+  * @extends Component
+  */
 class CardList extends Component {
   constructor(props) {
     super(props);
@@ -20,8 +24,15 @@ class CardList extends Component {
     };
   }
 
+  /**
+    * @param {object} node
+    */
   selected = node => !!this.state.selected.find(current => current.uid === node.uid);
 
+  /**
+    * toggle whether the card is selected or not.
+    * @param {object} node
+    */
   toggleCard = (node) => {
     const index = this.state.selected.findIndex(current => current.uid === node.uid);
     if (index !== -1) {
@@ -37,8 +48,9 @@ class CardList extends Component {
 
   render() {
     const {
-      nodes,
+      details,
       label,
+      nodes,
     } = this.props;
 
     return (
@@ -57,7 +69,7 @@ class CardList extends Component {
               <EnhancedCard
                 label={label(node)}
                 selected={this.selected(node)}
-                details={node}
+                details={details(node)}
                 onSelected={() => this.toggleCard(node)}
               />
             </span>
@@ -69,13 +81,15 @@ class CardList extends Component {
 }
 
 CardList.propTypes = {
-  nodes: PropTypes.array.isRequired,
+  details: PropTypes.func,
   label: PropTypes.func,
+  nodes: PropTypes.array.isRequired,
 };
 
 CardList.defaultProps = {
-  nodes: [],
+  details: () => (''),
   label: () => (''),
+  nodes: [],
 };
 
 function mapStateToProps(state) {

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
 import PropTypes from 'prop-types';
 
 import { animation } from 'network-canvas-ui';
 import StaggeredTransitionGroup from '../utils/StaggeredTransitionGroup';
 import { scrollable, selectable } from '../behaviours';
-import { protocolRegistry } from '../selectors/rehydrate';
 import { Card } from '.';
 
 const EnhancedCard = selectable(Card);
@@ -92,14 +90,7 @@ CardList.defaultProps = {
   nodes: [],
 };
 
-function mapStateToProps(state) {
-  return {
-    variables: protocolRegistry(state).node.person.variables,
-  };
-}
-
 export default compose(
   scrollable,
-  connect(mapStateToProps),
 )(CardList);
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { compose } from 'redux';
 import PropTypes from 'prop-types';
 
-import { animation } from 'network-canvas-ui';
-import StaggeredTransitionGroup from '../utils/StaggeredTransitionGroup';
 import { scrollable, selectable } from '../behaviours';
 import { Card } from '.';
 
@@ -11,86 +9,50 @@ const EnhancedCard = selectable(Card);
 
 /**
   * Card List
-  * @extends Component
   */
-class CardList extends Component {
-  constructor(props) {
-    super(props);
+const CardList = (props) => {
+  const {
+    details,
+    label,
+    nodes,
+    onToggleCard,
+    selected,
+  } = props;
 
-    this.state = {
-      selected: [],
-    };
-  }
-
-  /**
-    * @param {object} node
-    */
-  selected = node => !!this.state.selected.find(current => current.uid === node.uid);
-
-  /**
-    * toggle whether the card is selected or not.
-    * @param {object} node
-    */
-  toggleCard = (node) => {
-    const index = this.state.selected.findIndex(current => current.uid === node.uid);
-    if (index !== -1) {
-      this.setState({
-        selected: this.state.selected.filter((ele, i) => index !== i),
-      });
-    } else {
-      this.setState({
-        selected: this.state.selected.concat(node),
-      });
-    }
-  };
-
-  render() {
-    const {
-      details,
-      label,
-      nodes,
-    } = this.props;
-
-    return (
-      <StaggeredTransitionGroup
-        className="card-list"
-        component="div"
-        delay={animation.duration.fast * 0.2}
-        duration={animation.duration.slow}
-        start={animation.duration.slow + 3}
-        transitionName="card-list--transition"
-        transitionLeave={false}
-      >
-        {
-          nodes.map(node => (
-            <span key={node.uid}>
-              <EnhancedCard
-                label={label(node)}
-                selected={this.selected(node)}
-                details={details(node)}
-                onSelected={() => this.toggleCard(node)}
-              />
-            </span>
-          ))
-        }
-      </StaggeredTransitionGroup>
-    );
-  }
-}
+  return (
+    <div>
+      {
+        nodes.map(node => (
+          <span key={node.uid}>
+            <EnhancedCard
+              label={label(node)}
+              selected={selected(node)}
+              details={details(node)}
+              onSelected={() => onToggleCard(node)}
+            />
+          </span>
+        ))
+      }
+    </div>
+  );
+};
 
 CardList.propTypes = {
   details: PropTypes.func,
   label: PropTypes.func,
   nodes: PropTypes.array.isRequired,
+  onToggleCard: PropTypes.func,
+  selected: PropTypes.func,
 };
 
 CardList.defaultProps = {
   details: () => (''),
   label: () => (''),
   nodes: [],
+  onToggleCard: () => {},
+  selected: () => false,
 };
 
 export default compose(
   scrollable,
 )(CardList);
-

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import PropTypes from 'prop-types';
+
+import { animation } from 'network-canvas-ui';
+import StaggeredTransitionGroup from '../utils/StaggeredTransitionGroup';
+import { scrollable, selectable } from '../behaviours';
+import { protocolRegistry } from '../selectors/rehydrate';
+import { Card } from '.';
+
+const EnhancedCard = selectable(Card);
+
+class CardList extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selected: [],
+    };
+  }
+
+  selected = node => !!this.state.selected.find(current => current.uid === node.uid);
+
+  toggleCard = (node) => {
+    const index = this.state.selected.findIndex(current => current.uid === node.uid);
+    if (index !== -1) {
+      this.setState({
+        selected: this.state.selected.filter((ele, i) => index !== i),
+      });
+    } else {
+      this.setState({
+        selected: this.state.selected.concat(node),
+      });
+    }
+  };
+
+  render() {
+    const {
+      nodes,
+      label,
+    } = this.props;
+
+    return (
+      <StaggeredTransitionGroup
+        className="card-list"
+        component="div"
+        delay={animation.duration.fast * 0.2}
+        duration={animation.duration.slow}
+        start={animation.duration.slow + 3}
+        transitionName="card-list--transition"
+        transitionLeave={false}
+      >
+        {
+          nodes.map(node => (
+            <span key={node.uid}>
+              <EnhancedCard
+                label={label(node)}
+                selected={this.selected(node)}
+                details={node}
+                onSelected={() => this.toggleCard(node)}
+              />
+            </span>
+          ))
+        }
+      </StaggeredTransitionGroup>
+    );
+  }
+}
+
+CardList.propTypes = {
+  nodes: PropTypes.array.isRequired,
+  label: PropTypes.func,
+};
+
+CardList.defaultProps = {
+  nodes: [],
+  label: () => (''),
+};
+
+function mapStateToProps(state) {
+  return {
+    variables: protocolRegistry(state).node.person.variables,
+  };
+}
+
+export default compose(
+  scrollable,
+  connect(mapStateToProps),
+)(CardList);
+

--- a/src/components/__tests__/Card-test.js
+++ b/src/components/__tests__/Card-test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import Card from '../Card';
+
+describe('Card component', () => {
+  it('renders unselected card', () => {
+    const component = shallow(
+      <Card selected={false} label="name" details={[{ age: "33" }]} />,
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders selected card', () => {
+    const component = shallow(
+      <Card selected label="name" details={[{ age: "33" }, { fullname: "full name"}]} />,
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/Card-test.js
+++ b/src/components/__tests__/Card-test.js
@@ -7,7 +7,7 @@ import Card from '../Card';
 describe('Card component', () => {
   it('renders unselected card', () => {
     const component = shallow(
-      <Card selected={false} label="name" details={[{ age: "33" }]} />,
+      <Card selected={false} label="name" details={[{ age: '33' }]} />,
     );
 
     expect(component).toMatchSnapshot();
@@ -15,7 +15,7 @@ describe('Card component', () => {
 
   it('renders selected card', () => {
     const component = shallow(
-      <Card selected label="name" details={[{ age: "33" }, { fullname: "full name"}]} />,
+      <Card selected label="name" details={[{ age: '33' }, { fullname: 'full name' }]} />,
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/__tests__/CardList-test.js
+++ b/src/components/__tests__/CardList-test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import CardList from '../CardList';
+
+const nodes = [
+  { uid: 'a', name: 'a name', age: '22' },
+  { uid: 'b', name: 'b name', age: '88' },
+  { uid: 'c', name: 'c name', age: '33' },
+];
+
+describe('CardList component', () => {
+  it('renders cards with list', () => {
+    const component = shallow(
+      <CardList nodes={nodes} label={node => node.name} details={node => [{ age: `${node.age}` }]} />,
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/CardList-test.js
+++ b/src/components/__tests__/CardList-test.js
@@ -13,7 +13,13 @@ const nodes = [
 describe('CardList component', () => {
   it('renders cards with list', () => {
     const component = shallow(
-      <CardList nodes={nodes} label={node => node.name} details={node => [{ age: `${node.age}` }]} />,
+      <CardList
+        nodes={nodes}
+        label={node => node.name}
+        details={node => [{ age: `${node.age}` }]}
+        onToggleCard={() => {}}
+        selected={() => false}
+      />,
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/__tests__/__snapshots__/Card-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Card-test.js.snap
@@ -2,265 +2,9 @@
 
 exports[`Card component renders selected card 1`] = `
 ShallowWrapper {
-  "complexSelector": ComplexSelector {
-    "buildPredicate": [Function],
-    "childrenOfNode": [Function],
-    "findWhereUnwrapped": [Function],
-  },
   "length": 1,
-  "node": <div
-    className="card card--selected"
->
-    <svg
-        className="card__indicator"
-        viewBox="0 0 100 100"
-        x="0px"
-        xmlns="http://www.w3.org/2000/svg"
-        y="0px"
-    >
-        <g>
-            <path
-                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-            />
-            <polygon
-                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-            />
-        </g>
-    </svg>
-    <div>
-        <h1
-            className="card__label"
-        >
-            name
-        </h1>
-        <div
-            className="card__attributes"
-        >
-            <h5
-                className="card__attribute"
-            >
-                age
-                : 
-                33
-            </h5>
-            <h5
-                className="card__attribute"
-            >
-                fullname
-                : 
-                full name
-            </h5>
-        </div>
-    </div>
-</div>,
-  "nodes": Array [
-    <div
-      className="card card--selected"
->
-      <svg
-            className="card__indicator"
-            viewBox="0 0 100 100"
-            x="0px"
-            xmlns="http://www.w3.org/2000/svg"
-            y="0px"
-      >
-            <g>
-                  <path
-                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                  />
-                  <polygon
-                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                  />
-            </g>
-      </svg>
-      <div>
-            <h1
-                  className="card__label"
-            >
-                  name
-            </h1>
-            <div
-                  className="card__attributes"
-            >
-                  <h5
-                        className="card__attribute"
-                  >
-                        age
-                        : 
-                        33
-                  </h5>
-                  <h5
-                        className="card__attribute"
-                  >
-                        fullname
-                        : 
-                        full name
-                  </h5>
-            </div>
-      </div>
-</div>,
-  ],
-  "options": Object {},
-  "renderer": ReactShallowRenderer {
-    "_instance": ShallowComponentWrapper {
-      "_calledComponentWillUnmount": false,
-      "_compositeType": 2,
-      "_context": Object {},
-      "_currentElement": <Card
-        details={
-                Array [
-                        Object {
-                          "age": "33",
-                        },
-                        Object {
-                          "fullname": "full name",
-                        },
-                      ]
-        }
-        label="name"
-        selected={true}
-/>,
-      "_debugID": 3,
-      "_hostContainerInfo": null,
-      "_hostParent": null,
-      "_instance": StatelessComponent {
-        "_reactInternalInstance": [Circular],
-        "context": Object {},
-        "props": Object {
-          "details": Array [
-            Object {
-              "age": "33",
-            },
-            Object {
-              "fullname": "full name",
-            },
-          ],
-          "label": "name",
-          "selected": true,
-        },
-        "refs": Object {},
-        "state": null,
-        "updater": Object {
-          "enqueueCallback": [Function],
-          "enqueueCallbackInternal": [Function],
-          "enqueueElementInternal": [Function],
-          "enqueueForceUpdate": [Function],
-          "enqueueReplaceState": [Function],
-          "enqueueSetState": [Function],
-          "isMounted": [Function],
-          "validateCallback": [Function],
-        },
-      },
-      "_mountOrder": 2,
-      "_pendingCallbacks": null,
-      "_pendingElement": null,
-      "_pendingForceUpdate": false,
-      "_pendingReplaceState": false,
-      "_pendingStateQueue": null,
-      "_renderedComponent": NoopInternalComponent {
-        "_currentElement": <div
-          className="card card--selected"
->
-          <svg
-                    className="card__indicator"
-                    viewBox="0 0 100 100"
-                    x="0px"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0px"
-          >
-                    <g>
-                              <path
-                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                              />
-                              <polygon
-                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                              />
-                    </g>
-          </svg>
-          <div>
-                    <h1
-                              className="card__label"
-                    >
-                              name
-                    </h1>
-                    <div
-                              className="card__attributes"
-                    >
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        age
-                                        : 
-                                        33
-                              </h5>
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        fullname
-                                        : 
-                                        full name
-                              </h5>
-                    </div>
-          </div>
-</div>,
-        "_debugID": 4,
-        "_renderedOutput": <div
-          className="card card--selected"
->
-          <svg
-                    className="card__indicator"
-                    viewBox="0 0 100 100"
-                    x="0px"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0px"
-          >
-                    <g>
-                              <path
-                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                              />
-                              <polygon
-                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                              />
-                    </g>
-          </svg>
-          <div>
-                    <h1
-                              className="card__label"
-                    >
-                              name
-                    </h1>
-                    <div
-                              className="card__attributes"
-                    >
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        age
-                                        : 
-                                        33
-                              </h5>
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        fullname
-                                        : 
-                                        full name
-                              </h5>
-                    </div>
-          </div>
-</div>,
-      },
-      "_renderedNodeType": 0,
-      "_rootNodeID": 0,
-      "_topLevelWrapper": null,
-      "_updateBatchNumber": null,
-      "_warnedAboutRefsInRender": false,
-    },
-    "getRenderOutput": [Function],
-    "render": [Function],
-  },
-  "root": [Circular],
-  "unrendered": <Card
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Card
     details={
         Array [
             Object {
@@ -274,236 +18,498 @@ ShallowWrapper {
     label="name"
     selected={true}
 />,
-}
-`;
-
-exports[`Card component renders unselected card 1`] = `
-ShallowWrapper {
-  "complexSelector": ComplexSelector {
-    "buildPredicate": [Function],
-    "childrenOfNode": [Function],
-    "findWhereUnwrapped": [Function],
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
   },
-  "length": 1,
-  "node": <div
-    className="card"
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <svg
+          className="card__indicator"
+          viewBox="0 0 100 100"
+          x="0px"
+          xmlns="http://www.w3.org/2000/svg"
+          y="0px"
 >
-    <svg
-        className="card__indicator"
-        viewBox="0 0 100 100"
-        x="0px"
-        xmlns="http://www.w3.org/2000/svg"
-        y="0px"
-    >
-        <g>
+          <g>
+                    <path
+                              d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                    />
+                    <polygon
+                              points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                    />
+          </g>
+</svg>,
+        <div>
+          <h1
+                    className="card__label"
+          >
+                    name
+          </h1>
+          <div
+                    className="card__attributes"
+          >
+                    <h5
+                              className="card__attribute"
+                    >
+                              age
+                              : 
+                              33
+                    </h5>
+                    <h5
+                              className="card__attribute"
+                    >
+                              fullname
+                              : 
+                              full name
+                    </h5>
+          </div>
+</div>,
+      ],
+      "className": "card card--selected",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <g>
             <path
-                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
             />
             <polygon
-                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
             />
-        </g>
-    </svg>
-    <div>
-        <h1
-            className="card__label"
-        >
-            name
-        </h1>
-        <div
-            className="card__attributes"
-        >
-            <h5
-                className="card__attribute"
-            >
-                age
-                : 
-                33
-            </h5>
-        </div>
-    </div>
-</div>,
-  "nodes": Array [
-    <div
-      className="card"
+</g>,
+          "className": "card__indicator",
+          "viewBox": "0 0 100 100",
+          "x": "0px",
+          "xmlns": "http://www.w3.org/2000/svg",
+          "y": "0px",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <path
+                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+/>,
+              <polygon
+                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+/>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "d": "M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "path",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "points": "30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "polygon",
+            },
+          ],
+          "type": "g",
+        },
+        "type": "svg",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <h1
+              className="card__label"
 >
-      <svg
+              name
+</h1>,
+            <div
+              className="card__attributes"
+>
+              <h5
+                            className="card__attribute"
+              >
+                            age
+                            : 
+                            33
+              </h5>
+              <h5
+                            className="card__attribute"
+              >
+                            fullname
+                            : 
+                            full name
+              </h5>
+</div>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "name",
+              "className": "card__label",
+            },
+            "ref": null,
+            "rendered": "name",
+            "type": "h1",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <h5
+                  className="card__attribute"
+>
+                  age
+                  : 
+                  33
+</h5>,
+                <h5
+                  className="card__attribute"
+>
+                  fullname
+                  : 
+                  full name
+</h5>,
+              ],
+              "className": "card__attributes",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "age",
+                    ": ",
+                    "33",
+                  ],
+                  "className": "card__attribute",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "age",
+                  ": ",
+                  "33",
+                ],
+                "type": "h5",
+              },
+              Object {
+                "instance": null,
+                "key": "1",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "fullname",
+                    ": ",
+                    "full name",
+                  ],
+                  "className": "card__attribute",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "fullname",
+                  ": ",
+                  "full name",
+                ],
+                "type": "h5",
+              },
+            ],
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <svg
             className="card__indicator"
             viewBox="0 0 100 100"
             x="0px"
             xmlns="http://www.w3.org/2000/svg"
             y="0px"
-      >
+>
             <g>
-                  <path
-                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                  />
-                  <polygon
-                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                  />
+                        <path
+                                    d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                        />
+                        <polygon
+                                    points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                        />
             </g>
-      </svg>
-      <div>
+</svg>,
+          <div>
             <h1
-                  className="card__label"
+                        className="card__label"
             >
-                  name
+                        name
             </h1>
             <div
-                  className="card__attributes"
+                        className="card__attributes"
             >
-                  <h5
-                        className="card__attribute"
-                  >
-                        age
-                        : 
-                        33
-                  </h5>
+                        <h5
+                                    className="card__attribute"
+                        >
+                                    age
+                                    : 
+                                    33
+                        </h5>
+                        <h5
+                                    className="card__attribute"
+                        >
+                                    fullname
+                                    : 
+                                    full name
+                        </h5>
             </div>
-      </div>
 </div>,
-  ],
-  "options": Object {},
-  "renderer": ReactShallowRenderer {
-    "_instance": ShallowComponentWrapper {
-      "_calledComponentWillUnmount": false,
-      "_compositeType": 2,
-      "_context": Object {},
-      "_currentElement": <Card
-        details={
-                Array [
-                        Object {
-                          "age": "33",
-                        },
-                      ]
-        }
-        label="name"
-        selected={false}
+        ],
+        "className": "card card--selected",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <g>
+              <path
+                            d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+              />
+              <polygon
+                            points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+              />
+</g>,
+            "className": "card__indicator",
+            "viewBox": "0 0 100 100",
+            "x": "0px",
+            "xmlns": "http://www.w3.org/2000/svg",
+            "y": "0px",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <path
+                  d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
 />,
-      "_debugID": 1,
-      "_hostContainerInfo": null,
-      "_hostParent": null,
-      "_instance": StatelessComponent {
-        "_reactInternalInstance": [Circular],
-        "context": Object {},
-        "props": Object {
-          "details": Array [
+                <polygon
+                  points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+/>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "d": "M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "path",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "points": "30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "polygon",
+              },
+            ],
+            "type": "g",
+          },
+          "type": "svg",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <h1
+                className="card__label"
+>
+                name
+</h1>,
+              <div
+                className="card__attributes"
+>
+                <h5
+                                className="card__attribute"
+                >
+                                age
+                                : 
+                                33
+                </h5>
+                <h5
+                                className="card__attribute"
+                >
+                                fullname
+                                : 
+                                full name
+                </h5>
+</div>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
             Object {
-              "age": "33",
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "name",
+                "className": "card__label",
+              },
+              "ref": null,
+              "rendered": "name",
+              "type": "h1",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <h5
+                    className="card__attribute"
+>
+                    age
+                    : 
+                    33
+</h5>,
+                  <h5
+                    className="card__attribute"
+>
+                    fullname
+                    : 
+                    full name
+</h5>,
+                ],
+                "className": "card__attributes",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "0",
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "age",
+                      ": ",
+                      "33",
+                    ],
+                    "className": "card__attribute",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "age",
+                    ": ",
+                    "33",
+                  ],
+                  "type": "h5",
+                },
+                Object {
+                  "instance": null,
+                  "key": "1",
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "fullname",
+                      ": ",
+                      "full name",
+                    ],
+                    "className": "card__attribute",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "fullname",
+                    ": ",
+                    "full name",
+                  ],
+                  "type": "h5",
+                },
+              ],
+              "type": "div",
             },
           ],
-          "label": "name",
-          "selected": false,
+          "type": "div",
         },
-        "refs": Object {},
-        "state": null,
-        "updater": Object {
-          "enqueueCallback": [Function],
-          "enqueueCallbackInternal": [Function],
-          "enqueueElementInternal": [Function],
-          "enqueueForceUpdate": [Function],
-          "enqueueReplaceState": [Function],
-          "enqueueSetState": [Function],
-          "isMounted": [Function],
-          "validateCallback": [Function],
-        },
-      },
-      "_mountOrder": 1,
-      "_pendingCallbacks": null,
-      "_pendingElement": null,
-      "_pendingForceUpdate": false,
-      "_pendingReplaceState": false,
-      "_pendingStateQueue": null,
-      "_renderedComponent": NoopInternalComponent {
-        "_currentElement": <div
-          className="card"
->
-          <svg
-                    className="card__indicator"
-                    viewBox="0 0 100 100"
-                    x="0px"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0px"
-          >
-                    <g>
-                              <path
-                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                              />
-                              <polygon
-                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                              />
-                    </g>
-          </svg>
-          <div>
-                    <h1
-                              className="card__label"
-                    >
-                              name
-                    </h1>
-                    <div
-                              className="card__attributes"
-                    >
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        age
-                                        : 
-                                        33
-                              </h5>
-                    </div>
-          </div>
-</div>,
-        "_debugID": 2,
-        "_renderedOutput": <div
-          className="card"
->
-          <svg
-                    className="card__indicator"
-                    viewBox="0 0 100 100"
-                    x="0px"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0px"
-          >
-                    <g>
-                              <path
-                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
-                              />
-                              <polygon
-                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
-                              />
-                    </g>
-          </svg>
-          <div>
-                    <h1
-                              className="card__label"
-                    >
-                              name
-                    </h1>
-                    <div
-                              className="card__attributes"
-                    >
-                              <h5
-                                        className="card__attribute"
-                              >
-                                        age
-                                        : 
-                                        33
-                              </h5>
-                    </div>
-          </div>
-</div>,
-      },
-      "_renderedNodeType": 0,
-      "_rootNodeID": 0,
-      "_topLevelWrapper": null,
-      "_updateBatchNumber": null,
-      "_warnedAboutRefsInRender": false,
+      ],
+      "type": "div",
     },
-    "getRenderOutput": [Function],
-    "render": [Function],
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
   },
-  "root": [Circular],
-  "unrendered": <Card
+}
+`;
+
+exports[`Card component renders unselected card 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Card
     details={
         Array [
             Object {
@@ -514,5 +520,407 @@ ShallowWrapper {
     label="name"
     selected={false}
 />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <svg
+          className="card__indicator"
+          viewBox="0 0 100 100"
+          x="0px"
+          xmlns="http://www.w3.org/2000/svg"
+          y="0px"
+>
+          <g>
+                    <path
+                              d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                    />
+                    <polygon
+                              points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                    />
+          </g>
+</svg>,
+        <div>
+          <h1
+                    className="card__label"
+          >
+                    name
+          </h1>
+          <div
+                    className="card__attributes"
+          >
+                    <h5
+                              className="card__attribute"
+                    >
+                              age
+                              : 
+                              33
+                    </h5>
+          </div>
+</div>,
+      ],
+      "className": "card",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <g>
+            <path
+                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+            />
+            <polygon
+                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+            />
+</g>,
+          "className": "card__indicator",
+          "viewBox": "0 0 100 100",
+          "x": "0px",
+          "xmlns": "http://www.w3.org/2000/svg",
+          "y": "0px",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <path
+                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+/>,
+              <polygon
+                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+/>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "d": "M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "path",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "points": "30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": "polygon",
+            },
+          ],
+          "type": "g",
+        },
+        "type": "svg",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <h1
+              className="card__label"
+>
+              name
+</h1>,
+            <div
+              className="card__attributes"
+>
+              <h5
+                            className="card__attribute"
+              >
+                            age
+                            : 
+                            33
+              </h5>
+</div>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "name",
+              "className": "card__label",
+            },
+            "ref": null,
+            "rendered": "name",
+            "type": "h1",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <h5
+                  className="card__attribute"
+>
+                  age
+                  : 
+                  33
+</h5>,
+              ],
+              "className": "card__attributes",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    "age",
+                    ": ",
+                    "33",
+                  ],
+                  "className": "card__attribute",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "age",
+                  ": ",
+                  "33",
+                ],
+                "type": "h5",
+              },
+            ],
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <svg
+            className="card__indicator"
+            viewBox="0 0 100 100"
+            x="0px"
+            xmlns="http://www.w3.org/2000/svg"
+            y="0px"
+>
+            <g>
+                        <path
+                                    d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                        />
+                        <polygon
+                                    points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                        />
+            </g>
+</svg>,
+          <div>
+            <h1
+                        className="card__label"
+            >
+                        name
+            </h1>
+            <div
+                        className="card__attributes"
+            >
+                        <h5
+                                    className="card__attribute"
+                        >
+                                    age
+                                    : 
+                                    33
+                        </h5>
+            </div>
+</div>,
+        ],
+        "className": "card",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <g>
+              <path
+                            d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+              />
+              <polygon
+                            points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+              />
+</g>,
+            "className": "card__indicator",
+            "viewBox": "0 0 100 100",
+            "x": "0px",
+            "xmlns": "http://www.w3.org/2000/svg",
+            "y": "0px",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <path
+                  d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+/>,
+                <polygon
+                  points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+/>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "d": "M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "path",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "points": "30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": "polygon",
+              },
+            ],
+            "type": "g",
+          },
+          "type": "svg",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <h1
+                className="card__label"
+>
+                name
+</h1>,
+              <div
+                className="card__attributes"
+>
+                <h5
+                                className="card__attribute"
+                >
+                                age
+                                : 
+                                33
+                </h5>
+</div>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "name",
+                "className": "card__label",
+              },
+              "ref": null,
+              "rendered": "name",
+              "type": "h1",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <h5
+                    className="card__attribute"
+>
+                    age
+                    : 
+                    33
+</h5>,
+                ],
+                "className": "card__attributes",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "0",
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      "age",
+                      ": ",
+                      "33",
+                    ],
+                    "className": "card__attribute",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    "age",
+                    ": ",
+                    "33",
+                  ],
+                  "type": "h5",
+                },
+              ],
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
 }
 `;

--- a/src/components/__tests__/__snapshots__/Card-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Card-test.js.snap
@@ -1,0 +1,518 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card component renders selected card 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="card card--selected"
+>
+    <svg
+        className="card__indicator"
+        viewBox="0 0 100 100"
+        x="0px"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+    >
+        <g>
+            <path
+                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+            />
+            <polygon
+                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+            />
+        </g>
+    </svg>
+    <div>
+        <h1
+            className="card__label"
+        >
+            name
+        </h1>
+        <div
+            className="card__attributes"
+        >
+            <h5
+                className="card__attribute"
+            >
+                age
+                : 
+                33
+            </h5>
+            <h5
+                className="card__attribute"
+            >
+                fullname
+                : 
+                full name
+            </h5>
+        </div>
+    </div>
+</div>,
+  "nodes": Array [
+    <div
+      className="card card--selected"
+>
+      <svg
+            className="card__indicator"
+            viewBox="0 0 100 100"
+            x="0px"
+            xmlns="http://www.w3.org/2000/svg"
+            y="0px"
+      >
+            <g>
+                  <path
+                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                  />
+                  <polygon
+                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                  />
+            </g>
+      </svg>
+      <div>
+            <h1
+                  className="card__label"
+            >
+                  name
+            </h1>
+            <div
+                  className="card__attributes"
+            >
+                  <h5
+                        className="card__attribute"
+                  >
+                        age
+                        : 
+                        33
+                  </h5>
+                  <h5
+                        className="card__attribute"
+                  >
+                        fullname
+                        : 
+                        full name
+                  </h5>
+            </div>
+      </div>
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <Card
+        details={
+                Array [
+                        Object {
+                          "age": "33",
+                        },
+                        Object {
+                          "fullname": "full name",
+                        },
+                      ]
+        }
+        label="name"
+        selected={true}
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "details": Array [
+            Object {
+              "age": "33",
+            },
+            Object {
+              "fullname": "full name",
+            },
+          ],
+          "label": "name",
+          "selected": true,
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="card card--selected"
+>
+          <svg
+                    className="card__indicator"
+                    viewBox="0 0 100 100"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
+          >
+                    <g>
+                              <path
+                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                              />
+                              <polygon
+                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                              />
+                    </g>
+          </svg>
+          <div>
+                    <h1
+                              className="card__label"
+                    >
+                              name
+                    </h1>
+                    <div
+                              className="card__attributes"
+                    >
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        age
+                                        : 
+                                        33
+                              </h5>
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        fullname
+                                        : 
+                                        full name
+                              </h5>
+                    </div>
+          </div>
+</div>,
+        "_debugID": 4,
+        "_renderedOutput": <div
+          className="card card--selected"
+>
+          <svg
+                    className="card__indicator"
+                    viewBox="0 0 100 100"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
+          >
+                    <g>
+                              <path
+                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                              />
+                              <polygon
+                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                              />
+                    </g>
+          </svg>
+          <div>
+                    <h1
+                              className="card__label"
+                    >
+                              name
+                    </h1>
+                    <div
+                              className="card__attributes"
+                    >
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        age
+                                        : 
+                                        33
+                              </h5>
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        fullname
+                                        : 
+                                        full name
+                              </h5>
+                    </div>
+          </div>
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    details={
+        Array [
+            Object {
+              "age": "33",
+            },
+            Object {
+              "fullname": "full name",
+            },
+          ]
+    }
+    label="name"
+    selected={true}
+/>,
+}
+`;
+
+exports[`Card component renders unselected card 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="card"
+>
+    <svg
+        className="card__indicator"
+        viewBox="0 0 100 100"
+        x="0px"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
+    >
+        <g>
+            <path
+                d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+            />
+            <polygon
+                points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+            />
+        </g>
+    </svg>
+    <div>
+        <h1
+            className="card__label"
+        >
+            name
+        </h1>
+        <div
+            className="card__attributes"
+        >
+            <h5
+                className="card__attribute"
+            >
+                age
+                : 
+                33
+            </h5>
+        </div>
+    </div>
+</div>,
+  "nodes": Array [
+    <div
+      className="card"
+>
+      <svg
+            className="card__indicator"
+            viewBox="0 0 100 100"
+            x="0px"
+            xmlns="http://www.w3.org/2000/svg"
+            y="0px"
+      >
+            <g>
+                  <path
+                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                  />
+                  <polygon
+                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                  />
+            </g>
+      </svg>
+      <div>
+            <h1
+                  className="card__label"
+            >
+                  name
+            </h1>
+            <div
+                  className="card__attributes"
+            >
+                  <h5
+                        className="card__attribute"
+                  >
+                        age
+                        : 
+                        33
+                  </h5>
+            </div>
+      </div>
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <Card
+        details={
+                Array [
+                        Object {
+                          "age": "33",
+                        },
+                      ]
+        }
+        label="name"
+        selected={false}
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "details": Array [
+            Object {
+              "age": "33",
+            },
+          ],
+          "label": "name",
+          "selected": false,
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="card"
+>
+          <svg
+                    className="card__indicator"
+                    viewBox="0 0 100 100"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
+          >
+                    <g>
+                              <path
+                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                              />
+                              <polygon
+                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                              />
+                    </g>
+          </svg>
+          <div>
+                    <h1
+                              className="card__label"
+                    >
+                              name
+                    </h1>
+                    <div
+                              className="card__attributes"
+                    >
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        age
+                                        : 
+                                        33
+                              </h5>
+                    </div>
+          </div>
+</div>,
+        "_debugID": 2,
+        "_renderedOutput": <div
+          className="card"
+>
+          <svg
+                    className="card__indicator"
+                    viewBox="0 0 100 100"
+                    x="0px"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0px"
+          >
+                    <g>
+                              <path
+                                        d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z"
+                              />
+                              <polygon
+                                        points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6"
+                              />
+                    </g>
+          </svg>
+          <div>
+                    <h1
+                              className="card__label"
+                    >
+                              name
+                    </h1>
+                    <div
+                              className="card__attributes"
+                    >
+                              <h5
+                                        className="card__attribute"
+                              >
+                                        age
+                                        : 
+                                        33
+                              </h5>
+                    </div>
+          </div>
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Card
+    details={
+        Array [
+            Object {
+              "age": "33",
+            },
+          ]
+    }
+    label="name"
+    selected={false}
+/>,
+}
+`;

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -2,214 +2,9 @@
 
 exports[`CardList component renders cards with list 1`] = `
 ShallowWrapper {
-  "complexSelector": ComplexSelector {
-    "buildPredicate": [Function],
-    "childrenOfNode": [Function],
-    "findWhereUnwrapped": [Function],
-  },
   "length": 1,
-  "node": <div
-    className="scrollable"
->
-    <CardList
-        details={[Function]}
-        label={[Function]}
-        nodes={
-            Array [
-                Object {
-                  "age": "22",
-                  "name": "a name",
-                  "uid": "a",
-                },
-                Object {
-                  "age": "88",
-                  "name": "b name",
-                  "uid": "b",
-                },
-                Object {
-                  "age": "33",
-                  "name": "c name",
-                  "uid": "c",
-                },
-              ]
-        }
-    />
-</div>,
-  "nodes": Array [
-    <div
-      className="scrollable"
->
-      <CardList
-            details={[Function]}
-            label={[Function]}
-            nodes={
-                  Array [
-                        Object {
-                          "age": "22",
-                          "name": "a name",
-                          "uid": "a",
-                        },
-                        Object {
-                          "age": "88",
-                          "name": "b name",
-                          "uid": "b",
-                        },
-                        Object {
-                          "age": "33",
-                          "name": "c name",
-                          "uid": "c",
-                        },
-                      ]
-            }
-      />
-</div>,
-  ],
-  "options": Object {},
-  "renderer": ReactShallowRenderer {
-    "_instance": ShallowComponentWrapper {
-      "_calledComponentWillUnmount": false,
-      "_compositeType": 0,
-      "_context": Object {},
-      "_currentElement": <Scrollable
-        details={[Function]}
-        label={[Function]}
-        nodes={
-                Array [
-                        Object {
-                          "age": "22",
-                          "name": "a name",
-                          "uid": "a",
-                        },
-                        Object {
-                          "age": "88",
-                          "name": "b name",
-                          "uid": "b",
-                        },
-                        Object {
-                          "age": "33",
-                          "name": "c name",
-                          "uid": "c",
-                        },
-                      ]
-        }
-/>,
-      "_debugID": 1,
-      "_hostContainerInfo": null,
-      "_hostParent": null,
-      "_instance": Scrollable {
-        "_reactInternalInstance": [Circular],
-        "context": Object {},
-        "props": Object {
-          "details": [Function],
-          "label": [Function],
-          "nodes": Array [
-            Object {
-              "age": "22",
-              "name": "a name",
-              "uid": "a",
-            },
-            Object {
-              "age": "88",
-              "name": "b name",
-              "uid": "b",
-            },
-            Object {
-              "age": "33",
-              "name": "c name",
-              "uid": "c",
-            },
-          ],
-        },
-        "refs": Object {},
-        "state": Object {
-          "isScrolling": false,
-        },
-        "updateScrollState": [Function],
-        "updater": Object {
-          "enqueueCallback": [Function],
-          "enqueueCallbackInternal": [Function],
-          "enqueueElementInternal": [Function],
-          "enqueueForceUpdate": [Function],
-          "enqueueReplaceState": [Function],
-          "enqueueSetState": [Function],
-          "isMounted": [Function],
-          "validateCallback": [Function],
-        },
-      },
-      "_mountOrder": 1,
-      "_pendingCallbacks": null,
-      "_pendingElement": null,
-      "_pendingForceUpdate": false,
-      "_pendingReplaceState": false,
-      "_pendingStateQueue": null,
-      "_renderedComponent": NoopInternalComponent {
-        "_currentElement": <div
-          className="scrollable"
->
-          <CardList
-                    details={[Function]}
-                    label={[Function]}
-                    nodes={
-                              Array [
-                                        Object {
-                                          "age": "22",
-                                          "name": "a name",
-                                          "uid": "a",
-                                        },
-                                        Object {
-                                          "age": "88",
-                                          "name": "b name",
-                                          "uid": "b",
-                                        },
-                                        Object {
-                                          "age": "33",
-                                          "name": "c name",
-                                          "uid": "c",
-                                        },
-                                      ]
-                    }
-          />
-</div>,
-        "_debugID": 2,
-        "_renderedOutput": <div
-          className="scrollable"
->
-          <CardList
-                    details={[Function]}
-                    label={[Function]}
-                    nodes={
-                              Array [
-                                        Object {
-                                          "age": "22",
-                                          "name": "a name",
-                                          "uid": "a",
-                                        },
-                                        Object {
-                                          "age": "88",
-                                          "name": "b name",
-                                          "uid": "b",
-                                        },
-                                        Object {
-                                          "age": "33",
-                                          "name": "c name",
-                                          "uid": "c",
-                                        },
-                                      ]
-                    }
-          />
-</div>,
-      },
-      "_renderedNodeType": 0,
-      "_rootNodeID": 0,
-      "_topLevelWrapper": null,
-      "_updateBatchNumber": null,
-      "_warnedAboutRefsInRender": false,
-    },
-    "getRenderOutput": [Function],
-    "render": [Function],
-  },
-  "root": [Circular],
-  "unrendered": <Scrollable
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Scrollable
     details={[Function]}
     label={[Function]}
     nodes={
@@ -231,6 +26,156 @@ ShallowWrapper {
             },
           ]
     }
+    onToggleCard={[Function]}
+    selected={[Function]}
 />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <CardList
+        details={[Function]}
+        label={[Function]}
+        nodes={
+                Array [
+                        Object {
+                          "age": "22",
+                          "name": "a name",
+                          "uid": "a",
+                        },
+                        Object {
+                          "age": "88",
+                          "name": "b name",
+                          "uid": "b",
+                        },
+                        Object {
+                          "age": "33",
+                          "name": "c name",
+                          "uid": "c",
+                        },
+                      ]
+        }
+        onToggleCard={[Function]}
+        selected={[Function]}
+/>,
+      "className": "scrollable",
+    },
+    "ref": [Function],
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "details": [Function],
+        "label": [Function],
+        "nodes": Array [
+          Object {
+            "age": "22",
+            "name": "a name",
+            "uid": "a",
+          },
+          Object {
+            "age": "88",
+            "name": "b name",
+            "uid": "b",
+          },
+          Object {
+            "age": "33",
+            "name": "c name",
+            "uid": "c",
+          },
+        ],
+        "onToggleCard": [Function],
+        "selected": [Function],
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <CardList
+          details={[Function]}
+          label={[Function]}
+          nodes={
+                    Array [
+                              Object {
+                                "age": "22",
+                                "name": "a name",
+                                "uid": "a",
+                              },
+                              Object {
+                                "age": "88",
+                                "name": "b name",
+                                "uid": "b",
+                              },
+                              Object {
+                                "age": "33",
+                                "name": "c name",
+                                "uid": "c",
+                              },
+                            ]
+          }
+          onToggleCard={[Function]}
+          selected={[Function]}
+/>,
+        "className": "scrollable",
+      },
+      "ref": [Function],
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "details": [Function],
+          "label": [Function],
+          "nodes": Array [
+            Object {
+              "age": "22",
+              "name": "a name",
+              "uid": "a",
+            },
+            Object {
+              "age": "88",
+              "name": "b name",
+              "uid": "b",
+            },
+            Object {
+              "age": "33",
+              "name": "c name",
+              "uid": "c",
+            },
+          ],
+          "onToggleCard": [Function],
+          "selected": [Function],
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
 }
 `;

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -1,0 +1,236 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CardList component renders cards with list 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="scrollable"
+>
+    <CardList
+        details={[Function]}
+        label={[Function]}
+        nodes={
+            Array [
+                Object {
+                  "age": "22",
+                  "name": "a name",
+                  "uid": "a",
+                },
+                Object {
+                  "age": "88",
+                  "name": "b name",
+                  "uid": "b",
+                },
+                Object {
+                  "age": "33",
+                  "name": "c name",
+                  "uid": "c",
+                },
+              ]
+        }
+    />
+</div>,
+  "nodes": Array [
+    <div
+      className="scrollable"
+>
+      <CardList
+            details={[Function]}
+            label={[Function]}
+            nodes={
+                  Array [
+                        Object {
+                          "age": "22",
+                          "name": "a name",
+                          "uid": "a",
+                        },
+                        Object {
+                          "age": "88",
+                          "name": "b name",
+                          "uid": "b",
+                        },
+                        Object {
+                          "age": "33",
+                          "name": "c name",
+                          "uid": "c",
+                        },
+                      ]
+            }
+      />
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Scrollable
+        details={[Function]}
+        label={[Function]}
+        nodes={
+                Array [
+                        Object {
+                          "age": "22",
+                          "name": "a name",
+                          "uid": "a",
+                        },
+                        Object {
+                          "age": "88",
+                          "name": "b name",
+                          "uid": "b",
+                        },
+                        Object {
+                          "age": "33",
+                          "name": "c name",
+                          "uid": "c",
+                        },
+                      ]
+        }
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Scrollable {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "details": [Function],
+          "label": [Function],
+          "nodes": Array [
+            Object {
+              "age": "22",
+              "name": "a name",
+              "uid": "a",
+            },
+            Object {
+              "age": "88",
+              "name": "b name",
+              "uid": "b",
+            },
+            Object {
+              "age": "33",
+              "name": "c name",
+              "uid": "c",
+            },
+          ],
+        },
+        "refs": Object {},
+        "state": Object {
+          "isScrolling": false,
+        },
+        "updateScrollState": [Function],
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <div
+          className="scrollable"
+>
+          <CardList
+                    details={[Function]}
+                    label={[Function]}
+                    nodes={
+                              Array [
+                                        Object {
+                                          "age": "22",
+                                          "name": "a name",
+                                          "uid": "a",
+                                        },
+                                        Object {
+                                          "age": "88",
+                                          "name": "b name",
+                                          "uid": "b",
+                                        },
+                                        Object {
+                                          "age": "33",
+                                          "name": "c name",
+                                          "uid": "c",
+                                        },
+                                      ]
+                    }
+          />
+</div>,
+        "_debugID": 2,
+        "_renderedOutput": <div
+          className="scrollable"
+>
+          <CardList
+                    details={[Function]}
+                    label={[Function]}
+                    nodes={
+                              Array [
+                                        Object {
+                                          "age": "22",
+                                          "name": "a name",
+                                          "uid": "a",
+                                        },
+                                        Object {
+                                          "age": "88",
+                                          "name": "b name",
+                                          "uid": "b",
+                                        },
+                                        Object {
+                                          "age": "33",
+                                          "name": "c name",
+                                          "uid": "c",
+                                        },
+                                      ]
+                    }
+          />
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Scrollable
+    details={[Function]}
+    label={[Function]}
+    nodes={
+        Array [
+            Object {
+              "age": "22",
+              "name": "a name",
+              "uid": "a",
+            },
+            Object {
+              "age": "88",
+              "name": "b name",
+              "uid": "b",
+            },
+            Object {
+              "age": "33",
+              "name": "c name",
+              "uid": "c",
+            },
+          ]
+    }
+/>,
+}
+`;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 export { default as Card } from './Card';
+export { default as CardList } from './CardList';
 export { default as Menu } from './Menu';
 export { default as Scroller } from './Scroller';
 export { default as Pips } from './Pips';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
+export { default as Card } from './Card';
 export { default as Menu } from './Menu';
 export { default as Scroller } from './Scroller';
 export { default as Pips } from './Pips';

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -19,6 +19,7 @@ const forms = {
 
 // Render method for the node labels
 const label = node => `${node.nickname}`;
+const details = node => [{ name: `${node.name}` }, { age: `${node.age}` }];
 
 
 /**
@@ -119,8 +120,9 @@ class NameGenerator extends Component {
               onSelect={this.onSelectNode}
             />
             <CardList
-              nodes={nodesForPrompt}
+              details={details}
               label={label}
+              nodes={nodesForPrompt}
             />
           </div>
         </div>

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -9,7 +9,7 @@ import { actionCreators as modalActions } from '../../ducks/modules/modals';
 import { makeNetworkNodesForPrompt } from '../../selectors/interface';
 import { makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper, NodePanels, NodeForm } from '../../containers/';
-import { NodeList, NodeBin, CardList } from '../../components/';
+import { NodeList, NodeBin } from '../../components/';
 import { makeRehydrateForm } from '../../selectors/rehydrate';
 
 const forms = {
@@ -19,8 +19,6 @@ const forms = {
 
 // Render method for the node labels
 const label = node => `${node.nickname}`;
-const details = node => [{ name: `${node.name}` }, { age: `${node.age}` }];
-
 
 /**
   * Name Generator Interface
@@ -118,11 +116,6 @@ class NameGenerator extends Component {
               itemType="EXISTING_NODE"
               onDrop={this.onDrop}
               onSelect={this.onSelectNode}
-            />
-            <CardList
-              details={details}
-              label={label}
-              nodes={nodesForPrompt}
             />
           </div>
         </div>

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -9,7 +9,7 @@ import { actionCreators as modalActions } from '../../ducks/modules/modals';
 import { makeNetworkNodesForPrompt } from '../../selectors/interface';
 import { makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper, NodePanels, NodeForm } from '../../containers/';
-import { NodeList, NodeBin } from '../../components/';
+import { NodeList, NodeBin, CardList } from '../../components/';
 import { makeRehydrateForm } from '../../selectors/rehydrate';
 
 const forms = {
@@ -117,6 +117,10 @@ class NameGenerator extends Component {
               itemType="EXISTING_NODE"
               onDrop={this.onDrop}
               onSelect={this.onSelectNode}
+            />
+            <CardList
+              nodes={nodesForPrompt}
+              label={label}
             />
           </div>
         </div>

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -24,3 +24,4 @@
 @import 'edge-layout';
 @import 'node-layout';
 @import 'node-bucket';
+@import 'card';

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -1,0 +1,83 @@
+.card {
+  align-items: center;
+  border: 2px solid palette('text-dark');
+  border-radius: .5rem;
+  display: flex;
+  margin: 1rem;
+  padding: 1rem;
+
+  &__indicator {
+    fill: palette('text-dark');
+    height: 40px;
+    margin-right: 10px;
+    padding: 10px;
+    width: 40px;
+  }
+
+  &--selected {
+    .card__indicator {
+      height: 60px;
+      padding: 0;
+      width: 60px;
+    }
+  }
+
+  &:hover,
+  &--selected {
+    background-color: transparentize(palette('selected'), .95);
+    border-color: palette('primary');
+
+    > .card__indicator {
+      fill: palette('primary');
+    }
+  }
+
+  &__attribute {
+    font-weight: 300;
+  }
+
+  // context input formatting - incomplete
+  .context__container {
+    min-height: 40px;
+    min-width: 40px;
+  }
+
+  .context__button {
+    color: palette('text-dark');
+    border-color: palette('text-dark');
+    font-size: 20px;
+    height: 40px;
+    width: 40px;
+  }
+
+  &--selected {
+    .context__container {
+      min-height: 60px;
+      min-width: 60px;
+    }
+
+    .context__button {
+      height: 60px;
+      width: 60px;
+    }
+  }
+
+  &:hover {
+    cursor: pointer;
+
+    .context__button:after {
+      transition: transform $animation-default-easing $animation-fast-duration;
+      opacity: 1;
+      background-color: palette('primary');
+    }
+  }
+
+  &:hover,
+  &--selected {
+    .context__button {
+      background-color: transparent;
+      border-color: palette('primary');
+      color: palette('text');
+    }
+  }
+}

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -7,6 +7,7 @@
   padding: 1rem;
 
   &__indicator {
+    box-sizing: content-box;
     fill: palette('text-dark');
     height: 40px;
     margin-right: 10px;
@@ -34,50 +35,5 @@
 
   &__attribute {
     font-weight: 300;
-  }
-
-  // context input formatting - incomplete
-  .context__container {
-    min-height: 40px;
-    min-width: 40px;
-  }
-
-  .context__button {
-    color: palette('text-dark');
-    border-color: palette('text-dark');
-    font-size: 20px;
-    height: 40px;
-    width: 40px;
-  }
-
-  &--selected {
-    .context__container {
-      min-height: 60px;
-      min-width: 60px;
-    }
-
-    .context__button {
-      height: 60px;
-      width: 60px;
-    }
-  }
-
-  &:hover {
-    cursor: pointer;
-
-    .context__button:after {
-      transition: transform $animation-default-easing $animation-fast-duration;
-      opacity: 1;
-      background-color: palette('primary');
-    }
-  }
-
-  &:hover,
-  &--selected {
-    .context__button {
-      background-color: transparent;
-      border-color: palette('primary');
-      color: palette('text');
-    }
   }
 }


### PR DESCRIPTION
Resolves #272.

Just for show, it is temporarily added to `NameGeneratorInterface`, but will remove before merging.

This adds the formatting, though I am not sure if there is hover/animations that I may be missing. 

Also, the "selected" state of nodes is kept in the `CardList` state, but could be moved elsewhere based on feedback or as we actually use this.