### PR TITLE
fix can't delete edges

### DIFF
--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -132,7 +132,7 @@ describe('session actions', () => {
     });
   });
 
-  it('should toggle edges', () => {
+  it('should toggle edges, adding if not there and removing if it is', () => {
     const edgeA = { from: 'foo', to: 'bar', type: 'friend' };
     const edgeB = { from: 'asdf', to: 'qwerty', type: 'friend' };
     expect(
@@ -145,14 +145,19 @@ describe('session actions', () => {
       ),
     ).toEqual({
       ...mockState,
-      edges: [
-        edgeB,
+      edges: [edgeB],
+    });
+    expect(
+      reducer(
         {
-          from: 'bar',
-          to: 'foo',
-          type: 'friend',
+          ...mockState,
+          edges: [edgeB],
         },
-      ],
+        actionCreators.toggleEdge(edgeA),
+      ),
+    ).toEqual({
+      ...mockState,
+      edges: [edgeB, edgeA],
     });
   });
 

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -120,13 +120,11 @@ export default function reducer(state = initialState, action = {}) {
         edges: [...state.edges, action.edge],
       };
     case TOGGLE_EDGE:
+      // remove edge if it exists, add it if it doesn't
       if (edgeExists(state.edges, action.edge)) {
         return {
           ...state,
-          edges: [
-            ...reject(reject(state.edges, action.edge), flipEdge(action.edge)),
-            flipEdge(action.edge),
-          ],
+          edges: reject(reject(state.edges, action.edge), flipEdge(action.edge)),
         };
       }
       return {


### PR DESCRIPTION
This fixes #456, reverting TOGGLE_EDGE to add an edge if it doesn't exist already and remove it if it does exist. Also adds comments and updates the test.