### PR TITLE
Fix/hide hidden form fields

### DIFF
--- a/src/containers/FormWizard.js
+++ b/src/containers/FormWizard.js
@@ -24,26 +24,33 @@ class FormWizard extends Component {
   }
 
   nextField = () => {
-    const count = this.props.fields.length;
+    const count = this.shownFields().length;
     this.setState({
       fieldIndex: (this.state.fieldIndex + 1 + count) % count,
     });
   };
 
   previousField = () => {
-    const count = this.props.fields.length;
+    const count = this.shownFields().length;
     this.setState({
       fieldIndex: (this.state.fieldIndex - 1 + count) % count,
     });
   };
 
   shouldShowNextButton = () => {
-    const showingLastField = this.state.fieldIndex === this.props.fields.length - 1;
+    const showingLastField = this.state.fieldIndex === this.shownFields().length - 1;
     return !showingLastField;
   }
 
-  currentField() {
-    return [this.props.fields[this.state.fieldIndex]];
+  hiddenFields = () => this.props.fields.filter(field => field.component === 'hidden');
+
+  shownFields = () => this.props.fields.filter(field => field.component !== 'hidden');
+
+  filterFields = () => {
+    if (this.state.fieldIndex === 0) {
+      return [this.shownFields()[0]].concat(this.hiddenFields());
+    }
+    return [this.shownFields()[this.state.fieldIndex]];
   }
 
   render() {
@@ -55,14 +62,14 @@ class FormWizard extends Component {
 
     const formProps = {
       ...this.props,
-      fields: this.currentField(),
+      fields: this.filterFields(),
       onSubmit: this.onSubmit,
     };
 
     return (
       <div className="form-wizard">
         <div className="form-wizard__pips">
-          <Pips count={this.props.fields.length} currentIndex={this.state.fieldIndex} />
+          <Pips count={this.shownFields().length} currentIndex={this.state.fieldIndex} />
         </div>
         <div className="form-wizard__previous">
           {this.state.fieldIndex !== 0 && <Icon name="form-arrow-left" onClick={this.previousField} />}

--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -21,11 +21,19 @@ const makePropFieldVariables = () =>
     fields => map(fields, 'name'),
   );
 
+const makeGetPropFieldValues = () =>
+  createSelector(
+    makeRehydrateFields(),
+    fields => Object.assign({}, ...fields.filter(field => field.value)
+      .map(field => ({ [field.name]: field.value }))),
+  );
+
 const makeGetInitialValuesFromProps = () =>
   createSelector(
     makePropFieldVariables(),
+    makeGetPropFieldValues(),
     propNode,
-    (fields, node) => pick(node, fields),
+    (fields, values, node) => ({ ...values, ...pick(node, fields) }),
   );
 
 /**

--- a/src/containers/__tests__/Form.test.js
+++ b/src/containers/__tests__/Form.test.js
@@ -67,6 +67,13 @@ describe('<Form />', () => {
         placeholder: 'Nickname',
         validation: {},
       },
+      {
+        label: 'Hidden',
+        name: 'Hidden',
+        component: 'hidden',
+        placeholder: 'Hidden',
+        validation: {},
+      },
     ];
 
     const subject = mount((
@@ -75,7 +82,10 @@ describe('<Form />', () => {
       </Provider>
     ));
 
-    expect(subject.find(Field).length).toBe(2);
+    expect(subject.find(Field).length).toBe(3);
+
+    expect(subject.find('.input__container--hidden').length).toBe(1);
+    expect(subject.find('.input__container--hidden').children().find('input').props().type).toEqual('hidden');
   });
   it('Calls autoPopulate on Field blur');
 });

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -25,6 +25,7 @@ const rehydrateField = ({ registry, entity, type, field }) => {
   return {
     name: field.variable,
     component: field.component,
+    value: field.value,
     ...registry[entity][type].variables[field.variable],
   };
 };

--- a/src/styles/components/_form-wizard.scss
+++ b/src/styles/components/_form-wizard.scss
@@ -56,7 +56,7 @@
     justify-content: center;
     align-items: flex-start;
 
-    div {
+    div:not([class*='-hidden']) {
       flex-basis: 50%;
     }
   }


### PR DESCRIPTION
Fixes #405. 

Basically this collects all the hidden fields in a form and puts them on the first step in the wizard, but this time *actually* hidden. Any information the node needed from those hidden fields still gets submitted with the form. This also populates those fields with any "value" from the protocol form, although it doesn't run or return function values, so "timeCreated", for example, is just a string.

To verify, check the "New Node" form of the development protocol when aspect ratio is low enough to prompt the full screen form wizard. It should only have the three required field, for Name, Nickname, and Age, but "timeCreated" will still be part of the node attributes.

Depends on ui's fix/hide-hidden-form-fields branch to be merged. See codaco/Network-Canvas-UI#40.