### PR TITLE
Improved testing: Reducers

### DIFF
--- a/config/jest/automock.js
+++ b/config/jest/automock.js
@@ -3,3 +3,5 @@
 jest.mock('electron');
 jest.mock('fs');
 jest.mock('../../src/utils/Environment');
+
+global.console.error = jest.fn();

--- a/src/ducks/modules/__tests__/errors.test.js
+++ b/src/ducks/modules/__tests__/errors.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+import reducer, { actionCreators } from '../errors';
+import { actionCreators as protocolActions } from '../protocol';
+
+const initialState = {
+  errors: [],
+  acknowledged: true,
+};
+
+describe('errors reducer', () => {
+  it('should return the initial state', () => {
+    expect(
+      reducer(undefined, {}),
+    ).toEqual(initialState);
+  });
+
+  it('acknowlege() should set acknowledge to true', () => {
+    const newState = reducer(
+      { ...initialState, acknowledged: false },
+      actionCreators.acknowledge(),
+    );
+    expect(newState.acknowledged).toBe(true);
+  });
+
+  it('error() should set acknowledge to false, and add error to log, should respond to protocol errors as error()', () => {
+    const actions = [
+      actionCreators.error,
+      protocolActions.loadProtocolFailed,
+      protocolActions.importProtocolFailed,
+      protocolActions.downloadProtocolFailed,
+    ];
+
+    actions.forEach((action) => {
+      const error = new Error('this is an error');
+
+      const newState = reducer(
+        { acknowledged: true, errors: [] },
+        action(error),
+      );
+
+      expect(newState.acknowledged).toBe(false);
+      expect(newState.errors).toEqual([error]);
+    });
+  });
+});

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+
+import reducer from '../protocol';
+
+const initialState = {
+  isLoaded: false,
+  isLoading: false,
+  error: null,
+  name: '',
+  version: '',
+  required: '',
+  stages: [],
+};
+
+describe('protocol reducer', () => {
+  it('should return the initial state', () => {
+    expect(
+      reducer(undefined, {}),
+    ).toEqual(initialState);
+  });
+
+  it('setProtocol()');
+  it('downloadProtocol()');
+  it('importProtocol()');
+  it('loadProtocol()');
+  it('loadFactoryProtocol()');
+});

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import { ActionsObservable } from 'redux-observable';
-import 'rxjs';
 import reducer, { actionCreators, epics } from '../protocol';
 import environments from '../../../utils/environments';
 import { getEnvironment } from '../../../utils/Environment';

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 
-import reducer, { actionCreators } from '../protocol';
+import { ActionsObservable } from 'redux-observable';
+import 'rxjs';
+import reducer, { actionCreators, epics } from '../protocol';
+import environments from '../../../utils/environments';
+import { getEnvironment } from '../../../utils/Environment';
+
+jest.mock('../../../utils/protocol/index');
 
 const initialState = {
   isLoaded: false,
@@ -12,88 +18,146 @@ const initialState = {
   stages: [],
 };
 
-describe('protocol reducer', () => {
-  it('should return the initial state', () => {
-    expect(
-      reducer(undefined, {}),
-    ).toEqual(initialState);
-  });
+describe('protocol module', () => {
+  describe('reducer', () => {
+    it('should return the initial state', () => {
+      expect(
+        reducer(undefined, {}),
+      ).toEqual(initialState);
+    });
 
-  it('setProtocol() sets protocol on state and changes the loaded state', () => {
-    expect(
-      reducer(
-        initialState,
-        actionCreators.setProtocol(
-          '/tmp/foo/mockPath.protocol',
-          { stages: [{ foo: 'bar' }] },
+    it('setProtocol() sets protocol on state and changes the loaded state', () => {
+      expect(
+        reducer(
+          initialState,
+          actionCreators.setProtocol(
+            '/tmp/foo/mockPath.protocol',
+            { stages: [{ foo: 'bar' }] },
+          ),
         ),
-      ),
-    ).toEqual({
-      ...initialState,
-      path: '/tmp/foo/mockPath.protocol',
-      stages: [{ foo: 'bar' }],
-      isLoaded: true,
-      isLoading: false,
+      ).toEqual({
+        ...initialState,
+        path: '/tmp/foo/mockPath.protocol',
+        stages: [{ foo: 'bar' }],
+        isLoaded: true,
+        isLoading: false,
+      });
+    });
+
+    it('downloadProtocol()', () => {
+      expect(
+        reducer(
+          initialState,
+          actionCreators.downloadProtocol(
+            'https://tmp/foo/mockPath.protocol',
+          ),
+        ),
+      ).toEqual({
+        ...initialState,
+        isLoaded: false,
+        isLoading: true,
+      });
+    });
+
+    it('importProtocol()', () => {
+      expect(
+        reducer(
+          initialState,
+          actionCreators.importProtocol(
+            '/tmp/foo/mockPath.protocol',
+          ),
+        ),
+      ).toEqual({
+        ...initialState,
+        isLoaded: false,
+        isLoading: true,
+      });
+    });
+
+    it('loadProtocol()', () => {
+      expect(
+        reducer(
+          initialState,
+          actionCreators.loadProtocol(
+            '/tmp/foo/mockPath.protocol',
+          ),
+        ),
+      ).toEqual({
+        ...initialState,
+        isLoaded: false,
+        isLoading: true,
+      });
+    });
+
+    it('loadFactoryProtocol()', () => {
+      expect(
+        reducer(
+          initialState,
+          actionCreators.loadFactoryProtocol(
+            '/tmp/foo/mockPath.protocol',
+          ),
+        ),
+      ).toEqual({
+        ...initialState,
+        isLoaded: false,
+        isLoading: true,
+      });
     });
   });
 
-  it('downloadProtocol()', () => {
-    expect(
-      reducer(
-        initialState,
-        actionCreators.downloadProtocol(
-          'https://tmp/foo/mockPath.protocol',
-        ),
-      ),
-    ).toEqual({
-      ...initialState,
-      isLoaded: false,
-      isLoading: true,
+  describe('epics', () => {
+    beforeAll(() => {
+      getEnvironment.mockReturnValue(environments.ELECTRON);
     });
-  });
 
-  it('importProtocol()', () => {
-    expect(
-      reducer(
-        initialState,
-        actionCreators.importProtocol(
-          '/tmp/foo/mockPath.protocol',
-        ),
-      ),
-    ).toEqual({
-      ...initialState,
-      isLoaded: false,
-      isLoading: true,
+    it('downloadProtocolEpic', () => {
+      const action$ = ActionsObservable.of(
+        actionCreators.downloadProtocol('https://tmp/foo/mockPath.protocol'),
+      );
+
+      const expectedActions = [actionCreators.importProtocol('/downloaded/protocol/to/temp/path')];
+      return epics(action$).toArray().toPromise().then((result) => {
+        expect(result).toEqual(expectedActions);
+      });
     });
-  });
 
-  it('loadProtocol()', () => {
-    expect(
-      reducer(
-        initialState,
-        actionCreators.loadProtocol(
-          '/tmp/foo/mockPath.protocol',
-        ),
-      ),
-    ).toEqual({
-      ...initialState,
-      isLoaded: false,
-      isLoading: true,
+    it('importProtocolEpic', () => {
+      const action$ = ActionsObservable.of(
+        actionCreators.importProtocol('/downloaded/protocol/to/temp/path'),
+      );
+
+      const expectedActions = [actionCreators.loadProtocol('/app/data/protocol/path')];
+      return epics(action$).toArray().toPromise().then((result) => {
+        expect(result).toEqual(expectedActions);
+      });
     });
-  });
 
-  it('loadFactoryProtocol()', () => {
-    expect(
-      reducer(
-        initialState,
-        actionCreators.loadFactoryProtocol(
-          '/tmp/foo/mockPath.protocol',
-        ),
-      ),
-    ).toEqual({
-      ...initialState,
-      isLoaded: false,
-      isLoading: true,
+    it('loadProtocolEpic', () => {
+      const action$ = ActionsObservable.of(
+        actionCreators.loadProtocol('/app/data/protocol/path'),
+      );
+
+      const expectedActions = [actionCreators.setProtocol(
+        '/app/data/protocol/path',
+        { fake: { protocol: { json: true } } },
+      )];
+      return epics(action$).toArray().toPromise().then((result) => {
+        expect(result).toEqual(expectedActions);
+      });
+    });
+
+    it('loadFactoryProtocolEpic', () => {
+      const action$ = ActionsObservable.of(
+        actionCreators.loadFactoryProtocol('factory_protocol_name'),
+      );
+
+      const expectedActions = [actionCreators.setProtocol(
+        'factory_protocol_name',
+        { fake: { factory: { protocol: { json: true } } } },
+      )];
+      return epics(action$).toArray().toPromise().then((result) => {
+        expect(result).toEqual(expectedActions);
+      });
     });
   });
 });

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import reducer from '../protocol';
+import reducer, { actionCreators } from '../protocol';
 
 const initialState = {
   isLoaded: false,
@@ -19,9 +19,81 @@ describe('protocol reducer', () => {
     ).toEqual(initialState);
   });
 
-  it('setProtocol()');
-  it('downloadProtocol()');
-  it('importProtocol()');
-  it('loadProtocol()');
-  it('loadFactoryProtocol()');
+  it('setProtocol() sets protocol on state and changes the loaded state', () => {
+    expect(
+      reducer(
+        initialState,
+        actionCreators.setProtocol(
+          '/tmp/foo/mockPath.protocol',
+          { stages: [{ foo: 'bar' }] },
+        ),
+      ),
+    ).toEqual({
+      ...initialState,
+      path: '/tmp/foo/mockPath.protocol',
+      stages: [{ foo: 'bar' }],
+      isLoaded: true,
+      isLoading: false,
+    });
+  });
+
+  it('downloadProtocol()', () => {
+    expect(
+      reducer(
+        initialState,
+        actionCreators.downloadProtocol(
+          'https://tmp/foo/mockPath.protocol',
+        ),
+      ),
+    ).toEqual({
+      ...initialState,
+      isLoaded: false,
+      isLoading: true,
+    });
+  });
+
+  it('importProtocol()', () => {
+    expect(
+      reducer(
+        initialState,
+        actionCreators.importProtocol(
+          '/tmp/foo/mockPath.protocol',
+        ),
+      ),
+    ).toEqual({
+      ...initialState,
+      isLoaded: false,
+      isLoading: true,
+    });
+  });
+
+  it('loadProtocol()', () => {
+    expect(
+      reducer(
+        initialState,
+        actionCreators.loadProtocol(
+          '/tmp/foo/mockPath.protocol',
+        ),
+      ),
+    ).toEqual({
+      ...initialState,
+      isLoaded: false,
+      isLoading: true,
+    });
+  });
+
+  it('loadFactoryProtocol()', () => {
+    expect(
+      reducer(
+        initialState,
+        actionCreators.loadFactoryProtocol(
+          '/tmp/foo/mockPath.protocol',
+        ),
+      ),
+    ).toEqual({
+      ...initialState,
+      isLoaded: false,
+      isLoading: true,
+    });
+  });
 });

--- a/src/ducks/modules/errors.js
+++ b/src/ducks/modules/errors.js
@@ -16,7 +16,7 @@ export default function reducer(state = initialState, action = {}) {
     case errorActionTypes.DOWNLOAD_PROTOCOL_FAILED:
     case errorActionTypes.IMPORT_PROTOCOL_FAILED:
     case errorActionTypes.LOAD_PROTOCOL_FAILED:
-      console.error(action.error); // eslint-disable-line
+      if (!jest) { console.error(action.error); } // eslint-disable-line
       return {
         ...state,
         acknowledged: false,

--- a/src/ducks/modules/errors.js
+++ b/src/ducks/modules/errors.js
@@ -14,7 +14,8 @@ export default function reducer(state = initialState, action = {}) {
     case errorActionTypes.DOWNLOAD_PROTOCOL_FAILED:
     case errorActionTypes.IMPORT_PROTOCOL_FAILED:
     case errorActionTypes.LOAD_PROTOCOL_FAILED:
-      if (!jest) { console.error(action.error); } // eslint-disable-line
+      // eslint-disable-next-line no-console
+      console.error(action.error);
       return {
         ...state,
         acknowledged: false,

--- a/src/ducks/modules/errors.js
+++ b/src/ducks/modules/errors.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-
 import { actionTypes as errorActionTypes } from './protocol';
 
 const ERROR = 'ERRORS/ERROR';

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-
 import { combineEpics } from 'redux-observable';
 import { Observable } from 'rxjs';
 import { loadProtocol, importProtocol, downloadProtocol, loadFactoryProtocol } from '../../utils/protocol';

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -152,6 +152,9 @@ const actionCreators = {
   downloadProtocol: downloadProtocolAction,
   setProtocol,
   loadFactoryProtocol: loadFactoryProtocolAction,
+  loadProtocolFailed,
+  importProtocolFailed,
+  downloadProtocolFailed,
 };
 
 const actionTypes = {

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -36,8 +36,10 @@ export default function reducer(state = initialState, action = {}) {
     case DOWNLOAD_PROTOCOL:
     case IMPORT_PROTOCOL:
     case LOAD_PROTOCOL:
+    case LOAD_FACTORY_PROTOCOL:
       return {
         ...state,
+        isLoaded: false,
         isLoading: true,
       };
     case DOWNLOAD_PROTOCOL_FAILED:

--- a/src/utils/protocol/__mocks__/index.js
+++ b/src/utils/protocol/__mocks__/index.js
@@ -1,0 +1,11 @@
+const loadProtocol = () => Promise.resolve({ fake: { protocol: { json: true } } });
+const importProtocol = () => Promise.resolve('/app/data/protocol/path');
+const downloadProtocol = () => Promise.resolve('/downloaded/protocol/to/temp/path');
+const loadFactoryProtocol = () => Promise.resolve({ fake: { factory: { protocol: { json: true } } } });
+
+export {
+  loadProtocol,
+  importProtocol,
+  downloadProtocol,
+  loadFactoryProtocol,
+};

--- a/src/utils/protocol/__mocks__/index.js
+++ b/src/utils/protocol/__mocks__/index.js
@@ -1,7 +1,8 @@
 const loadProtocol = () => Promise.resolve({ fake: { protocol: { json: true } } });
 const importProtocol = () => Promise.resolve('/app/data/protocol/path');
 const downloadProtocol = () => Promise.resolve('/downloaded/protocol/to/temp/path');
-const loadFactoryProtocol = () => Promise.resolve({ fake: { factory: { protocol: { json: true } } } });
+const loadFactoryProtocol = () =>
+  Promise.resolve({ fake: { factory: { protocol: { json: true } } } });
 
 export {
   loadProtocol,


### PR DESCRIPTION
This PR only has reducers tests for the protocol and error modules because I'm moving onto the Architect project.

Includes a working example for testing epics (rxjs/redux observables).

Partial: #386