### PR TITLE
tweak default for full screen modal

### DIFF
--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -69,7 +69,7 @@ class NodeForm extends Component {
     }, this.submit);
   };
 
-  isLarge = () => window.matchMedia('screen and (min-device-aspect-ratio: 16/9)').matches;
+  isLarge = () => window.matchMedia('screen and (min-device-aspect-ratio: 8/5), (min-device-height: 1800px)').matches;
 
   render() {
     const {


### PR DESCRIPTION
Fixes #266. Triggers full screen modal (aka form wizard) when aspect ratio on device is below 1.6 *and* device height is below 1800px. The regular modal with the entire form should show if the aspect ratio is 1.6 or above, or the device height is 1800px or above.

This just tweaks the default until #390 can add a setting for user's preference.