### PR TITLE
Feature/implement skip logic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/utils/networkQuery"]
+	path = src/utils/networkQuery
+	url = https://github.com/codaco/networkQuery

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ node-gyp rebuild --target=1.8.2 --arch=x64 --dist-url=https://atom.io/download/e
 
 0. Install the correct node and npm versions.
 1. Clone this repsitory.
-2. Enter the directory where the repository is cloned, and install the project dependencies by typing `npm install`.
-3. Refer to the development tasks section below to learn how to test and build the app.
+2. Fetch submodules by typing `git submodule update --init`.
+3. Enter the directory where the repository is cloned, and install the project dependencies by typing `npm install`.
+4. Refer to the development tasks section below to learn how to test and build the app.
 
 ## Development Tasks
 

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -944,7 +944,7 @@
               "options": {
                 "type": "person",
                 "attribute": "name",
-                "operator": "EQUAL",
+                "operator": "EXACTLY",
                 "value": "Dee"
               }
             },

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -705,45 +705,6 @@
       "id": "namegenroster2",
       "type": "NameGeneratorList",
       "label": "NG Classmates",
-      "skipLogic": {
-        "action": "SHOW",
-        "operator": "EQUAL",
-        "value": "3",
-        "filter": {
-          "join": "OR",
-          "rules": [
-            {
-              "type": "alter",
-              "id": "15218241538622",
-              "options": {
-                "type": "person",
-                "attribute": "name",
-                "operator": "EQUAL",
-                "value": "Dee"
-              }
-            },
-            {
-              "type": "ego",
-              "id": "15218241553253",
-              "options": {
-                "attribute": "name",
-                "operator": "EXACTLY",
-                "value": "Bob"
-              }
-            },
-            {
-              "type": "edge",
-              "id": "15218241565624",
-              "options": {
-                "type": "friends",
-                "attribute": "to",
-                "operator": "NOT",
-                "value": "2"
-              }
-            }
-          ]
-        }
-      },
       "showExistingNodes": false,
       "prompts": [
         {
@@ -833,26 +794,6 @@
       "id": "sociogram",
       "type": "Sociogram",
       "label": "Sociogram",
-      "skipLogic": {
-        "action": "SKIP",
-        "operator": "LESS_THAN_OR_EQUAL",
-        "value": 1,
-        "filter": {
-          "join": "",
-          "rules": [
-            {
-              "type": "alter",
-              "options": {
-                "type": "person",
-                "attribute": "name",
-                "operator": "GREATER_THAN",
-                "value": "C"
-              },
-              "id": "15215634697512"
-            }
-          ]
-        }
-      },
       "prompts": [
         {
           "id": "closeness1",
@@ -981,6 +922,52 @@
           }
         }
       ]
+    },
+    {
+      "id": "skippable screen",
+      "label": "Skip or Show",
+      "type": "Information",
+      "title": "To skip or not to skip...",
+      "items": [
+        { "type": "text", "content": "...that is the question." }
+      ],
+      "skipLogic": {
+        "action": "SHOW",
+        "operator": "EXACTLY",
+        "value": "3",
+        "filter": {
+          "join": "OR",
+          "rules": [
+            {
+              "type": "alter",
+              "id": "15218241538622",
+              "options": {
+                "type": "person",
+                "attribute": "name",
+                "operator": "EQUAL",
+                "value": "Dee"
+              }
+            },
+            {
+              "type": "ego",
+              "id": "15218241553253",
+              "options": {
+                "attribute": "name",
+                "operator": "EXACTLY",
+                "value": "Bob"
+              }
+            },
+            {
+              "type": "edge",
+              "id": "15218241565624",
+              "options": {
+                "type": "friends",
+                "operator": "EXISTS"
+              }
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -705,6 +705,45 @@
       "id": "namegenroster2",
       "type": "NameGeneratorList",
       "label": "NG Classmates",
+      "skipLogic": {
+        "action": "SHOW",
+        "operator": "EQUAL",
+        "value": "3",
+        "filter": {
+          "join": "OR",
+          "rules": [
+            {
+              "type": "alter",
+              "id": "15218241538622",
+              "options": {
+                "type": "person",
+                "attribute": "name",
+                "operator": "EQUAL",
+                "value": "Dee"
+              }
+            },
+            {
+              "type": "ego",
+              "id": "15218241553253",
+              "options": {
+                "attribute": "name",
+                "operator": "EXACTLY",
+                "value": "Bob"
+              }
+            },
+            {
+              "type": "edge",
+              "id": "15218241565624",
+              "options": {
+                "type": "friends",
+                "attribute": "to",
+                "operator": "NOT",
+                "value": "2"
+              }
+            }
+          ]
+        }
+      },
       "showExistingNodes": false,
       "prompts": [
         {
@@ -794,6 +833,26 @@
       "id": "sociogram",
       "type": "Sociogram",
       "label": "Sociogram",
+      "skipLogic": {
+        "action": "SKIP",
+        "operator": "LESS_THAN_OR_EQUAL",
+        "value": 1,
+        "filter": {
+          "join": "",
+          "rules": [
+            {
+              "type": "alter",
+              "options": {
+                "type": "person",
+                "attribute": "name",
+                "operator": "GREATER_THAN",
+                "value": "C"
+              },
+              "id": "15215634697512"
+            }
+          ]
+        }
+      },
       "prompts": [
         {
           "id": "closeness1",

--- a/public/protocols/education.netcanvas/protocol.json
+++ b/public/protocols/education.netcanvas/protocol.json
@@ -396,7 +396,7 @@
         },
         {
           "id": "6el",
-          "text": "Please list all the people the community (such as a sports team, church, voluntary group, neighbours) who are important to you.",
+          "text": "Please list all the people in the community (such as a sports team, church, voluntary group, neighbours) who are important to you.",
           "additionalAttributes": {
             "community_important": true
           }
@@ -410,7 +410,7 @@
         },
         {
           "id": "6gl",
-          "text": "Finally, is there anyone else important to you who was not yet listed",
+          "text": "Finally, is there anyone else important to you who was not yet listed?",
           "additionalAttributes": {
             "other_important": true
           }

--- a/src/containers/LoadParamsRoute.js
+++ b/src/containers/LoadParamsRoute.js
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators, compose } from 'redux';
+import { Redirect } from 'react-router-dom';
 
 import { actionCreators as protocolActions } from '../ducks/modules/protocol';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
+import { getNextIndex, isStageSkipped } from '../selectors/skip-logic';
 
 class LoadParamsRoute extends Component {
   componentWillMount() {
@@ -34,36 +36,53 @@ class LoadParamsRoute extends Component {
 
   render() {
     const {
+      backParam,
       component: RenderComponent,
+      isSkipped,
       shouldReset,
+      skipToIndex,
       ...rest
     } = this.props;
 
     return (
-      <RenderComponent {...rest} stageIndex={this.props.computedMatch.params.stageIndex || 0} />
+      isSkipped ?
+        (<Redirect to={{ pathname: `/protocol/${this.props.computedMatch.params.protocolId}/${skipToIndex}`, search: backParam }} />) :
+        (<RenderComponent {...rest} stageIndex={this.props.computedMatch.params.stageIndex || 0} />)
     );
   }
 }
 
 LoadParamsRoute.propTypes = {
+  backParam: PropTypes.string.isRequired,
   component: PropTypes.func.isRequired,
   computedMatch: PropTypes.object.isRequired,
   isProtocolLoaded: PropTypes.bool.isRequired,
+  isSkipped: PropTypes.bool,
   loadFactoryProtocol: PropTypes.func.isRequired,
   protocolPath: PropTypes.string,
   resetState: PropTypes.func.isRequired,
   shouldReset: PropTypes.bool,
+  skipToIndex: PropTypes.number.isRequired,
 };
 
 LoadParamsRoute.defaultProps = {
+  isSkipped: false,
   protocolPath: '',
   shouldReset: false,
 };
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
+  let nextIndex = Math.trunc(ownProps.computedMatch.params.stageIndex) + 1;
+  if (ownProps.location && ownProps.location.search === '?back') {
+    nextIndex = Math.trunc(ownProps.computedMatch.params.stageIndex) - 1;
+  }
+
   return {
+    backParam: ownProps.location.search,
     isProtocolLoaded: state.protocol.isLoaded,
+    isSkipped: isStageSkipped(ownProps.computedMatch.params.stageIndex)(state),
     protocolPath: state.protocol.path,
+    skipToIndex: getNextIndex(nextIndex)(state),
   };
 }
 

--- a/src/containers/Stage.js
+++ b/src/containers/Stage.js
@@ -18,7 +18,7 @@ class Stage extends Component {
 
   // change the stage to the previous
   onClickBack = () => {
-    this.props.changeStage(`${this.props.pathPrefix}/${this.props.previousIndex}`);
+    this.props.changeStage(`${this.props.pathPrefix}/${this.props.previousIndex}?back`);
   }
 
   render() {

--- a/src/selectors/__tests__/skip-logic.test.js
+++ b/src/selectors/__tests__/skip-logic.test.js
@@ -1,0 +1,218 @@
+/* eslint-env jest */
+
+import { getNextIndex, isStageSkipped } from '../skip-logic';
+
+const mockState = {
+  network: {
+    edges: [
+      { id: 1, type: 'friend', to: 1, from: 2 }
+    ],
+    edgo: {},
+    nodes: [
+      { id: 1, type: 'person', name: 'soAndSo' },
+      { id: 2, type: 'person', name: 'whoDunnit' },
+      { id: 3, type: 'person', name: 'whatsErName' }
+    ]
+  },
+  protocol: {
+    stages: [
+      { id: 1 },
+      {
+        id: 2,
+        skipLogic: {
+          action: 'SHOW',
+          operator: 'LESS_THAN_OR_EQUAL',
+          value: 3,
+          filter: {
+            rules: [
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'name',
+                  operator: 'GREATER_THAN',
+                  value: 't'
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: 3,
+        skipLogic: {
+          action: 'SHOW',
+          operator: 'EXACTLY',
+          value: 1,
+          filter: {
+            rules: [
+              {
+                type: 'edge',
+                options: {
+                  type: 'friend',
+                  attribute: 'type',
+                  operator: 'EXISTS'
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: 4,
+        skipLogic: {
+          action: 'SKIP',
+          operator: 'GREATER_THAN',
+          value: 2,
+          filter: {
+            rules: [
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'id',
+                  operator: 'GREATER_THAN_OR_EQUAL',
+                  value: '1'
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: 5,
+        skipLogic: {
+          action: 'SKIP',
+          operator: 'NOT',
+          value: 1,
+          filter: {
+            rules: [
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'name',
+                  operator: 'EXACTLY',
+                  value: 'soAndSo'
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: 6,
+        skipLogic: {
+          action: 'SKIP',
+          operator: 'GREATER_THAN',
+          value: 1,
+          filter: {
+            join: 'AND',
+            rules: [
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'name',
+                  operator: 'EXACTLY',
+                  value: 'soAndSo'
+                }
+              },
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'id',
+                  operator: 'EXACTLY',
+                  value: 2
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        id: 7,
+        skipLogic: {
+          action: 'SKIP',
+          operator: 'GREATER_THAN',
+          value: 1,
+          filter: {
+            join: 'OR',
+            rules: [
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'name',
+                  operator: 'EXACTLY',
+                  value: 'soAndSo'
+                }
+              },
+              {
+                type: 'alter',
+                options: {
+                  type: 'person',
+                  attribute: 'id',
+                  operator: 'EXACTLY',
+                  value: 2
+                }
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+};
+
+describe('skip-logic selector', () => {
+  describe('getNextIndex()', () => {
+    it('returns the index if valid', () => {
+      const index = getNextIndex(1)(mockState);
+      expect(index).toEqual(1);
+    });
+
+    it('rotates the index if out of bounds', () => {
+      const index = getNextIndex(7)(mockState);
+      expect(index).toEqual(0);
+    });
+  });
+
+  describe('isStageSkipped()', () => {
+    it('shows any stage with missing skip logic', () => {
+      const skipped = isStageSkipped(0)(mockState);
+      expect(skipped).toEqual(false);
+    });
+
+    it('returns false for stage if show logic query is met', () => {
+      const skipped = isStageSkipped(1)(mockState);
+      expect(skipped).toEqual(false);
+    });
+
+    it('returns true for stage if show logic query is not met', () => {
+      const skipped = isStageSkipped(2)(mockState);
+      expect(skipped).toEqual(true);
+    });
+
+    it('returns true for stage if skip logic query is met', () => {
+      const skipped = isStageSkipped(3)(mockState);
+      expect(skipped).toEqual(true);
+    });
+
+    it('returns false for stage if skip logic query is not met', () => {
+      const skipped = isStageSkipped(4)(mockState);
+      expect(skipped).toEqual(false);
+    });
+
+    it('returns false for stage if skip logic query with AND is not met', () => {
+      const skipped = isStageSkipped(5)(mockState);
+      expect(skipped).toEqual(false);
+    });
+
+    it('returns false for stage if skip logic query with OR is not met', () => {
+      const skipped = isStageSkipped(6)(mockState);
+      expect(skipped).toEqual(true);
+    });
+  });
+});

--- a/src/selectors/__tests__/skip-logic.test.js
+++ b/src/selectors/__tests__/skip-logic.test.js
@@ -5,14 +5,14 @@ import { getNextIndex, isStageSkipped } from '../skip-logic';
 const mockState = {
   network: {
     edges: [
-      { id: 1, type: 'friend', to: 1, from: 2 }
+      { id: 1, type: 'friend', to: 1, from: 2 },
     ],
     edgo: {},
     nodes: [
       { id: 1, type: 'person', name: 'soAndSo' },
       { id: 2, type: 'person', name: 'whoDunnit' },
-      { id: 3, type: 'person', name: 'whatsErName' }
-    ]
+      { id: 3, type: 'person', name: 'whatsErName' },
+    ],
   },
   protocol: {
     stages: [
@@ -31,12 +31,12 @@ const mockState = {
                   type: 'person',
                   attribute: 'name',
                   operator: 'GREATER_THAN',
-                  value: 't'
-                }
-              }
-            ]
-          }
-        }
+                  value: 't',
+                },
+              },
+            ],
+          },
+        },
       },
       {
         id: 3,
@@ -51,12 +51,12 @@ const mockState = {
                 options: {
                   type: 'friend',
                   attribute: 'type',
-                  operator: 'EXISTS'
-                }
-              }
-            ]
-          }
-        }
+                  operator: 'EXISTS',
+                },
+              },
+            ],
+          },
+        },
       },
       {
         id: 4,
@@ -72,12 +72,12 @@ const mockState = {
                   type: 'person',
                   attribute: 'id',
                   operator: 'GREATER_THAN_OR_EQUAL',
-                  value: '1'
-                }
-              }
-            ]
-          }
-        }
+                  value: '1',
+                },
+              },
+            ],
+          },
+        },
       },
       {
         id: 5,
@@ -93,12 +93,12 @@ const mockState = {
                   type: 'person',
                   attribute: 'name',
                   operator: 'EXACTLY',
-                  value: 'soAndSo'
-                }
-              }
-            ]
-          }
-        }
+                  value: 'soAndSo',
+                },
+              },
+            ],
+          },
+        },
       },
       {
         id: 6,
@@ -115,8 +115,8 @@ const mockState = {
                   type: 'person',
                   attribute: 'name',
                   operator: 'EXACTLY',
-                  value: 'soAndSo'
-                }
+                  value: 'soAndSo',
+                },
               },
               {
                 type: 'alter',
@@ -124,12 +124,12 @@ const mockState = {
                   type: 'person',
                   attribute: 'id',
                   operator: 'EXACTLY',
-                  value: 2
-                }
-              }
-            ]
-          }
-        }
+                  value: 2,
+                },
+              },
+            ],
+          },
+        },
       },
       {
         id: 7,
@@ -146,8 +146,8 @@ const mockState = {
                   type: 'person',
                   attribute: 'name',
                   operator: 'EXACTLY',
-                  value: 'soAndSo'
-                }
+                  value: 'soAndSo',
+                },
               },
               {
                 type: 'alter',
@@ -155,15 +155,15 @@ const mockState = {
                   type: 'person',
                   attribute: 'id',
                   operator: 'EXACTLY',
-                  value: 2
-                }
-              }
-            ]
-          }
-        }
-      }
-    ]
-  }
+                  value: 2,
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
 };
 
 describe('skip-logic selector', () => {

--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -1,0 +1,112 @@
+import { createSelector } from 'reselect';
+
+import * as query from '../utils/networkQuery/query';
+import predicate from '../utils/networkQuery/predicate';
+import { stages as getStages } from './session';
+
+const getNetwork = state => state.network;
+
+const rotateIndex = (max, nextIndex) => (nextIndex + max) % max;
+const maxLength = state => getStages(state).length;
+
+const mapRuleType = (type) => {
+  switch (type) {
+    case 'alter':
+      return 'query.alterRule';
+    case 'ego':
+      return 'query.egoRule';
+    case 'edge':
+      return 'query.edgeRule';
+    default:
+      return '';
+  }
+};
+
+export const getNextIndex = index => createSelector(
+  maxLength,
+  max => rotateIndex(max, index),
+);
+
+const getSkipLogic = index => createSelector(
+  getStages,
+  stages => stages && stages[index] && stages[index].skipLogic,
+);
+
+const getFilter = index => createSelector(
+  getSkipLogic(index),
+  logic => logic && logic.filter,
+);
+
+const getJoinType = index => createSelector(
+  getFilter(index),
+  filter => ((filter && filter.join === 'OR') ? 'query.or' : 'query.and'),
+);
+
+const getRules = index => createSelector(
+  getFilter(index),
+  filter => (filter && filter.rules) || [],
+);
+
+const convertRules = index => createSelector(
+  getRules(index),
+  rules => rules.filter(rule => rule.type && rule.options).map(
+    (rule) => {
+      const fixedValue = typeof rule.options.value === 'number' ? rule.options.value : `'${rule.options.value}'`;
+      return `${mapRuleType(rule.type)}({
+        type: '${rule.options.type}',
+        attribute: '${rule.options.attribute}',
+        operator: '${rule.options.operator}',
+        value: ${fixedValue},
+      })`;
+    },
+  ),
+);
+
+const getFilterFunction = index => createSelector(
+  getJoinType(index),
+  convertRules(index),
+  (join, rules) => {
+    const filterMethod = `
+      return ${join}([${rules}]);
+    `;
+    const Fn = Function;
+    const functionize = method => new Fn('query', `${method}`)(query);
+
+    return functionize(filterMethod);
+  },
+);
+
+export const filterNetwork = index => createSelector(
+  getFilterFunction(index),
+  getNetwork,
+  (filter, network) => filter(network),
+);
+
+const isSkipAction = index => createSelector(
+  getSkipLogic(index),
+  logic => logic && logic.action === 'SKIP',
+);
+
+const getSkipValue = index => createSelector(
+  getSkipLogic(index),
+  logic => logic && logic.value && Math.trunc(logic.value),
+);
+
+const getSkipOperator = index => createSelector(
+  getSkipLogic(index),
+  logic => logic && logic.operator,
+);
+
+export const isStageSkipped = index => createSelector(
+  getSkipLogic(index),
+  isSkipAction(index),
+  getSkipOperator(index),
+  getSkipValue(index),
+  filterNetwork(index),
+  (logic, action, operator, comparisonValue, results) => {
+    const outerQuery = predicate(operator)(
+      { value: results.nodes.length, other: comparisonValue });
+
+    return !!logic && ((action && outerQuery) || (!action && !outerQuery));
+  },
+);

--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { alterRule, egoRule, edgeRule, or, and } from '../utils/networkQuery/query';
+import * as query from '../utils/networkQuery/query';
 import predicate from '../utils/networkQuery/predicate';
 import { stages as getStages } from './session';
 
@@ -12,11 +12,11 @@ const maxLength = state => getStages(state).length;
 const mapRuleType = (type) => {
   switch (type) {
     case 'alter':
-      return alterRule;
+      return query.alterRule;
     case 'ego':
-      return egoRule;
+      return query.egoRule;
     case 'edge':
-      return edgeRule;
+      return query.edgeRule;
     default:
       return () => {};
   }
@@ -39,7 +39,7 @@ const getFilter = index => createSelector(
 
 const getJoinType = index => createSelector(
   getFilter(index),
-  filter => ((filter && filter.join === 'OR') ? or : and),
+  filter => ((filter && filter.join === 'OR') ? query.or : query.and),
 );
 
 const getRules = index => createSelector(
@@ -54,10 +54,13 @@ const convertRules = index => createSelector(
   ),
 );
 
+const functionize = method => new Function('query', `${method}`)(query); // eslint-disable-line no-new-func
+
 const getFilterFunction = index => createSelector(
+  getFilter(index),
   getJoinType(index),
   convertRules(index),
-  (join, rules) => join(rules),
+  (filter, join, rules) => ((typeof filter === 'string') ? functionize(filter) : join(rules)),
 );
 
 const filterNetwork = index => createSelector(

--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -76,7 +76,7 @@ const getFilterFunction = index => createSelector(
   },
 );
 
-export const filterNetwork = index => createSelector(
+const filterNetwork = index => createSelector(
   getFilterFunction(index),
   getNetwork,
   (filter, network) => filter(network),


### PR DESCRIPTION
Resolves #276. I've put an interface in the development protocol to test against, that currently shows only if there are exactly three nodes with either the name "Dee" or as part of an existing edge.

This adds a submodule to the project for querying against the network at codaco/networkQuery. This means when you check out this branch you need to run `git submodule init`. I think you only need to run `git submodule update` if the submodule gets changed.

Assumption I've made: the top level (network) query is asking how many nodes exist in the network after the rules have all been run. This means, for example, that when an edge query is run and nodes are pruned that don't connect to qualified edges, the ultimate question is still how many _nodes_ are left in the query result. 

Outstanding questions: 
1. Architect uses ANY/NONE at the network level query, but EXISTS/NOT_EXISTS at the rule level query. However, ANY/NONE are not part of the predicate.js list, so I'm not sure whether this difference was intentional. Either the predicate file just needs to be updated, or Architect needs to be consistent.
2. Some fields need to be quoted, and some do not. I'm using "typeof" to check for numbers, but will there be object/array/etc node/edge values that need to be unquoted to match correctly in the future?
3. I think circleCI may need to be updated to use the submodule correctly. Where would this go? https://circleci.com/docs/1.0/configuration/#checkout