### PR TITLE
move cleartimeout to fix nodelist on quick prompt changes

### DIFF
--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -34,6 +34,8 @@ class NodeList extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
+
     // Don't update if nodes are the same
     if (isEqual(newProps.nodes, this.state.nodes)) {
       return;
@@ -54,7 +56,6 @@ class NodeList extends Component {
       this.setState(
         { nodes: [], stagger: true },
         () => {
-          if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
           this.refreshTimer = setTimeout(
             () => this.setState({
               nodes: newProps.nodes,

--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -68,6 +68,10 @@ class NodeList extends Component {
     });
   }
 
+  componentWillUnmount() {
+    if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
+  }
+
   render() {
     const {
       nodeColor,


### PR DESCRIPTION
Fixes #305. I think this does actually fix the issue with node lists displaying the previous prompt's nodes.