### PR TITLE
Feature/node bin sort default

### DIFF
--- a/src/containers/Interfaces/NameGeneratorAutoComplete.js
+++ b/src/containers/Interfaces/NameGeneratorAutoComplete.js
@@ -9,8 +9,8 @@ import withPrompt from '../../behaviours/withPrompt';
 import Search from '../../containers/Search';
 import { actionCreators as networkActions } from '../../ducks/modules/network';
 import { actionCreators as searchActions } from '../../ducks/modules/search';
-import { makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
-import { getCardDisplayLabel, getCardAdditionalProperties, makeGetNodeIconName, makeGetNodeType, makeGetPromptNodeAttributes } from '../../selectors/name-generator';
+import { makeGetNodeType, makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
+import { getCardDisplayLabel, getCardAdditionalProperties, makeGetNodeIconName, makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper } from '../';
 import { NodeBin, NodeList } from '../../components/';
 

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { makeGetNodeType } from './name-generator';
+import { makeGetNodeType } from './interface';
 import { protocolRegistry, protocolForms } from './protocol';
 
 // Prop selectors

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -72,8 +72,7 @@ export const makeGetDisplayVariable = () => createDeepEqualSelector(
   protocolRegistry,
   makeGetNodeType(),
   (variableRegistry, nodeType) => {
-    const nodeInfo = variableRegistry.node;
-    console.log(nodeInfo[nodeType].displayVariable);
+    const nodeInfo = variableRegistry && variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].displayVariable;
   },
 );

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -3,6 +3,7 @@
 import { createSelector } from 'reselect';
 import { filter, has, reject } from 'lodash';
 import { createDeepEqualSelector } from './utils';
+import { protocolRegistry } from './protocol';
 
 // Selectors that are generic between interfaces
 
@@ -61,6 +62,21 @@ export const makeGetSubject = () =>
       return prompt.subject;
     },
   );
+
+export const makeGetNodeType = () => (createSelector(
+  makeGetSubject(),
+  subject => subject && subject.type,
+));
+
+export const makeGetDisplayVariable = () => createDeepEqualSelector(
+  protocolRegistry,
+  makeGetNodeType(),
+  (variableRegistry, nodeType) => {
+    const nodeInfo = variableRegistry.node;
+    console.log(nodeInfo[nodeType].displayVariable);
+    return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].displayVariable;
+  },
+);
 
 export const makeNetworkNodesForSubject = () => {
   const getSubject = makeGetSubject();

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from 'reselect';
 import { has } from 'lodash';
-import { makeGetSubject, makeGetIds, makeGetAdditionalAttributes } from './interface';
+import { makeGetSubject, makeGetIds, makeGetNodeType, makeGetAdditionalAttributes } from './interface';
 import { getExternalData, protocolRegistry } from './protocol';
 import { nextUid } from '../ducks/modules/network';
 
@@ -20,11 +20,6 @@ These selectors assume the following props:
 const getDatasourceKey = (_, props) => props.prompt.dataSource;
 const propCardOptions = (_, props) => props.prompt.cardOptions;
 const propSortOptions = (_, props) => props.prompt.sortOptions;
-
-export const makeGetNodeType = () => (createSelector(
-  makeGetSubject(),
-  subject => subject && subject.type,
-));
 
 export const makeGetPromptNodeAttributes = () => {
   const getSubject = makeGetSubject();

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -3,7 +3,7 @@
 import { createDeepEqualSelector } from './utils';
 
 export const protocolRegistry = createDeepEqualSelector(
-  state => state.protocol.variableRegistry,
+  state => state.protocol && state.protocol.variableRegistry,
   registry => registry,
 );
 

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -19,7 +19,7 @@ import {
   flow,
 } from 'lodash';
 import { PropTypes } from 'prop-types';
-import { networkEdges, makeNetworkNodesForSubject } from './interface';
+import { networkEdges, makeGetDisplayVariable, makeNetworkNodesForSubject } from './interface';
 import { createDeepEqualSelector } from './utils';
 
 // Selectors that are specific to the name generator
@@ -72,7 +72,8 @@ const getLayoutOptions = createDeepEqualSelector(
 
 const getSortOptions = createDeepEqualSelector(
   propPromptSort,
-  sort => ({ nodeBinSortOrder: sort }),
+  makeGetDisplayVariable(),
+  (sort, displayVariable) => (sort ? { nodeBinSortOrder: sort } : { nodeBinSortOrder: { [displayVariable]: 'ASC' } }),
 );
 
 const getBackgroundOptions = createDeepEqualSelector(

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -17,6 +17,7 @@ import {
   values,
   flatten,
   flow,
+  isEmpty,
 } from 'lodash';
 import { PropTypes } from 'prop-types';
 import { networkEdges, makeGetDisplayVariable, makeNetworkNodesForSubject } from './interface';
@@ -73,7 +74,7 @@ const getLayoutOptions = createDeepEqualSelector(
 const getSortOptions = createDeepEqualSelector(
   propPromptSort,
   makeGetDisplayVariable(),
-  (sort, displayVariable) => (sort ? { nodeBinSortOrder: sort } : { nodeBinSortOrder: { [displayVariable]: 'ASC' } }),
+  (sort, displayVariable) => (sort && !isEmpty(sort) ? { nodeBinSortOrder: sort } : { nodeBinSortOrder: { [displayVariable]: 'ASC' } }),
 );
 
 const getBackgroundOptions = createDeepEqualSelector(


### PR DESCRIPTION
Resolves #357. To test, try removing the `nodeBinSortOrder` from a Sociogram interface. It should still sort by "nickname", since that is the `displayVariable` in the variableRegistry. This can be changed to other fields as well. If there is no `displayVariable`, it doesn't sort (e.g. nodes are displayed in whatever order the network nodes array is returned).