### PR TITLE
In Cordova attempt to load assets from factory location first

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src gap://ready file://* *; img-src asset: 'self' data: cdvfile: file:; media-src 'self' asset: cdvfile: file:; style-src 'self' http://* https://* 'unsafe-inline'; script-src 'self' http://* https://* 'unsafe-inline' 'unsafe-eval'; font-src 'self' gap://ready file://* http://* https://* 'unsafe-inline' 'unsafe-eval' data:">
+    <meta http-equiv="Content-Security-Policy" content="default-src gap://ready file://* *; img-src asset: 'self' data: cdvfile: file:; media-src 'self' asset: cdvfile: file: data:; style-src 'self' http://* https://* 'unsafe-inline'; script-src 'self' http://* https://* 'unsafe-inline' 'unsafe-eval'; font-src 'self' gap://ready file://* http://* https://* 'unsafe-inline' 'unsafe-eval' data:">
     <meta name="viewport" content="viewport-fit=cover, initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/icons/netCanvas-icon.ico">
     <title>Network Canvas</title>

--- a/src/ducks/modules/errors.js
+++ b/src/ducks/modules/errors.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 
-import { isString } from 'lodash';
 import { actionTypes as errorActionTypes } from './protocol';
 
 const ACKNOWLEDGE_ERROR = 'ERRORS/ACKNOWLEDGE_ERROR';
@@ -11,9 +10,8 @@ const initialState = {
 };
 
 const getErrorMessage = (error) => {
-  if (isString(error)) return error;
-  if (error && error.toString) return error.toString();
-  return 'Unknown error';
+  if (error && error.message) return error.message;
+  return error.toString();
 };
 
 export default function reducer(state = initialState, action = {}) {

--- a/src/utils/protocol/assetUrl.js
+++ b/src/utils/protocol/assetUrl.js
@@ -2,6 +2,7 @@ import environments from '../environments';
 import inEnvironment from '../Environment';
 import { readFileAsDataUrl } from '../filesystem';
 import protocolPath from './protocolPath';
+import factoryProtocolPath from './factoryProtocolPath';
 
 const isRequired = (param) => { throw new Error(`${param} is required`); };
 
@@ -19,8 +20,10 @@ const assetUrl = (environment) => {
       protocolName = isRequired('protocolName'),
       assetPath = isRequired('assetPath'),
     ) => {
+      const factoryFilename = factoryProtocolPath(protocolName, `assets/${assetPath}`);
       const filename = protocolPath(protocolName, `assets/${assetPath}`);
-      return readFileAsDataUrl(filename);
+      return readFileAsDataUrl(factoryFilename)
+        .catch(readFileAsDataUrl(filename));
     };
   }
 

--- a/src/utils/protocol/downloadProtocol.js
+++ b/src/utils/protocol/downloadProtocol.js
@@ -36,22 +36,17 @@ const downloadProtocol = inEnvironment((environment) => {
         .then(destination =>
           new Promise((resolve, reject) => {
             const fileTransfer = new FileTransfer();
-            fileTransfer.download(encodeURI(uri), destination, () => resolve(destination), reject);
+            fileTransfer.download(
+              encodeURI(uri),
+              destination,
+              () => resolve(destination),
+              error => reject(`Error code: ${error.code}. (${error.source})`),
+            );
           }),
         );
   }
 
   throw new Error(`downloadProtocol() not available on platform ${environment}`);
 });
-
-// const importRemoteProtocol = inEnvironment((environment) => {
-//   if (environment !== environments.WEB) {
-//     return uri =>
-//       downloadProtocol(uri)
-//         .then(importProtocol);
-//   }
-
-//   throw new Error(`importRemoteProtocol() not available on platform ${environment}`);
-// });
 
 export default downloadProtocol;


### PR DESCRIPTION
In Cordova attempt to load assets from factory location before the app data location.

This means that factory protocol assets should now load correctly

# Known issues

If a factory protocol name matched an imported protocol name, the factory protocol assets would be loaded (this is already the case for electron).

Resolves: #327 
Partial: #333