### PR TITLE
Node panels only shows if panels accept the node type.

### DIFF
--- a/src/containers/Elements/NodePanels.js
+++ b/src/containers/Elements/NodePanels.js
@@ -39,10 +39,12 @@ class NodePanels extends PureComponent {
     newNodeAttributes: PropTypes.object.isRequired,
     isDragging: PropTypes.bool,
     panels: PropTypes.array,
+    meta: PropTypes.object,
   };
 
   static defaultProps = {
     panels: [],
+    meta: {},
     isDragging: false,
   };
 
@@ -56,8 +58,10 @@ class NodePanels extends PureComponent {
 
   isPanelEmpty = index => this.props.panels[index].nodes.length === 0;
 
+  isPanelCompatible = index => this.props.panels[index].accepts({ meta: this.props.meta });
+
   isPanelOpen = index =>
-    this.props.isDragging || !this.isPanelEmpty(index);
+    (this.props.isDragging && this.isPanelCompatible(index)) || !this.isPanelEmpty(index);
 
   isAnyPanelOpen = () =>
     this.props.panels
@@ -175,5 +179,5 @@ export { NodePanels };
 export default compose(
   configurePanels,
   connect(makeMapStateToProps, mapDispatchToProps),
-  MonitorDragSource(['isDragging']),
+  MonitorDragSource(['isDragging', 'meta']),
 )(NodePanels);

--- a/src/containers/Elements/NodePanels.js
+++ b/src/containers/Elements/NodePanels.js
@@ -26,6 +26,8 @@ const getHighlight = (highlight, panelNumber) => {
   return null;
 };
 
+const label = node => `${node.nickname}`;
+
 /**
   * Configures and renders `NodeProvider`s into panels according to the protocol config
   */
@@ -52,52 +54,22 @@ class NodePanels extends PureComponent {
     }
   }
 
-  panelHasNodes = index => this.props.panels[index].nodes.length;
+  isPanelEmpty = index => this.props.panels[index].nodes.length === 0;
 
-  panelIsOpen = index =>
-    this.props.isDragging || this.panelHasNodes(index) > 0;
+  isPanelOpen = index =>
+    this.props.isDragging || !this.isPanelEmpty(index);
 
-  anyPanelIsOpen = () =>
+  isAnyPanelOpen = () =>
     this.props.panels
-      .map((panel, index) => this.panelIsOpen(index))
+      .map((panel, index) => this.isPanelOpen(index))
       .reduce((memo, panelOpen) => memo || panelOpen, false);
-
-  configureNodeList = ({ dataSource, originNodeIds, ...nodeListOptions }) => {
-    const {
-      newNodeAttributes: {
-        stageId,
-        promptId,
-      },
-    } = this.props;
-
-    const label = node => `${node.nickname}`;
-
-    // external, needs to check list
-    // otherwise check created at details.
-    const accepts = (dataSource === 'existing') ?
-      ({ meta }) => (
-        meta.itemType === 'EXISTING_NODE' &&
-        (meta.stageId !== stageId || meta.promptId !== promptId)
-      ) :
-      ({ meta }) => (
-        meta.itemType === 'EXISTING_NODE' &&
-        includes(originNodeIds, meta.uid)
-      );
-
-    return {
-      ...nodeListOptions,
-      onDrop: item => this.onDrop(item, dataSource),
-      itemType: 'NEW_NODE',
-      accepts,
-      label,
-    };
-  }
 
   renderNodePanel = (panel, index) => {
     const {
       title,
       highlight,
-      ...nodeListOptions
+      dataSource,
+      ...nodeListProps
     } = panel;
 
     return (
@@ -105,11 +77,14 @@ class NodePanels extends PureComponent {
         title={title}
         key={index}
         highlight={getHighlight(highlight, index)}
-        minimise={!this.panelIsOpen(index)}
+        minimise={!this.isPanelOpen(index)}
       >
         <NodeList
           id={`PANEL_NODE_LIST_${index}`}
-          {...this.configureNodeList(nodeListOptions)}
+          {...nodeListProps}
+          label={label}
+          itemType="NEW_NODE"
+          onDrop={item => this.onDrop(item, dataSource)}
         />
       </Panel>
     );
@@ -117,7 +92,7 @@ class NodePanels extends PureComponent {
 
   render() {
     return (
-      <Panels minimise={!this.anyPanelIsOpen()}>
+      <Panels minimise={!this.isAnyPanelOpen()}>
         {this.props.panels.map(this.renderNodePanel)}
       </Panels>
     );
@@ -141,32 +116,49 @@ function makeMapStateToProps() {
   const networkNodesForOtherPrompts = makeNetworkNodesForOtherPrompts();
 
   return function mapStateToProps(state, props) {
-    const nodes = networkNodes(state);
+    const allNodes = networkNodes(state);
     const existingNodes = networkNodesForOtherPrompts(state, props);
     const externalData = getExternalData(state);
+    const newNodeAttributes = getPromptNodeAttributes(state, props);
 
-    const panels = props.panels.map(
-      panel => ({
+    const panels = props.panels.map((panel) => {
+      const originNodeIds = getOriginNodeIds({
+        existingNodes,
+        externalData,
+        dataSource: panel.dataSource,
+      });
+
+      const nodes = getNodesForDataSource({
+        nodes: allNodes,
+        existingNodes,
+        externalData,
+        dataSource: panel.dataSource,
+      });
+
+      const accepts = (panel.dataSource === 'existing') ?
+        ({ meta }) => (
+          meta.itemType === 'EXISTING_NODE' &&
+          (meta.stageId !== newNodeAttributes.stageId ||
+            meta.promptId !== newNodeAttributes.promptId)
+        ) :
+        ({ meta }) => (
+          meta.itemType === 'EXISTING_NODE' &&
+          includes(originNodeIds, meta.uid)
+        );
+
+      return {
         ...panel,
-        originNodeIds: getOriginNodeIds({
-          existingNodes,
-          externalData,
-          dataSource: panel.dataSource,
-        }),
-        nodes: getNodesForDataSource({
-          nodes,
-          existingNodes,
-          externalData,
-          dataSource: panel.dataSource,
-        }),
-      }),
-    );
+        originNodeIds,
+        nodes,
+        accepts,
+      };
+    });
 
     return {
       isDragging: state.draggable.isDragging,
       activePromptAttributes: props.prompt.additionalAttributes,
       panels,
-      newNodeAttributes: getPromptNodeAttributes(state, props),
+      newNodeAttributes,
     };
   };
 }
@@ -177,6 +169,8 @@ function mapDispatchToProps(dispatch) {
     removeNode: bindActionCreators(networkActions.removeNode, dispatch),
   };
 }
+
+export { NodePanels };
 
 export default compose(
   configurePanels,

--- a/src/containers/Elements/__tests__/NodePanels.test.js
+++ b/src/containers/Elements/__tests__/NodePanels.test.js
@@ -7,8 +7,8 @@ import { NodePanels } from '../../Elements/NodePanels';
 const mockProps = {
   toggleNodeAttributes: () => {},
   removeNode: () => {},
-  activePromptAttributes: () => {},
-  newNodeAttributes: () => {},
+  activePromptAttributes: {},
+  newNodeAttributes: {},
 };
 
 describe('<NodePanels />', () => {

--- a/src/containers/Elements/__tests__/NodePanels.test.js
+++ b/src/containers/Elements/__tests__/NodePanels.test.js
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { NodePanels } from '../../Elements/NodePanels';
+
+const mockProps = {
+  toggleNodeAttributes: () => {},
+  removeNode: () => {},
+  activePromptAttributes: () => {},
+  newNodeAttributes: () => {},
+};
+
+describe('<NodePanels />', () => {
+  it('renders ok', () => {
+    const component = shallow(<NodePanels {...mockProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/containers/Elements/__tests__/__snapshots__/NodePanels.test.js.snap
+++ b/src/containers/Elements/__tests__/__snapshots__/NodePanels.test.js.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NodePanels /> renders ok 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <Panels
+    minimise={true}
+>
+    
+</Panels>,
+  "nodes": Array [
+    <Panels
+      minimise={true}
+>
+      
+</Panels>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 1,
+      "_context": Object {},
+      "_currentElement": <NodePanels
+        activePromptAttributes={[Function]}
+        isDragging={false}
+        newNodeAttributes={[Function]}
+        panels={Array []}
+        removeNode={[Function]}
+        toggleNodeAttributes={[Function]}
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": NodePanels {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "isAnyPanelOpen": [Function],
+        "isPanelEmpty": [Function],
+        "isPanelOpen": [Function],
+        "onDrop": [Function],
+        "props": Object {
+          "activePromptAttributes": [Function],
+          "isDragging": false,
+          "newNodeAttributes": [Function],
+          "panels": Array [],
+          "removeNode": [Function],
+          "toggleNodeAttributes": [Function],
+        },
+        "refs": Object {},
+        "renderNodePanel": [Function],
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <Panels
+          minimise={true}
+>
+          
+</Panels>,
+        "_debugID": 2,
+        "_renderedOutput": <Panels
+          minimise={true}
+>
+          
+</Panels>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <NodePanels
+    activePromptAttributes={[Function]}
+    isDragging={false}
+    newNodeAttributes={[Function]}
+    panels={Array []}
+    removeNode={[Function]}
+    toggleNodeAttributes={[Function]}
+/>,
+}
+`;

--- a/src/containers/Elements/__tests__/__snapshots__/NodePanels.test.js.snap
+++ b/src/containers/Elements/__tests__/__snapshots__/NodePanels.test.js.snap
@@ -27,9 +27,10 @@ ShallowWrapper {
       "_compositeType": 1,
       "_context": Object {},
       "_currentElement": <NodePanels
-        activePromptAttributes={[Function]}
+        activePromptAttributes={Object {}}
         isDragging={false}
-        newNodeAttributes={[Function]}
+        meta={Object {}}
+        newNodeAttributes={Object {}}
         panels={Array []}
         removeNode={[Function]}
         toggleNodeAttributes={[Function]}
@@ -41,13 +42,15 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "isAnyPanelOpen": [Function],
+        "isPanelCompatible": [Function],
         "isPanelEmpty": [Function],
         "isPanelOpen": [Function],
         "onDrop": [Function],
         "props": Object {
-          "activePromptAttributes": [Function],
+          "activePromptAttributes": Object {},
           "isDragging": false,
-          "newNodeAttributes": [Function],
+          "meta": Object {},
+          "newNodeAttributes": Object {},
           "panels": Array [],
           "removeNode": [Function],
           "toggleNodeAttributes": [Function],
@@ -96,9 +99,10 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <NodePanels
-    activePromptAttributes={[Function]}
+    activePromptAttributes={Object {}}
     isDragging={false}
-    newNodeAttributes={[Function]}
+    meta={Object {}}
+    newNodeAttributes={Object {}}
     panels={Array []}
     removeNode={[Function]}
     toggleNodeAttributes={[Function]}


### PR DESCRIPTION
### Known issues:

- Both panels can sometimes be valid, is that confusing?:
    1. Node originally in 'previous' panel, dragged into main list
    1. On a different prompt that node now shows in 'existing' panel, and again can be dragged to the main list
    1. If that node is now picked up from the main list it can be a) dropped into existing to de-select prompt attributes b) be dropped into 'previous' to be deleted.

Fixes #275