### PR TITLE
Fix/windows protocol path test

### DIFF
--- a/src/utils/protocol/__tests__/protocolPath.test.js
+++ b/src/utils/protocol/__tests__/protocolPath.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+import path from 'path';
 import environments from '../../environments';
 import { getEnvironment } from '../../Environment';
 import protocolPath from '../protocolPath';
@@ -15,11 +16,11 @@ describe('protocolPath', () => {
     it('Generates an asset path for the file', () => {
       expect(
         protocolPath('foo.canvas', 'protocol.json'),
-      ).toEqual('tmp/mock/user/path/protocols/foo.canvas/protocol.json');
+      ).toEqual(path.join('tmp', 'mock', 'user', 'path', 'protocols', 'foo.canvas', 'protocol.json'));
 
       expect(
         protocolPath('foo.canvas'),
-      ).toEqual('tmp/mock/user/path/protocols/foo.canvas');
+      ).toEqual(path.join('tmp', 'mock', 'user', 'path', 'protocols', 'foo.canvas'));
     });
 
     it('Thows an error if the protocol is not specified', () => {


### PR DESCRIPTION
Use node's path.join to use correct syntax on windows.

Not actually tested on Windows, but should work in theory.

Resolves #367