### PR TITLE
Fix default form lookup

### DIFF
--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -59,7 +59,9 @@ class NameGenerator extends Component {
    */
   onSelectNode = (node) => {
     this.setState({ selectedNode: node }, () => {
-      this.props.openModal(this.forms.EDIT_NODE);
+      if (this.props.form) {
+        this.props.openModal(this.forms.EDIT_NODE);
+      }
     });
   }
 
@@ -93,6 +95,34 @@ class NameGenerator extends Component {
       prompts,
     } = this.props.stage;
 
+    const nodeForms = form && (
+      <React.Fragment>
+        <NodeForm
+          node={this.state.selectedNode}
+          name={this.forms.EDIT_NODE}
+          title={form.title}
+          fields={form.fields}
+          entity={form.entity}
+          type={form.type}
+          autoPopulate={form.autoPopulate}
+          onSubmit={this.onSubmitEditNode}
+        />
+        <NodeForm
+          name={this.forms.ADD_NODE}
+          title={form.title}
+          fields={form.fields}
+          entity={form.entity}
+          type={form.type}
+          autoPopulate={form.autoPopulate}
+          onSubmit={this.onSubmitNewNode}
+          addAnother
+        />
+        <button className="name-generator-interface__add-person" onClick={() => openModal(this.forms.ADD_NODE)}>
+          Add a person
+        </button>
+      </React.Fragment>
+    );
+
     return (
       <div className="name-generator-interface">
         <div className="name-generator-interface__prompt">
@@ -121,31 +151,7 @@ class NameGenerator extends Component {
           </div>
         </div>
 
-        <NodeForm
-          node={this.state.selectedNode}
-          name={this.forms.EDIT_NODE}
-          title={form.title}
-          fields={form.fields}
-          entity={form.entity}
-          type={form.type}
-          autoPopulate={form.autoPopulate}
-          onSubmit={this.onSubmitEditNode}
-        />
-
-        <NodeForm
-          name={this.forms.ADD_NODE}
-          title={form.title}
-          fields={form.fields}
-          entity={form.entity}
-          type={form.type}
-          autoPopulate={form.autoPopulate}
-          onSubmit={this.onSubmitNewNode}
-          addAnother
-        />
-
-        <button className="name-generator-interface__add-person" onClick={() => openModal(this.forms.ADD_NODE)}>
-          Add a person
-        </button>
+        { nodeForms }
 
         <div className="name-generator-interface__node-bin">
           <NodeBin id="NODE_BIN" />

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -1,12 +1,20 @@
 import { createSelector } from 'reselect';
+import { makeGetNodeType } from './name-generator';
 import { protocolRegistry, protocolForms } from './protocol';
 
 // Prop selectors
 
 const propFields = (_, props) => props.fields;
-const propStageForm = (_, props) =>
-  (props.stage.form ? props.stage.form : props.stage.creates.entity);
+const propStageForm = (_, props) => props.stage.form;
 const propForm = (_, { entity, type }) => ({ entity, type });
+
+// Use the node type (e.g. "person") as the fallback form name —
+// this should always be present and will be created by architect.
+const nodeFormKey = createSelector(
+  propStageForm,
+  makeGetNodeType(),
+  (stageForm, nodeType) => stageForm || nodeType,
+);
 
 // MemoedSelectors
 
@@ -32,6 +40,6 @@ export const makeRehydrateFields = () =>
 
 export const makeRehydrateForm = () =>
   createSelector(
-    [propStageForm, protocolForms],
+    [nodeFormKey, protocolForms],
     (form, forms) => forms[form],
   );


### PR DESCRIPTION
This updates the form lookup logic specified in #353. If a stage doesn't define a `form`, then the app attempts to use one whose name matches `subject.type`. If the chosen form key describes a non-existent form, then an error occurs.

Surfacing error to the user: #353 describes an optional error message to the user. I haven't included that yet, as I think we should discuss the best way to handle it. For now, I render the interface without any forms (or new form button), and a 'form' prop validation error displays in the client console. If we wanted to message the user about a missing form at render time, then this provides a logical point to add that.

