### PR TITLE
Add sass-lint task, restrict includes to src

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,7 +1,7 @@
 options:
   formatter: stylish
 files:
-  include: '**/*.s+(a|c)ss'
+  include: 'src/**/*.s+(a|c)ss'
 rules:
   # Extends
   extends-before-mixins: 1

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
         "lint": "eslint src",
+        "sass-lint": "sass-lint -vc .sass-lint.yml",
         "test": "node scripts/test.js --env=jsdom",
         "test-update-snapshots": "node scripts/test.js --env=jsdom --updateSnapshot",
         "build-docs": "NODE_ENV=production jsdoc src -r -d docs-build -c ./jsdoc.conf.json --verbose",


### PR DESCRIPTION
I'm not sure if anyone's been using sass-lint recently, but since it's included, I thought this would be useful. 

Prior to the config change, the linter ran on everything including node_modules.

I also added an npm script to be able to run it more easily.