### PR TITLE
iOS panel animations

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -39,9 +39,9 @@
     <preference name="Orientation" value="landscape" />
     <preference name="target-device" value="tablet" />
     <preference name="DisallowOverscroll" value="true" />
-    <engine name="android" spec="^6.2.3" />
-    <engine name="ios" spec="^4.5.0" />
     <plugin name="cordova-plugin-app-version" spec="^0.1.9" />
     <plugin name="cordova-plugin-file" spec="^4.3.3" />
     <plugin name="cordova-plugin-x-socialsharing" spec="^5.2.0" />
+    <engine name="android" spec="^6.2.3" />
+    <engine name="ios" spec="^4.5.0" />
 </widget>

--- a/src/styles/components/_panel.scss
+++ b/src/styles/components/_panel.scss
@@ -1,8 +1,10 @@
 $heading-size: 100px;
 
 .panel {
-  @include transition-properties((opacity flex-basis flex-grow margin-bottom border-bottom-width), $animation-default-easing, $animation-standard-duration)
-  flex: 1 0 $heading-size;
+  @include transition-properties((opacity max-height margin-bottom border-bottom-width), $animation-default-easing, $animation-standard-duration);
+  flex-grow: 1;
+  flex-shrink: 0;
+  flex-basis: $heading-size;
   display: flex;
   flex-direction: column;
   background-color: palette('light-background');
@@ -13,6 +15,7 @@ $heading-size: 100px;
   margin: 0 0 30px;
   overflow: hidden;
   opacity: 1;
+  max-height: 1000px;
 
   &:last-child {
     margin-bottom: 0;
@@ -50,8 +53,9 @@ $heading-size: 100px;
 
   &--minimise {
     border-bottom-width: 0;
-    flex-basis: 0;
-    flex-grow: 0;
+    max-height: 0; // flex-grow, flex-basis would be preferable, but not supported on safari/ios
+    // flex-basis: 0;
+    // flex-grow: 0;
     margin-bottom: 0;
     opacity: 0;
   }

--- a/src/styles/components/_panels.scss
+++ b/src/styles/components/_panels.scss
@@ -1,22 +1,22 @@
 .panels {
-  @include transition-properties((opacity width margin-right), $animation-default-easing, $animation-standard-duration)
+  @include transition-properties((opacity max-width margin-right), $animation-default-easing, $animation-standard-duration);
   display: flex;
   flex-direction: column;
   opacity: 1;
   margin-right: 0;
   width: 29vw;
-  max-width:435px;
+  max-width: 435px;
   transform: translateZ(0);
   will-change: transform;
 
   @include breakpoint('full') {
-    width:435px;
+    width: 435px;
     margin-right: 30px;
   }
 
   &--minimise {
     margin-right: 0;
-    width: 0;
+    max-width: 0;
     opacity: 0;
   }
 }


### PR DESCRIPTION
iOS/Safari can't animate the flex properties we're using in the layout, so this is a work around using `max-width/max-height`.

Known issues:
- Because we animate from an arbitrary max-height, the border animation/margin animations appear out of sync. What's actually happening is that the max height is being transitioned between that higher arbitrary figure and the actual height, so visually nothing changes:

    ```
    start                                             end
    |A--------------------------B----------------------C| max-height
    |D-------------------------------------------------E| border-width
    ```

    A: 1000px
    B: the actual displayed height of the panel, say 400px, at this point the animation appears to start.
    C: 0px

Another way to do it would be to set these figures dynamically using getBoundingRect/animate.js if we would prefer a more precise look.
 
Resolves #282