### PR TITLE
Pin UI dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11143,7 +11143,7 @@
             }
         },
         "network-canvas-ui": {
-            "version": "git+https://github.com/codaco/Network-Canvas-UI.git#eafc73765289399d2dab7b34d86533668e99121d",
+            "version": "git+https://github.com/codaco/Network-Canvas-UI.git#2b7f567cd2ed4a390027c6eb3bddc5a78fccb525",
             "dev": true,
             "requires": {
                 "classnames": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "jszip": "^3.1.5",
         "lodash": "^4.17.4",
         "mdns": "^2.3.4",
-        "network-canvas-ui": "git+https://github.com/codaco/Network-Canvas-UI.git",
+        "network-canvas-ui": "git+https://github.com/codaco/Network-Canvas-UI.git#1.13.2",
         "node-sass": "^4.5.3",
         "object-assign": "4.1.1",
         "postcss-flexbugs-fixes": "3.2.0",


### PR DESCRIPTION
Network-Canvas-UI is good about adding tags to releases. This adds a version hash to the dependency, so that we can control when changes are introduced.

This will make it easier to work on outstanding fix & feature branches that require running `npm install` without introducing unrelated breaking changes. (Case in point: the open react-markdown branch.)