### PR TITLE
add key for items in list

### DIFF
--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -80,6 +80,7 @@ class NodeForm extends Component {
       autoFocus: true,
       controls: [
         (showAddAnotherToggle && <ToggleInput
+          key="toggleInput"
           name="addAnother"
           label="Add another?"
           checked={this.state.addAnotherNode}


### PR DESCRIPTION
Fixes #444. If you open the new node form in the education protocol, no warning about missing key for unique props should show now.