### PR TITLE
Update mocks to use addNodes()

### DIFF
--- a/public/protocols/demo.canvas/custom.js
+++ b/public/protocols/demo.canvas/custom.js
@@ -54,7 +54,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    addNode: bindActionCreators(api.actions.network.addNode, dispatch),
+    addNode: bindActionCreators(api.actions.network.addNodes, dispatch),
     closeModal: bindActionCreators(api.actions.modal.closeModal, dispatch),
     openModal: bindActionCreators(api.actions.modal.openModal, dispatch),
   };

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -13,7 +13,7 @@ const generateNodes = (howMany = 0) =>
       const lastName = faker.name.lastName();
       const age = faker.random.number({ min: 16, max: 99 });
 
-      return dispatch(networkActions.addNode({
+      return dispatch(networkActions.addNodes({
         type: 'person',
         promptId: 'mock',
         stageId: 'mock',


### PR DESCRIPTION
The network interface was simplified to reduce the number of actions.

This updates mocks (and the custom protocol JS) to use the new action.

Resolves #329.