### PR TITLE
Removes isNumericOnly key from input props for non-text inputs.

### DIFF
--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -90,6 +90,10 @@ export const makeRenderInput = (componentType) => {
       InputComponent = withOptionsFromSelector(InputComponent, optionsSelector);
     }
 
+    if (['ToggleInput', 'CheckboxGroup', 'RadioGroup'].includes(componentType)) {
+      delete inputProps.isNumericOnly;
+    }
+
     return <InputComponent {...inputProps} {...input} />;
   };
 


### PR DESCRIPTION
Fixes #375 