### PR TITLE
Support copy/paste in Electron

### DIFF
--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -1,4 +1,4 @@
-const electron = require('electron');
+const { app, BrowserWindow, Menu } = require('electron');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -6,11 +6,6 @@ const url = require('url');
 const log = require('electron-log');
 const registerAssetsProtocol = require('./components/assetsProtocol').registerAssetsProtocol;
 require('./components/updater');
-
-// Module to control application life.
-const app = electron.app;
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow;
 
 const isMacOS = () => os.platform() === 'darwin';
 
@@ -66,10 +61,39 @@ function createWindow() {
   });
 }
 
+function createMenu() {
+  const template = [
+    {
+      submenu: [
+        { role: 'quit' }
+      ]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { type: 'separator' },
+        { role: 'selectall' }
+      ]
+    }
+  ];
+  if (!isMacOS()) {
+    template[0].label = 'File';
+  }
+
+  const appMenu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(appMenu);
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow);
+app.on('ready', () => {
+  createMenu();
+  createWindow();
+});
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -77,6 +77,13 @@ function createMenu() {
         { type: 'separator' },
         { role: 'selectall' }
       ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'toggledevtools' }
+      ]
     }
   ];
   if (!isMacOS()) {

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -9,7 +9,7 @@ import { actionCreators as mockActions } from '../ducks/modules/mock';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { actionCreators as modalActions } from '../ducks/modules/modals';
 import { sessionMenuIsOpen } from '../selectors/session';
-import { isCordova, isElectron, isMacOS } from '../utils/Environment';
+import { isCordova, isElectron } from '../utils/Environment';
 import { Menu } from '../components';
 import createGraphML from '../utils/ExportData';
 import { Dialog } from '../containers/';
@@ -132,10 +132,6 @@ class SessionMenu extends Component {
         this.props.openModal('UPDATE_DIALOG');
       });
     });
-
-    if (isElectron()) {
-      this.registerPlatformShortcuts();
-    }
   }
 
   componentWillMount() {
@@ -169,34 +165,6 @@ class SessionMenu extends Component {
     // TODO: implement progress updates/loader
     // Trigger the download. Returns promise.
     updater.downloadUpdate();
-  }
-
-  registerShortcut = (accelerator, callback) => {
-    if (!isElectron()) return;
-
-    const electron = window.require('electron');
-    const register = () => electron.remote.globalShortcut.register(accelerator, callback);
-    const unregister = () => electron.remote.globalShortcut.unregister(accelerator, callback);
-
-    electron.remote.getCurrentWindow().on('ready', register);
-
-    // register and unregister on focus/blur so the shortcut is not so aggressive
-    electron.remote.getCurrentWindow().on('focus', register);
-    electron.remote.getCurrentWindow().on('blur', unregister);
-
-    window.onbeforeunload = () => {
-      unregister();
-      // remove listeners since this renderer window is going away
-      electron.remote.getCurrentWindow().removeAllListeners();
-    };
-  }
-
-  registerPlatformShortcuts = () => {
-    if (isMacOS()) {
-      this.registerShortcut('Cmd+Option+I', this.toggleDevTools);
-    } else {
-      this.registerShortcut('Ctrl+Shift+I', this.toggleDevTools);
-    }
   }
 
   toggleDevTools = () => {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -24,6 +24,7 @@ $font-path: '../ui/assets/fonts';
 
 html,
 body {
+  cursor: default;
   overflow: hidden;
   user-select: none;
   color: palette('text');


### PR DESCRIPTION
Mostly just pulling in the related change from Server here.

Including the built-in copy/paste menu items automatically adds keyboard shortcuts. This enables copy/paste across the entire app, which I assume is OK. The mac-specific handling is for the app menu item, as in [the electron docs](https://electronjs.org/docs/api/menu#main-process).

(Note that this also overrides Electron's default menu during development; if we were purposefully using different menus for dev/prod, then this may not be what we want.)

Fixes #489.