### PR TITLE
pass icon to menu item

### DIFF
--- a/src/containers/StageMenu.js
+++ b/src/containers/StageMenu.js
@@ -43,6 +43,7 @@ class StageMenu extends Component {
     const items = filteredList.map(filteredStage =>
       ({
         id: filteredStage.id,
+        icon: filteredStage.icon,
         label: filteredStage.label,
         interfaceType: filteredStage.type,
         isActive: currentStage === filteredStage,


### PR DESCRIPTION
Fixes #362.

This allows the user to specify an `icon` in the stage's protocol to override the default icon for that interface in the menu. To test, edit the protocol to add an `icon` field set to one of the other available icons.