### PR TITLE
WIP: Reconcile multiple service advertisements

### DIFF
--- a/src/components/ServerList.js
+++ b/src/components/ServerList.js
@@ -38,24 +38,23 @@ class ServerList extends Component {
     });
 
     this.serverDiscoverer.on('SERVER_ANNOUNCED', (response) => {
+      if (!response.name) { return; }
+
+      const servers = this.state.servers.slice();
       // Detect if we already have a service with this name
       const serverIndex = this.state.servers.findIndex(server => response.name === server.name);
-
-      // TODO: update the existing record with additional data,
-      // if multiple advertisements for the same service.
       if (serverIndex === -1) {
-        this.setState(prevState => ({
-          servers: [...prevState.servers, response],
-        }));
+        servers.push(response);
+      } else {
+        servers[serverIndex] = response;
       }
+      this.setState(() => ({ servers }));
     });
 
     this.serverDiscoverer.on('SERVER_REMOVED', (response) => {
       this.setState(prevState => ({
-        // eslint-disable-next-line
-        servers: prevState.servers.filter(item => !(item.name == response.name)),
-      }), () => {
-      });
+        servers: prevState.servers.filter(item => (item.name !== response.name)),
+      }));
     });
 
     this.serverDiscoverer.on('SERVER_ERROR', (error) => {

--- a/src/components/__tests__/ServerList.test.js
+++ b/src/components/__tests__/ServerList.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ServerList from '../ServerList';
+
+jest.mock('../../utils/serverDiscoverer', () => jest.fn().mockImplementation(() => ({
+  init: jest.fn(),
+  on: jest.fn(),
+})));
+
+jest.mock('../../utils/Environment', () => ({
+  isCordova: () => false,
+  isElectron: () => true,
+}));
+
+describe('ServerList component', () => {
+  let component;
+  beforeEach(() => {
+    component = mount(<ServerList />);
+  });
+
+  it('displays listening state', () => {
+    expect(component.find('ServerCard')).toHaveLength(0);
+    expect(component.text()).toContain('Listening');
+  });
+
+  it('displays servers', () => {
+    component.setState({ servers: [{ name: 'nc' }] });
+    expect(component.find('ServerCard')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Names are still assumed unique. A subsequent advertisement for a name
replaces the earlier entry entirely. (For zeroconf-cordova, coalescing
happens at the library level; for electron, I haven't seen multiple
advertisements.)

Logs from a test run below. `fe80...` is a link-local address and so discarded; we don't get a usable IP address for the device API until `192.168.1.8`.

```
05-01 09:07:33.239  6512  6586 V ZeroConf: Initialized
05-01 09:07:33.239  6512  6586 D ZeroConf: Watch _network-canvas._tcp.local.
05-01 09:07:33.620  6512  6602 D ZeroConf: Added
05-01 09:07:33.621  6512  6602 D ZeroConf: Sending result: {"action":"added","service":{"domain":"local.","type":"_network-canvas._tcp.","name":"network-canvas","port":0,"hostname":"network-canvas._network-canvas._tcp.local.","ipv4Addresses":[],"ipv6Addresses":[],"txtRecord":{"network-canvas._network-canvas._tcp.local.":"true"}}}
05-01 09:07:33.624  6512  6602 D ZeroConf: Resolved
05-01 09:07:33.625  6512  6602 D ZeroConf: Sending result: {"action":"resolved","service":{"domain":"local.","type":"_network-canvas._tcp.","name":"network-canvas","port":51001,"hostname":"","ipv4Addresses":[],"ipv6Addresses":["fe80::4b1:e41d:6481:36b7"],"txtRecord":{}}}
05-01 09:07:33.625  6512  6602 D ZeroConf: Resolved
05-01 09:07:33.625  6512  6602 D ZeroConf: Sending result: {"action":"resolved","service":{"domain":"local.","type":"_network-canvas._tcp.","name":"network-canvas","port":51001,"hostname":"","ipv4Addresses":["192.168.1.8"],"ipv6Addresses":["fe80::4b1:e41d:6481:36b7"],"txtRecord":{}}}
```

Tested on top of the [feature/pairing](https://github.com/codaco/Network-Canvas/tree/feature/pairing) branch.

Fixes #481.