### PR TITLE
Fix/sociogram highlighting

### DIFF
--- a/src/containers/ConcentricCircles/LayoutNode.js
+++ b/src/containers/ConcentricCircles/LayoutNode.js
@@ -17,6 +17,7 @@ class LayoutNode extends PureComponent {
     const {
       node,
       selected,
+      linking,
       allowPositioning,
       allowSelect,
       layoutVariable,
@@ -39,6 +40,7 @@ class LayoutNode extends PureComponent {
           label={label(node)}
           onSelected={this.props.onSelected}
           selected={selected}
+          linking={linking}
           allowDrag={allowPositioning}
           allowSelect={allowSelect}
           meta={() => ({ ...node, itemType: 'POSITIONED_NODE' })}
@@ -57,6 +59,7 @@ LayoutNode.propTypes = {
   allowPositioning: PropTypes.bool,
   allowSelect: PropTypes.bool,
   selected: PropTypes.bool,
+  linking: PropTypes.bool,
   areaWidth: PropTypes.number,
   areaHeight: PropTypes.number,
 };
@@ -65,6 +68,7 @@ LayoutNode.defaultProps = {
   allowPositioning: false,
   allowSelect: false,
   selected: false,
+  linking: false,
   areaWidth: 0,
   areaHeight: 0,
   onSelected: () => {},

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -116,9 +116,11 @@ class NodeLayout extends Component {
   }
 
   isSelected(node) {
-    const { allowSelect } = this.props;
+    const { allowHighlighting } = this.props;
 
-    if (!allowSelect) { return false; }
+    console.log(node, allowHighlighting);
+
+    if (!allowHighlighting) { return false; }
 
     return (
       node.id === this.state.connectFrom ||
@@ -130,7 +132,7 @@ class NodeLayout extends Component {
     const {
       nodes,
       allowPositioning,
-      allowSelect,
+      allowHighlighting,
       layoutVariable,
     } = this.props;
 
@@ -147,7 +149,7 @@ class NodeLayout extends Component {
               onSelected={() => this.onSelected(node)}
               selected={this.isSelected(node)}
               allowPositioning={allowPositioning}
-              allowSelect={allowSelect}
+              allowSelect={allowHighlighting}
               areaWidth={this.props.width}
               areaHeight={this.props.height}
             />

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -121,7 +121,7 @@ class NodeLayout extends Component {
     );
   }
 
-  isSelected(node) {
+  isHighlighted(node) {
     return !isEmpty(this.props.highlightAttributes) &&
       isMatch(node, this.props.highlightAttributes);
   }
@@ -151,7 +151,7 @@ class NodeLayout extends Component {
               node={node}
               layoutVariable={layoutVariable}
               onSelected={() => this.onSelected(node)}
-              selected={this.isSelected(node)}
+              selected={this.isHighlighted(node)}
               linking={this.isLinking(node)}
               allowPositioning={allowPositioning}
               allowSelect={allowSelect}

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompose';
-import { isEqual, pick, isMatch, has } from 'lodash';
+import { isEqual, isEmpty, pick, isMatch, has } from 'lodash';
 import LayoutNode from './LayoutNode';
 import { withBounds } from '../../behaviours';
 import { makeGetSociogramOptions, makeGetPlacedNodes, sociogramOptionsProps } from '../../selectors/sociogram';
@@ -116,23 +116,21 @@ class NodeLayout extends Component {
   }
 
   isSelected(node) {
-    const { allowHighlighting } = this.props;
+    return !isEmpty(this.props.highlightAttributes) &&
+      isMatch(node, this.props.highlightAttributes);
+  }
 
-    console.log(node, allowHighlighting);
-
-    if (!allowHighlighting) { return false; }
-
-    return (
-      node.id === this.state.connectFrom ||
-      isMatch(node, this.props.highlightAttributes)
-    );
+  isLinking(node) {
+    return this.props.allowSelect &&
+      this.props.canCreateEdge &&
+      node.id === this.state.connectFrom;
   }
 
   render() {
     const {
       nodes,
       allowPositioning,
-      allowHighlighting,
+      allowSelect,
       layoutVariable,
     } = this.props;
 
@@ -148,8 +146,9 @@ class NodeLayout extends Component {
               layoutVariable={layoutVariable}
               onSelected={() => this.onSelected(node)}
               selected={this.isSelected(node)}
+              linking={this.isLinking(node)}
               allowPositioning={allowPositioning}
-              allowSelect={allowHighlighting}
+              allowSelect={allowSelect}
               areaWidth={this.props.width}
               areaHeight={this.props.height}
             />

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -77,7 +77,9 @@ class NodeLayout extends Component {
   }
 
   onSelected = (node) => {
-    const { allowSelect } = this.props;
+    const {
+      allowSelect,
+    } = this.props;
 
     if (!allowSelect) { return; }
 
@@ -89,8 +91,10 @@ class NodeLayout extends Component {
   }
 
   connectNode(nodeId) {
-    const { createEdge } = this.props;
+    const { createEdge, canCreateEdge } = this.props;
     const { connectFrom } = this.state;
+
+    if (!canCreateEdge) { return; }
 
     if (!connectFrom) {
       this.setState({ connectFrom: nodeId });
@@ -109,6 +113,8 @@ class NodeLayout extends Component {
   }
 
   toggleHighlightAttributes(nodeId) {
+    if (!this.props.allowHighlighting) { return; }
+
     this.props.toggleHighlight(
       nodeId,
       { ...this.props.highlightAttributes },

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/LayoutNode.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/LayoutNode.test.js.snap
@@ -11,6 +11,7 @@ ShallowWrapper {
     areaWidth={100}
     draggableType="bar"
     layoutVariable="foo"
+    linking={false}
     node={
         Object {
             "foo": Object {
@@ -47,6 +48,7 @@ ShallowWrapper {
                       }
         }
         label={undefined}
+        linking={false}
         meta={[Function]}
         onSelected={[Function]}
         selected={false}
@@ -72,6 +74,7 @@ ShallowWrapper {
           "y": 0.2,
         },
         "label": undefined,
+        "linking": false,
         "meta": [Function],
         "onSelected": [Function],
         "selected": false,
@@ -99,6 +102,7 @@ ShallowWrapper {
                             }
           }
           label={undefined}
+          linking={false}
           meta={[Function]}
           onSelected={[Function]}
           selected={false}
@@ -124,6 +128,7 @@ ShallowWrapper {
             "y": 0.2,
           },
           "label": undefined,
+          "linking": false,
           "meta": [Function],
           "onSelected": [Function],
           "selected": false,

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
@@ -55,6 +55,7 @@ ShallowWrapper {
           areaHeight={456}
           areaWidth={123}
           layoutVariable="foo"
+          linking={false}
           node={
                     Object {
                               "bar": "buzz",
@@ -66,7 +67,7 @@ ShallowWrapper {
                             }
           }
           onSelected={[Function]}
-          selected={true}
+          selected={false}
 />,
       ],
       "className": "node-layout",
@@ -83,6 +84,7 @@ ShallowWrapper {
           "areaHeight": 456,
           "areaWidth": 123,
           "layoutVariable": "foo",
+          "linking": false,
           "node": Object {
             "bar": "buzz",
             "foo": Object {
@@ -92,7 +94,7 @@ ShallowWrapper {
             "uid": 123,
           },
           "onSelected": [Function],
-          "selected": true,
+          "selected": false,
         },
         "ref": null,
         "rendered": null,
@@ -114,6 +116,7 @@ ShallowWrapper {
             areaHeight={456}
             areaWidth={123}
             layoutVariable="foo"
+            linking={false}
             node={
                         Object {
                                     "bar": "buzz",
@@ -125,7 +128,7 @@ ShallowWrapper {
                                   }
             }
             onSelected={[Function]}
-            selected={true}
+            selected={false}
 />,
         ],
         "className": "node-layout",
@@ -142,6 +145,7 @@ ShallowWrapper {
             "areaHeight": 456,
             "areaWidth": 123,
             "layoutVariable": "foo",
+            "linking": false,
             "node": Object {
               "bar": "buzz",
               "foo": Object {
@@ -151,7 +155,7 @@ ShallowWrapper {
               "uid": 123,
             },
             "onSelected": [Function],
-            "selected": true,
+            "selected": false,
           },
           "ref": null,
           "rendered": null,

--- a/src/selectors/__tests__/sociogram.js
+++ b/src/selectors/__tests__/sociogram.js
@@ -2,10 +2,12 @@
 
 import { makeGetSociogramOptions } from '../sociogram';
 
+const mockPrompt = {
+  layout: {},
+};
+
 const mockProps = {
-  prompt: {
-    layout: {},
-  },
+  prompt: mockPrompt,
 };
 
 const mockState = {
@@ -19,9 +21,34 @@ describe('sociogram selector', () => {
       getSociogramOptions = makeGetSociogramOptions();
     });
 
-    it('when highlight option is missing, allowHighlighting is false', () => {
-      const subject = getSociogramOptions(mockState, mockProps);
-      expect(subject.allowHighlighting).toEqual(false);
+    describe('props.prompt.highlight', () => {
+      it('when highlight option is missing, allowHighlighting is false', () => {
+        const subject = getSociogramOptions(mockState, mockProps);
+        expect(subject.allowHighlighting).toEqual(false);
+      });
+      it('when highlight option exists, allowHighlighting is true', () => {
+        const prompt = {
+          ...mockPrompt,
+          highlight: {},
+        };
+        const subject = getSociogramOptions(mockState, { prompt });
+        expect(subject.allowHighlighting).toEqual(true);
+      });
+      it('when allowHighlighting option exists, allowHighlighting should match', () => {
+        let prompt = {
+          ...mockPrompt,
+          highlight: { allowHighlighting: false },
+        };
+        let subject = getSociogramOptions(mockState, { prompt });
+        expect(subject.allowHighlighting).toEqual(false);
+
+        prompt = {
+          ...mockPrompt,
+          highlight: { allowHighlighting: true },
+        };
+        subject = getSociogramOptions(mockState, { prompt });
+        expect(subject.allowHighlighting).toEqual(true);
+      });
     });
   });
 });

--- a/src/selectors/__tests__/sociogram.js
+++ b/src/selectors/__tests__/sociogram.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+
+import { makeGetSociogramOptions } from '../sociogram';
+
+const mockProps = {
+  prompt: {
+    layout: {},
+  },
+};
+
+const mockState = {
+};
+
+describe('sociogram selector', () => {
+  describe('makeGetSociogramOptions()', () => {
+    let getSociogramOptions;
+
+    beforeEach(() => {
+      getSociogramOptions = makeGetSociogramOptions();
+    });
+
+    it('when highlight option is missing, allowHighlighting is false', () => {
+      const subject = getSociogramOptions(mockState, mockProps);
+      expect(subject.allowHighlighting).toEqual(false);
+    });
+  });
+});

--- a/src/selectors/__tests__/sociogram.js
+++ b/src/selectors/__tests__/sociogram.js
@@ -21,7 +21,7 @@ describe('sociogram selector', () => {
       getSociogramOptions = makeGetSociogramOptions();
     });
 
-    describe('props.prompt.highlight', () => {
+    describe('allowHighlighting', () => {
       it('when highlight option is missing, allowHighlighting is false', () => {
         const subject = getSociogramOptions(mockState, mockProps);
         expect(subject.allowHighlighting).toEqual(false);
@@ -48,6 +48,15 @@ describe('sociogram selector', () => {
         };
         subject = getSociogramOptions(mockState, { prompt });
         expect(subject.allowHighlighting).toEqual(true);
+      });
+      it('when props.prompt.edges.create option exists, allowHighlighting should be false', () => {
+        const prompt = {
+          ...mockPrompt,
+          edges: { create: 'foo' },
+          highlight: { allowHighlighting: true },
+        };
+        const subject = getSociogramOptions(mockState, { prompt });
+        expect(subject.allowHighlighting).toEqual(false);
       });
     });
   });

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -58,7 +58,7 @@ const makeGetHighlightOptions = () =>
       const allowHighlighting = highlight && !edges.canCreateEdge ? get(highlight, 'allowHighlighting', true) : false;
       return ({
         allowHighlighting,
-        highlightAttributes: highlight.variable ?
+        highlightAttributes: has(highlight, 'variable') ?
           { [highlight.variable]: highlight.value } :
           undefined,
       });

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -1,7 +1,23 @@
 /* eslint-disable import/prefer-default-export */
 
 import { createSelector } from 'reselect';
-import { find, filter, has, reject, first, toPairs, unzip, orderBy, lowerCase, groupBy, pick, values, flatten, flow } from 'lodash';
+import {
+  find,
+  filter,
+  has,
+  get,
+  reject,
+  first,
+  toPairs,
+  unzip,
+  orderBy,
+  lowerCase,
+  groupBy,
+  pick,
+  values,
+  flatten,
+  flow,
+} from 'lodash';
 import { PropTypes } from 'prop-types';
 import { networkEdges, makeNetworkNodesForSubject } from './interface';
 import { createDeepEqualSelector } from './utils';
@@ -35,10 +51,13 @@ const getEdgeOptions = createDeepEqualSelector(
 
 const getHighlightOptions = createDeepEqualSelector(
   propPromptHighlight,
-  highlight => ({
-    allowHighlighting: has(highlight, 'allowHighlighting') ? highlight.allowHighlighting : false,
-    highlightAttributes: has(highlight, 'allowHighlighting') ? { [highlight.variable]: highlight.value } : {},
-  }),
+  (highlight) => {
+    const allowHighlighting = highlight ? get(highlight, 'allowHighlighting', true) : false;
+    return ({
+      allowHighlighting,
+      highlightAttributes: allowHighlighting ? { [highlight.variable]: highlight.value } : {},
+    });
+  },
 );
 
 const getLayoutOptions = createDeepEqualSelector(

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -58,7 +58,9 @@ const makeGetHighlightOptions = () =>
       const allowHighlighting = highlight && !edges.canCreateEdge ? get(highlight, 'allowHighlighting', true) : false;
       return ({
         allowHighlighting,
-        highlightAttributes: allowHighlighting ? { [highlight.variable]: highlight.value } : {},
+        highlightAttributes: highlight.variable ?
+          { [highlight.variable]: highlight.value } :
+          undefined,
       });
     },
   );
@@ -190,7 +192,7 @@ export const sociogramOptionsProps = {
   displayEdges: PropTypes.array.isRequired,
   canCreateEdge: PropTypes.bool.isRequired,
   allowHighlighting: PropTypes.bool.isRequired,
-  highlightAttributes: PropTypes.object.isRequired,
+  highlightAttributes: PropTypes.object,
   nodeBinSortOrder: PropTypes.object.isRequired,
   concentricCircles: PropTypes.number.isRequired,
   skewedTowardCenter: PropTypes.bool.isRequired,

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -44,8 +44,8 @@ const makeGetEdgeOptions = () =>
   createDeepEqualSelector(
     propPromptEdges,
     edges => ({
-      displayEdges: has(edges, 'display') ? edges.display : [],
-      createEdge: has(edges, 'create') ? edges.create : null,
+      displayEdges: get(edges, 'display', []),
+      createEdge: get(edges, 'create', undefined),
       canCreateEdge: has(edges, 'create'),
     }),
   );
@@ -78,7 +78,7 @@ const getBackgroundOptions = createDeepEqualSelector(
   background => ({
     concentricCircles: has(background, 'concentricCircles') ? background.concentricCircles : undefined,
     skewedTowardCenter: has(background, 'skewedTowardCenter') ? background.skewedTowardCenter : true,
-    image: has(background, 'image') ? background.image : undefined,
+    image: get(background, 'image', undefined),
   }),
 );
 
@@ -186,7 +186,7 @@ export const makeGetPlacedNodes = () => {
 export const sociogramOptionsProps = {
   layoutVariable: PropTypes.string.isRequired,
   allowPositioning: PropTypes.bool.isRequired,
-  createEdge: PropTypes.string.isRequired,
+  createEdge: PropTypes.string,
   displayEdges: PropTypes.array.isRequired,
   canCreateEdge: PropTypes.bool.isRequired,
   allowHighlighting: PropTypes.bool.isRequired,


### PR DESCRIPTION
Resolves #358

Changes behaviour of Sociogram configuration:
- make highlight disabled by default, 
- make edge creation override toggling highlight
- Use new linking prop on Nodes to indicate edge creation