### PR TITLE
Render from LoadParamsRoute if resetting state

### DIFF
--- a/src/containers/LoadParamsRoute.js
+++ b/src/containers/LoadParamsRoute.js
@@ -84,8 +84,8 @@ class LoadParamsRoute extends Component {
       sessionId,
     } = this.props.computedMatch.params;
 
-    // not finished loading
-    if (!isProtocolLoaded || this.props.sessionId !== sessionId) { return null; }
+    const finishedLoading = isProtocolLoaded && this.props.sessionId === sessionId;
+    if (!shouldReset && !finishedLoading) { return null; }
 
     return (
       isSkipped ?


### PR DESCRIPTION
This updates the LoadParamsRoute to render if `shouldResetState` is true.

I'm not sure this is the correct fix, but it seems to solve the following problem on `master`. If I'm viewing a session/protocol and then "Reset Session" (from side menu), the app renders a blank screen (and empty menus), and I'm forced to quit & restart the app.