### PR TITLE
Hide Menu search when panel closes

### DIFF
--- a/src/containers/StageMenu.js
+++ b/src/containers/StageMenu.js
@@ -50,7 +50,7 @@ class StageMenu extends Component {
       }));
 
     const search = (
-      <div className="menu__search">
+      <div className={`menu__search ${isOpen ? '' : 'menu__search--closed'}`}>
         <input ref={(input) => { this.search = input; }} type="search" placeholder="Filter" onChange={this.onInputChange} value={searchValue} />
       </div>
     );

--- a/src/styles/components/_menu.scss
+++ b/src/styles/components/_menu.scss
@@ -43,6 +43,11 @@
   &__search {
     padding: 1rem;
 
+    &--closed {
+      // Hiding the input keeps iOS from displaying input nav keys to it
+      visibility: hidden;
+    }
+
     input {
       border-radius: .5rem;
       outline: none;


### PR DESCRIPTION
This fixes the minor issue described in #352.

Before, user could see "previous" nav button in iOS, but would not lead to anywhere visible (it points to the Stage Menu filter).

![before](https://user-images.githubusercontent.com/39674/36160307-d7f3627e-10ae-11e8-94b9-a3b2065c6c3e.png)

With this change:

![after](https://user-images.githubusercontent.com/39674/36160312-dce58802-10ae-11e8-8fda-6181aecfd045.png)

Resolves #352.
