### PR TITLE
Fixes #364. Matches optional props checks with what wiki documents.

### DIFF
--- a/src/containers/Interfaces/Information.js
+++ b/src/containers/Interfaces/Information.js
@@ -34,7 +34,7 @@ const Information = ({ stage: { title, items } }) => (
     <div className="instructions-interface__frame">
       <h1 className="instructions-interface__title type--title-1">{ title }</h1>
       <div className="instructions-interface__items">
-        { renderItems(items) }
+        { items && renderItems(items) }
       </div>
     </div>
   </div>

--- a/src/containers/Search/Search.js
+++ b/src/containers/Search/Search.js
@@ -238,6 +238,7 @@ Search.defaultProps = {
   clearResultsOnClose: true,
   nodeColor: '',
   nodeType: '',
+  options: {},
 };
 
 Search.propTypes = {
@@ -255,7 +256,7 @@ Search.propTypes = {
   /* eslint-disable react/no-unused-prop-types */
   // These props are required by the fuse selector
   dataSourceKey: PropTypes.string.isRequired,
-  options: PropTypes.object.isRequired,
+  options: PropTypes.object,
   // This prop used by the nodeColor selector
   nodeType: PropTypes.string,
   /* eslint-enable react/no-unused-prop-types */

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -61,13 +61,13 @@ export const getSortFields = createSelector(
 
 export const getSortOrderDefault = createSelector(
   propSortOptions,
-  sortOptions => sortOptions.sortOrder && (Object.keys(sortOptions.sortOrder)[0] || ''),
+  sortOptions => (has(sortOptions, 'sortOrder') ? Object.keys(sortOptions.sortOrder)[0] : ''),
 );
 
 export const getSortDirectionDefault = createSelector(
   propSortOptions,
   getSortOrderDefault,
-  (sortOptions, key) => sortOptions.sortOrder && (sortOptions.sortOrder[key] || ''),
+  (sortOptions, key) => (has(sortOptions, 'sortOrder') ? sortOptions.sortOrder[key] : ''),
 );
 
 export const getDataByPrompt = createSelector(


### PR DESCRIPTION
- Adds new selectors for sort orders for name generator
- Created a default property for `options` in Search interface
- checks for `items` before rendering them in Information interface