### PR TITLE
Feature/display label defaults

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -79,6 +79,7 @@
       },
       "venue": {
         "label": "Venue",
+        "displayVariable": "Abbreviated Name",
         "color": "kiwi",
         "iconVariant": "add-a-place",
         "variables": {

--- a/src/containers/ConcentricCircles/LayoutNode.js
+++ b/src/containers/ConcentricCircles/LayoutNode.js
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { Node } from 'network-canvas-ui';
+import { getNodeLabelFunction } from '../../selectors/interface';
 import { selectable } from '../../behaviours';
 import { DragSource } from '../../behaviours/DragAndDrop';
 import { NO_SCROLL } from '../../behaviours/DragAndDrop/DragManager';
-
-const label = node => node.nickname;
 
 const EnhancedNode = compose(
   DragSource,
@@ -16,12 +16,13 @@ const EnhancedNode = compose(
 class LayoutNode extends PureComponent {
   render() {
     const {
-      node,
-      selected,
-      linking,
       allowPositioning,
       allowSelect,
+      getLabel,
       layoutVariable,
+      linking,
+      node,
+      selected,
     } = this.props;
 
     const { x, y } = node[layoutVariable];
@@ -38,7 +39,7 @@ class LayoutNode extends PureComponent {
         style={styles}
       >
         <EnhancedNode
-          label={label(node)}
+          label={getLabel(node)}
           onSelected={this.props.onSelected}
           selected={selected}
           linking={linking}
@@ -55,27 +56,36 @@ class LayoutNode extends PureComponent {
 }
 
 LayoutNode.propTypes = {
-  onSelected: PropTypes.func.isRequired,
-  layoutVariable: PropTypes.string.isRequired,
-  node: PropTypes.object.isRequired,
   allowPositioning: PropTypes.bool,
   allowSelect: PropTypes.bool,
-  selected: PropTypes.bool,
-  linking: PropTypes.bool,
-  areaWidth: PropTypes.number,
   areaHeight: PropTypes.number,
+  areaWidth: PropTypes.number,
+  getLabel: PropTypes.func.isRequired,
+  layoutVariable: PropTypes.string.isRequired,
+  linking: PropTypes.bool,
+  node: PropTypes.object.isRequired,
+  onSelected: PropTypes.func.isRequired,
+  selected: PropTypes.bool,
 };
 
 LayoutNode.defaultProps = {
   allowPositioning: false,
   allowSelect: false,
-  selected: false,
-  linking: false,
-  areaWidth: 0,
   areaHeight: 0,
+  areaWidth: 0,
+  linking: false,
   onSelected: () => {},
+  selected: false,
 };
+
+function mapStateToProps(state) {
+  return {
+    getLabel: getNodeLabelFunction(state),
+  };
+}
 
 export { LayoutNode };
 
-export default LayoutNode;
+export default compose(
+  connect(mapStateToProps),
+)(LayoutNode);

--- a/src/containers/ConcentricCircles/__tests__/LayoutNode.test.js
+++ b/src/containers/ConcentricCircles/__tests__/LayoutNode.test.js
@@ -11,10 +11,11 @@ const mockProps = {
   updateNode: () => {},
   onSelected: () => {},
   layoutVariable: layout,
-  node: { [layout]: { x: 0.77, y: 0.2 } },
+  node: { [layout]: { x: 0.77, y: 0.2 }, label: 'some content' },
   areaWidth: 100,
   areaHeight: 40,
   draggableType: 'bar',
+  getLabel: node => node.label,
 };
 
 describe('<LayoutNode />', () => {

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/LayoutNode.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/LayoutNode.test.js.snap
@@ -10,6 +10,7 @@ ShallowWrapper {
     areaHeight={40}
     areaWidth={100}
     draggableType="bar"
+    getLabel={[Function]}
     layoutVariable="foo"
     linking={false}
     node={
@@ -18,6 +19,7 @@ ShallowWrapper {
               "x": 0.77,
               "y": 0.2,
             },
+            "label": "some content",
           }
     }
     onDropped={[Function]}
@@ -47,7 +49,7 @@ ShallowWrapper {
                         "y": 0.2,
                       }
         }
-        label={undefined}
+        label="some content"
         linking={false}
         meta={[Function]}
         onSelected={[Function]}
@@ -74,7 +76,7 @@ ShallowWrapper {
           "x": 0.77,
           "y": 0.2,
         },
-        "label": undefined,
+        "label": "some content",
         "linking": false,
         "meta": [Function],
         "onSelected": [Function],
@@ -103,7 +105,7 @@ ShallowWrapper {
                               "y": 0.2,
                             }
           }
-          label={undefined}
+          label="some content"
           linking={false}
           meta={[Function]}
           onSelected={[Function]}
@@ -130,7 +132,7 @@ ShallowWrapper {
             "x": 0.77,
             "y": 0.2,
           },
-          "label": undefined,
+          "label": "some content",
           "linking": false,
           "meta": [Function],
           "onSelected": [Function],

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
@@ -49,7 +49,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
-        <LayoutNode
+        <Connect(LayoutNode)
           allowPositioning={false}
           allowSelect={true}
           areaHeight={456}
@@ -110,7 +110,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
-          <LayoutNode
+          <Connect(LayoutNode)
             allowPositioning={false}
             allowSelect={true}
             areaHeight={456}

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -6,14 +6,11 @@ import { get, has } from 'lodash';
 import withPrompt from '../../behaviours/withPrompt';
 import { actionCreators as networkActions } from '../../ducks/modules/network';
 import { actionCreators as modalActions } from '../../ducks/modules/modals';
-import { makeNetworkNodesForPrompt } from '../../selectors/interface';
+import { getNodeLabelFunction, makeNetworkNodesForPrompt } from '../../selectors/interface';
 import { makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper, NodePanels, NodeForm } from '../../containers/';
 import { NodeList, NodeBin } from '../../components/';
 import { makeRehydrateForm } from '../../selectors/forms';
-
-// Render method for the node labels
-const label = node => `${node.nickname}`;
 
 /**
   * Name Generator Interface
@@ -82,13 +79,14 @@ class NameGenerator extends Component {
 
   render() {
     const {
-      openModal,
-      promptForward,
-      promptBackward,
-      prompt,
-      nodesForPrompt,
-      stage,
       form,
+      getLabel,
+      nodesForPrompt,
+      openModal,
+      prompt,
+      promptBackward,
+      promptForward,
+      stage,
     } = this.props;
 
     const {
@@ -140,7 +138,7 @@ class NameGenerator extends Component {
           <div className="name-generator-interface__nodes">
             <NodeList
               nodes={nodesForPrompt}
-              label={label}
+              label={getLabel}
               listId={`${stage.id}_${prompt.id}_MAIN_NODE_LIST`}
               id={'MAIN_NODE_LIST'}
               accepts={({ meta }) => get(meta, 'itemType', null) === 'NEW_NODE'}
@@ -162,17 +160,18 @@ class NameGenerator extends Component {
 }
 
 NameGenerator.propTypes = {
-  nodesForPrompt: PropTypes.array.isRequired,
-  stage: PropTypes.object.isRequired,
-  prompt: PropTypes.object.isRequired,
-  addNodes: PropTypes.func.isRequired,
-  updateNode: PropTypes.func.isRequired,
-  openModal: PropTypes.func.isRequired,
   activePromptAttributes: PropTypes.object.isRequired,
-  newNodeAttributes: PropTypes.object.isRequired,
-  promptForward: PropTypes.func.isRequired,
-  promptBackward: PropTypes.func.isRequired,
+  addNodes: PropTypes.func.isRequired,
   form: PropTypes.object.isRequired,
+  getLabel: PropTypes.func.isRequired,
+  newNodeAttributes: PropTypes.object.isRequired,
+  nodesForPrompt: PropTypes.array.isRequired,
+  openModal: PropTypes.func.isRequired,
+  prompt: PropTypes.object.isRequired,
+  promptBackward: PropTypes.func.isRequired,
+  promptForward: PropTypes.func.isRequired,
+  stage: PropTypes.object.isRequired,
+  updateNode: PropTypes.func.isRequired,
 };
 
 function makeMapStateToProps() {
@@ -183,9 +182,10 @@ function makeMapStateToProps() {
   return function mapStateToProps(state, props) {
     return {
       activePromptAttributes: props.prompt.additionalAttributes,
+      form: rehydrateForm(state, props),
+      getLabel: getNodeLabelFunction(state),
       newNodeAttributes: getPromptNodeAttributes(state, props),
       nodesForPrompt: networkNodesForPrompt(state, props),
-      form: rehydrateForm(state, props),
     };
   };
 }
@@ -193,9 +193,9 @@ function makeMapStateToProps() {
 function mapDispatchToProps(dispatch) {
   return {
     addNodes: bindActionCreators(networkActions.addNodes, dispatch),
-    updateNode: bindActionCreators(networkActions.updateNode, dispatch),
     closeModal: bindActionCreators(modalActions.closeModal, dispatch),
     openModal: bindActionCreators(modalActions.openModal, dispatch),
+    updateNode: bindActionCreators(networkActions.updateNode, dispatch),
   };
 }
 

--- a/src/containers/Interfaces/NameGeneratorAutoComplete.js
+++ b/src/containers/Interfaces/NameGeneratorAutoComplete.js
@@ -9,7 +9,7 @@ import withPrompt from '../../behaviours/withPrompt';
 import Search from '../../containers/Search';
 import { actionCreators as networkActions } from '../../ducks/modules/network';
 import { actionCreators as searchActions } from '../../ducks/modules/search';
-import { makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
+import { getNodeLabelFunction, makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
 import { getCardDisplayLabel, getCardAdditionalProperties, makeGetNodeIconName, makeGetNodeType, makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper } from '../';
 import { NodeBin, NodeList } from '../../components/';
@@ -47,13 +47,14 @@ class NameGeneratorAutoComplete extends Component {
     const {
       closeSearch,
       excludedNodes,
+      getLabel,
       labelKey,
-      nodesForPrompt,
       nodeIconName,
+      nodesForPrompt,
       nodeType,
       prompt,
-      promptForward,
       promptBackward,
+      promptForward,
       searchIsOpen,
       stage,
       toggleSearch,
@@ -71,9 +72,6 @@ class NameGeneratorAutoComplete extends Component {
 
     const ListId = 'AUTOCOMPLETE_NODE_LIST';
 
-    // TODO: Remove this workaround for the label formatter depending on prompt vars. See #305.
-    const labeledNodes = nodesForPrompt.map(n => ({ ...n, label: n[labelKey] }));
-
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__prompt`}>
@@ -88,8 +86,9 @@ class NameGeneratorAutoComplete extends Component {
         <div className={`${baseClass}__nodes`}>
           <NodeList
             id={ListId}
+            label={getLabel}
             listId={`${stage.id}_${prompt.id}_${ListId}`}
-            nodes={labeledNodes}
+            nodes={nodesForPrompt}
             itemType="EXISTING_NODE"
           />
         </div>
@@ -126,17 +125,18 @@ NameGeneratorAutoComplete.propTypes = {
   addNodes: PropTypes.func.isRequired,
   closeSearch: PropTypes.func.isRequired,
   excludedNodes: PropTypes.array.isRequired,
+  getLabel: PropTypes.func.isRequired,
   labelKey: PropTypes.string.isRequired,
   newNodeAttributes: PropTypes.object.isRequired,
   nodesForPrompt: PropTypes.array.isRequired,
   nodeIconName: PropTypes.string.isRequired,
   nodeType: PropTypes.string.isRequired,
-  toggleSearch: PropTypes.func.isRequired,
   prompt: PropTypes.object.isRequired,
-  promptForward: PropTypes.func.isRequired,
   promptBackward: PropTypes.func.isRequired,
+  promptForward: PropTypes.func.isRequired,
   searchIsOpen: PropTypes.bool.isRequired,
   stage: PropTypes.object.isRequired,
+  toggleSearch: PropTypes.func.isRequired,
   visibleSupplementaryFields: PropTypes.array.isRequired,
 };
 
@@ -151,10 +151,11 @@ function mapDispatchToProps(dispatch) {
 function makeMapStateToProps() {
   return function mapStateToProps(state, props) {
     return {
+      excludedNodes: networkNodes(state, props),
+      getLabel: getNodeLabelFunction(state),
       labelKey: getCardDisplayLabel(state, props),
       newNodeAttributes: getPromptNodeAttributes(state, props),
       nodeIconName: getNodeIconName(state, props),
-      excludedNodes: networkNodes(state, props),
       nodesForPrompt: networkNodesForPrompt(state, props),
       nodeType: getNodeType(state, props),
       searchIsOpen: !state.search.collapsed,

--- a/src/containers/NodeBucket.js
+++ b/src/containers/NodeBucket.js
@@ -4,14 +4,15 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { Node } from 'network-canvas-ui';
 import { makeGetNextUnplacedNode, makeGetSociogramOptions } from '../selectors/sociogram';
+import { getNodeLabelFunction } from '../selectors/interface';
 import { DragSource } from '../behaviours/DragAndDrop';
 import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
 
 const EnhancedNode = DragSource(Node);
-const label = node => node.nickname;
 
 class NodeBucket extends Component {
   static propTypes = {
+    getLabel: PropTypes.func.isRequired,
     node: PropTypes.object,
   };
 
@@ -21,6 +22,7 @@ class NodeBucket extends Component {
 
   render() {
     const {
+      getLabel,
       node,
     } = this.props;
 
@@ -30,7 +32,7 @@ class NodeBucket extends Component {
       <div className="node-bucket">
         { node &&
           <EnhancedNode
-            label={label(node)}
+            label={getLabel(node)}
             meta={() => ({ ...node, itemType: 'POSITIONED_NODE' })}
             scrollDirection={NO_SCROLL}
             {...node}
@@ -47,6 +49,7 @@ function makeMapStateToProps() {
 
   return function mapStateToProps(state, props) {
     return {
+      getLabel: getNodeLabelFunction(state),
       node: getNextUnplacedNode(state, props),
       ...getSociogramOptions(state, props),
     };

--- a/src/containers/NodePanels.js
+++ b/src/containers/NodePanels.js
@@ -3,7 +3,7 @@ import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { includes, map, differenceBy } from 'lodash';
-import { networkNodes, makeNetworkNodesForOtherPrompts } from '../selectors/interface';
+import { getNodeLabelFunction, networkNodes, makeNetworkNodesForOtherPrompts } from '../selectors/interface';
 import { getExternalData } from '../selectors/protocol';
 import { actionCreators as networkActions } from '../ducks/modules/network';
 import { makeGetPromptNodeAttributes } from '../selectors/name-generator';
@@ -25,28 +25,27 @@ const getHighlight = (highlight, panelNumber) => {
   return null;
 };
 
-const label = node => `${node.nickname}`;
-
 /**
   * Configures and renders `NodeProvider`s into panels according to the protocol config
   */
 class NodePanels extends PureComponent {
   static propTypes = {
-    toggleNodeAttributes: PropTypes.func.isRequired,
-    removeNode: PropTypes.func.isRequired,
     activePromptAttributes: PropTypes.object.isRequired,
-    newNodeAttributes: PropTypes.object.isRequired,
+    getLabel: PropTypes.func.isRequired,
     isDragging: PropTypes.bool,
-    panels: PropTypes.array,
     meta: PropTypes.object,
+    panels: PropTypes.array,
     prompt: PropTypes.object,
+    newNodeAttributes: PropTypes.object.isRequired,
+    removeNode: PropTypes.func.isRequired,
     stage: PropTypes.object,
+    toggleNodeAttributes: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
-    panels: [],
-    meta: {},
     isDragging: false,
+    meta: {},
+    panels: [],
     prompt: { id: null },
     stage: { id: null },
   };
@@ -93,7 +92,7 @@ class NodePanels extends PureComponent {
           listId={`PANEL_NODE_LIST_${stageId}_${promptId}_${index}`}
           id={`PANEL_NODE_LIST_${index}`}
           {...nodeListProps}
-          label={label}
+          label={this.props.getLabel}
           itemType="NEW_NODE"
           onDrop={item => this.onDrop(item, dataSource)}
         />
@@ -167,8 +166,9 @@ function makeMapStateToProps() {
 
     return {
       activePromptAttributes: props.prompt.additionalAttributes,
-      panels,
+      getLabel: getNodeLabelFunction(state),
       newNodeAttributes,
+      panels,
     };
   };
 }

--- a/src/containers/__tests__/NodeBucket.test.js
+++ b/src/containers/__tests__/NodeBucket.test.js
@@ -21,10 +21,11 @@ const sociogramOptionsDefault = {
 
 const mockProps = {
   ...sociogramOptionsDefault,
-  node: {},
+  node: { label: 'some label' },
   updateNode: () => {},
   layout: 'foo',
   sort: {},
+  getLabel: node => node.label,
 };
 
 describe('<NodeBucket />', () => {

--- a/src/containers/__tests__/NodePanels.test.js
+++ b/src/containers/__tests__/NodePanels.test.js
@@ -11,6 +11,7 @@ const mockProps = {
   removeNode: () => {},
   activePromptAttributes: {},
   newNodeAttributes: {},
+  getLabel: () => 'some label',
 };
 
 describe('<NodePanels />', () => {

--- a/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
@@ -12,10 +12,15 @@ ShallowWrapper {
     concentricCircles={0}
     createEdge="bar"
     displayEdges={Array []}
+    getLabel={[Function]}
     highlightAttributes={Object {}}
     layout="foo"
     layoutVariable="foo"
-    node={Object {}}
+    node={
+        Object {
+            "label": "some label",
+          }
+    }
     nodeBinSortOrder={Object {}}
     selectMode=""
     skewedTowardCenter={false}
@@ -36,7 +41,7 @@ ShallowWrapper {
     "props": Object {
       "children": <DragSource
         allowDrag={true}
-        label={undefined}
+        label="some label"
         meta={[Function]}
         scrollDirection="NO_SCROLL"
 />,
@@ -49,7 +54,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "allowDrag": true,
-        "label": undefined,
+        "label": "some label",
         "meta": [Function],
         "scrollDirection": "NO_SCROLL",
       },
@@ -67,7 +72,7 @@ ShallowWrapper {
       "props": Object {
         "children": <DragSource
           allowDrag={true}
-          label={undefined}
+          label="some label"
           meta={[Function]}
           scrollDirection="NO_SCROLL"
 />,
@@ -80,7 +85,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "allowDrag": true,
-          "label": undefined,
+          "label": "some label",
           "meta": [Function],
           "scrollDirection": "NO_SCROLL",
         },

--- a/src/containers/__tests__/__snapshots__/NodePanels.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/NodePanels.test.js.snap
@@ -6,6 +6,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <NodePanels
     activePromptAttributes={Object {}}
+    getLabel={[Function]}
     isDragging={false}
     meta={Object {}}
     newNodeAttributes={Object {}}

--- a/src/selectors/__tests__/interface.test.js
+++ b/src/selectors/__tests__/interface.test.js
@@ -21,6 +21,58 @@ const mockStage = {
   },
 };
 
+const externalNode1 = {
+  uid: 'person_1',
+  type: 'person',
+  name: 'F. Anita',
+  nickname: 'Annie',
+  age: 23,
+  label: 'Custom Label',
+};
+
+const externalNode2 = {
+  uid: 'person_2',
+  type: 'person',
+  name: 'H. Barry',
+  nickname: 'Baz',
+  age: 31,
+};
+
+const externalNode3 = {
+  uid: 'person_3',
+  type: 'person',
+  nickname: 'Carl',
+  age: 25,
+};
+
+const externalNode4 = {
+  id: 4,
+  uid: 'person_3',
+  type: 'person',
+  age: 25,
+};
+
+const mockProtocol = {
+  externalData: {
+    schoolPupils: {
+      nodes: [externalNode1, externalNode2, externalNode3, externalNode4],
+    },
+  },
+  variableRegistry: {
+    node: {
+      person: {
+        displayVariable: 'name',
+        iconVariant: 'add-a-person',
+        variables: {
+          nickname: {
+            type: 'text',
+          },
+        },
+      },
+    },
+  },
+};
+
 const mockProps = {
   prompt: mockPrompt,
   stage: mockStage,
@@ -45,6 +97,7 @@ const edges = [{ to: 'bar', from: 'foo' }, { to: 'asdf', from: 'qwerty' }];
 
 const mockState = {
   network: { nodes, edges },
+  protocol: mockProtocol,
 };
 
 describe('interface selector', () => {
@@ -75,6 +128,24 @@ describe('interface selector', () => {
       const selected = Interface.makeGetSubject();
       expect(selected(mockState, mockProps)).toEqual(mockStage.subject);
       expect(selected(null, emptyProps)).toEqual({});
+    });
+
+    it('should get node type', () => {
+      const selected = Interface.makeGetNodeType();
+      expect(selected(mockState, mockProps)).toEqual('person');
+    });
+
+    it('should get displayVariable', () => {
+      const selected = Interface.makeGetDisplayVariable();
+      expect(selected(mockState, mockProps)).toEqual('name');
+    });
+
+    it('should get node label function', () => {
+      const getLabel = Interface.getNodeLabelFunction(mockState, mockProps);
+      expect(getLabel(externalNode1)).toEqual('Custom Label');
+      expect(getLabel(externalNode2)).toEqual('H. Barry');
+      expect(getLabel(externalNode3)).toEqual('Carl');
+      expect(getLabel(externalNode4)).toEqual('4');
     });
 
     it('makeNetworkNodesForSubject()', () => {

--- a/src/selectors/__tests__/name-generator.test.js
+++ b/src/selectors/__tests__/name-generator.test.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import * as NameGen from '../name-generator';
-import * as Interface from '../interface';
 
 const mockPrompt = {
   id: 'promptId123',
@@ -40,6 +39,7 @@ const externalNode = {
   nickname: 'Annie',
   age: 23,
 };
+
 const mockProtocol = {
   externalData: {
     schoolPupils: {
@@ -82,11 +82,6 @@ const mockState = {
 
 describe('name generator selector', () => {
   describe('memoed selectors', () => {
-    it('should get node type', () => {
-      const selected = Interface.makeGetNodeType();
-      expect(selected(mockState, mockProps)).toEqual('person');
-    });
-
     it('should get node attributes for the prompt', () => {
       const selected = NameGen.makeGetPromptNodeAttributes();
       expect(selected(mockState, mockProps)).toEqual({

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { createSelector } from 'reselect';
-import { filter, has, reject, values } from 'lodash';
+import { findKey, filter, has, reject } from 'lodash';
 import { createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
 
@@ -63,16 +63,6 @@ export const makeGetSubject = () =>
     },
   );
 
-export const getNodeLabelFunction = createDeepEqualSelector(
-  protocolRegistry,
-  variableRegistry => (node) => {
-    const nodeInfo = variableRegistry && variableRegistry.node;
-    const displayVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&
-      nodeInfo[node.type].displayVariable;
-    return (displayVariable && node[displayVariable]) || values(node)[0] || node.id;
-  },
-);
-
 export const makeGetNodeType = () => (createSelector(
   makeGetSubject(),
   subject => subject && subject.type,
@@ -84,6 +74,20 @@ export const makeGetDisplayVariable = () => createDeepEqualSelector(
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry && variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].displayVariable;
+  },
+);
+
+export const getNodeLabelFunction = createDeepEqualSelector(
+  protocolRegistry,
+  variableRegistry => (node) => {
+    const nodeInfo = variableRegistry && variableRegistry.node;
+    const displayVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&
+      nodeInfo[node.type].displayVariable;
+    const firstTextVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&
+      nodeInfo[node.type].variables && findKey(nodeInfo[node.type].variables, ['type', 'text']);
+    return (displayVariable && node[displayVariable]) ||
+      (firstTextVariable && node[firstTextVariable]) ||
+      String(node.id);
   },
 );
 

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -85,7 +85,8 @@ export const getNodeLabelFunction = createDeepEqualSelector(
       nodeInfo[node.type].displayVariable;
     const firstTextVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&
       nodeInfo[node.type].variables && findKey(nodeInfo[node.type].variables, ['type', 'text']);
-    return (displayVariable && node[displayVariable]) ||
+    return node.label ||
+      (displayVariable && node[displayVariable]) ||
       (firstTextVariable && node[firstTextVariable]) ||
       String(node.id);
   },

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -1,8 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 
 import { createSelector } from 'reselect';
-import { filter, has, reject } from 'lodash';
+import { filter, has, reject, values } from 'lodash';
 import { createDeepEqualSelector } from './utils';
+import { protocolRegistry } from './protocol';
 
 // Selectors that are generic between interfaces
 
@@ -61,6 +62,16 @@ export const makeGetSubject = () =>
       return prompt.subject;
     },
   );
+
+export const getNodeLabelFunction = createDeepEqualSelector(
+  protocolRegistry,
+  variableRegistry => (node) => {
+    const nodeInfo = variableRegistry && variableRegistry.node;
+    const displayVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&
+      nodeInfo[node.type].displayVariable;
+    return (displayVariable && node[displayVariable]) || values(node)[0] || node.id;
+  },
+);
 
 export const makeNetworkNodesForSubject = () => {
   const getSubject = makeGetSubject();


### PR DESCRIPTION
This resolves #311 and (I believe) the last case for #305. It updates node labels so they are no longer hardcoded to display `node.nickname`. Instead, this has a three-fold fallback solution to attempt to use a node's type to lookup the `displayVariable` for that type in the `variableRegistry`. If that fails, it shows the first field in the node object, and if that fails it shows `node.id`.

This should address the situation that nodes of different types can end up in a node list together, and still show something intelligent on a node specific basis. 

To verify, experiment with prompts with different node types, giving them identical `additionalAttributes` and adding nodes on each. `NodeList`s should show both node types with something intelligent for each label.