### PR TITLE
Avoid having to `window.require`

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -87,7 +87,9 @@ module.exports = {
     // for React Native Web.
     extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
-
+      // Use the UMD version of React Markdown, so that we can keep building for
+      // electron-renderer and running other browsers
+      'react-markdown': require.resolve('react-markdown/umd/react-markdown.js'),
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -82,7 +82,9 @@ module.exports = {
     // for React Native Web.
     extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
-
+      // Use the UMD version of React Markdown, so that we can keep building for
+      // electron-renderer and running other browsers
+      'react-markdown': require.resolve('react-markdown/umd/react-markdown.js'),
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -47,7 +47,7 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
 module.exports = {
-  target: 'web',
+  target: 'electron-renderer',
   // Don't attempt to continue if there are any errors.
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,29 +10,13 @@
             "integrity": "sha512-juYJNi8JEpTUWXwz8ssa8Oop4n/kwJ/pIQP22vJAVAe6RTRD+0m+e9LRNnfK2EDaX8uwmUzLNGviFQRD6SxeOw==",
             "dev": true,
             "requires": {
-                "7zip-bin-linux": "1.3.1",
-                "7zip-bin-mac": "1.0.1",
-                "7zip-bin-win": "2.2.0"
+                "7zip-bin-mac": "1.0.1"
             }
-        },
-        "7zip-bin-linux": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-            "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-            "dev": true,
-            "optional": true
         },
         "7zip-bin-mac": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
             "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-            "dev": true,
-            "optional": true
-        },
-        "7zip-bin-win": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.2.0.tgz",
-            "integrity": "sha512-uPHXapEmUtlUKTBx4asWMlxtFUWXzEY0KVEgU7QKhgO2LJzzM3kYxM6yOyUZTtYE6mhK4dDn3FDut9SCQWHzgg==",
             "dev": true,
             "optional": true
         },
@@ -227,29 +211,13 @@
             "integrity": "sha512-F08sJ8N/ttb3mM0lQXPC3IgJU7ZqrQmaQJ4BXCDs8iz79nLN7RRoe0zupAxaSq0Siptd6T3cfdUnO73FjtOhNg==",
             "dev": true,
             "requires": {
-                "app-builder-bin-linux": "1.3.1",
-                "app-builder-bin-mac": "1.3.1",
-                "app-builder-bin-win": "1.3.1"
+                "app-builder-bin-mac": "1.3.1"
             }
-        },
-        "app-builder-bin-linux": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/app-builder-bin-linux/-/app-builder-bin-linux-1.3.1.tgz",
-            "integrity": "sha512-+drdENi7FBmQ4kMOyu1wx4QSVAdiHhAucArHZpHC8R99aWDkBA+4fnQRnQV//X1DQlii/AAOqipN/3nKa/RMWw==",
-            "dev": true,
-            "optional": true
         },
         "app-builder-bin-mac": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/app-builder-bin-mac/-/app-builder-bin-mac-1.3.1.tgz",
             "integrity": "sha512-AzQ34nQdClZyA0HbYoOzZEhysf8O0oSnL7mA+xBxQV4vtEQ9BxmLvsldXAj9uIQ+nWLd5L8LuZDYPvKHNXYSFw==",
-            "dev": true,
-            "optional": true
-        },
-        "app-builder-bin-win": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/app-builder-bin-win/-/app-builder-bin-win-1.3.1.tgz",
-            "integrity": "sha512-E0J7TI8Wf6eNCc8mSOqlZxeWw6ovmtTSZTZaPX9RTOJnWkKRbYcgL0r3GGQkN+WPfsU9feovOKFBPDfwJLDoRA==",
             "dev": true,
             "optional": true
         },

--- a/public/components/log.js
+++ b/public/components/log.js
@@ -1,9 +1,9 @@
-const electron = window.require('electron');
-const path = window.require('path');
-const log = window.require('electron-log');
-const fs = window.require('fs');
+const electron = require('electron');
+const path = require('path');
+const log = require('electron-log');
+const fs = require('fs');
 
-const userDataPath = (electron.app || electron.remote.app).getPath('userData');
+const userDataPath = (electron.app || electron.remote.app).getPath('userData')
 
 // Same as for console transport
 log.transports.file.level = 'log';

--- a/src/utils/Updater.js
+++ b/src/utils/Updater.js
@@ -1,9 +1,10 @@
-import { EventEmitter } from 'eventemitter3';
 import { isElectron } from '../utils/Environment';
 
+let EventEmitter;
 let ipcRenderer;
 
 if (isElectron()) {
+  EventEmitter = window.require('events').EventEmitter;
   ipcRenderer = window.require('electron').ipcRenderer;
 }
 

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -24,7 +24,7 @@ const inSequence = (items, apply) =>
 
 const userDataPath = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const electron = window.require('electron');
+    const electron = require('electron');
 
     return () => (electron.app || electron.remote.app).getPath('userData');
   }
@@ -38,7 +38,7 @@ const userDataPath = inEnvironment((environment) => {
 
 const appPath = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const electron = window.require('electron');
+    const electron = require('electron');
 
     return () => (electron.app || electron.remote.app).getAppPath();
   }
@@ -63,7 +63,7 @@ const resolveFileSystemUrl = inEnvironment((environment) => {
 
 const readFile = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const fs = window.require('fs');
+    const fs = require('fs');
 
     return filename =>
       new Promise((resolve, reject) => {
@@ -153,7 +153,7 @@ const writeFile = inEnvironment((environment) => {
   }
 
   if (environment === environments.ELECTRON) {
-    const fs = window.require('fs');
+    const fs = require('fs');
 
     return (filePath, data) =>
       new Promise((resolve, reject) => {
@@ -169,7 +169,7 @@ const writeFile = inEnvironment((environment) => {
 
 const createDirectory = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const fs = window.require('fs');
+    const fs = require('fs');
 
     return targetPath =>
       new Promise((resolve, reject) => {
@@ -208,7 +208,7 @@ const createDirectory = inEnvironment((environment) => {
 
 const removeDirectory = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const rimraf = window.require('rimraf');
+    const rimraf = require('rimraf');
     return targetPath =>
       new Promise((resolve, reject) => {
         try {
@@ -287,7 +287,7 @@ const getNestedPaths = inEnvironment((environment) => {
 
 const writeStream = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const fs = window.require('fs');
+    const fs = require('fs');
 
     return (destination, stream) =>
       new Promise((resolve, reject) => {

--- a/src/utils/getVersion.js
+++ b/src/utils/getVersion.js
@@ -4,7 +4,7 @@ import { isElectron, isCordova } from '../utils/Environment';
 
 const getVersion = () => {
   if (isElectron()) {
-    const remote = window.require('electron').remote;  // eslint-disable-line global-require
+    const remote = require('electron').remote;  // eslint-disable-line global-require
 
     return new Promise((resolve) => {
       const version = remote.app.getVersion();

--- a/src/utils/protocol/downloadProtocol.js
+++ b/src/utils/protocol/downloadProtocol.js
@@ -27,9 +27,9 @@ const fileError = friendlyErrorMessage('The protocol could not be saved to your 
 
 const downloadProtocol = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const request = window.require('request-promise-native');
-    const path = window.require('path');
-    const electron = window.require('electron');
+    const request = require('request-promise-native');
+    const path = require('path');
+    const electron = require('electron');
 
     return (uri) => {
       const tempPath = (electron.app || electron.remote.app).getPath('temp');

--- a/src/utils/protocol/factoryProtocolPath.js
+++ b/src/utils/protocol/factoryProtocolPath.js
@@ -9,7 +9,7 @@ const isValidProtocolName = protocolName => (isString(protocolName) && protocolN
 
 const factoryProtocolPath = (environment) => {
   if (environment === environments.ELECTRON) {
-    const path = window.require('path');
+    const path = require('path');
 
     return (protocolName, filePath = '') => {
       if (!isValidProtocolName(protocolName)) throw Error('Protocol name is not valid');

--- a/src/utils/protocol/importProtocol.js
+++ b/src/utils/protocol/importProtocol.js
@@ -18,7 +18,7 @@ const prepareDestination = destination =>
 
 const extractZipDirectory = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const path = window.require('path');
+    const path = require('path');
 
     return (zipObject, destination) => {
       const extractPath = path.join(destination, zipObject.name);
@@ -40,7 +40,7 @@ const extractZipDirectory = inEnvironment((environment) => {
 
 const extractZipFile = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const path = window.require('path');
+    const path = require('path');
 
     return (zipObject, destination) => {
       const extractPath = path.join(destination, zipObject.name);
@@ -105,7 +105,7 @@ const importZip = inEnvironment((environment) => {
 
 const importProtocol = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
-    const path = window.require('path');
+    const path = require('path');
 
     return (protocolFile = isRequired('protocolFile')) => {
       const protocolName = path.basename(protocolFile);

--- a/src/utils/protocol/protocolPath.js
+++ b/src/utils/protocol/protocolPath.js
@@ -9,7 +9,7 @@ const isValidProtocolName = protocolName => (isString(protocolName) && protocolN
 
 const protocolPath = (environment) => {
   if (environment === environments.ELECTRON) {
-    const path = require('path');
+    const path = window.require('path');
 
     return (protocolName, filePath = '') => {
       if (!isValidProtocolName(protocolName)) throw Error('Protocol name is not valid');


### PR DESCRIPTION
This is a PR onto the ui branch which targeted web and added `window.require`s for electron (needed to get things working with the new markdown dependency). 

Presumably we want to keep a single output target. `react-markdown` already includes a universal build, so this resolves the module to the UMD version via an alias.

- reverts 11a967d and 7af2bd3
- updates webpack config for dev & prod

If you want to rebase the other changes away in the ui branch & just cherry-pick the config change, 60190a2 is the commit you want.

Markdown rendering seems to work as I'd expect (testing Android and Electron).