### PR TITLE
Fix app reset

### DIFF
--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, shell } = require('electron');
+const { app, BrowserWindow, dialog, Menu, shell } = require('electron');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -85,10 +85,26 @@ function createMenu() {
       ]
     },
     {
-      label: 'View',
+      label: 'Develop',
       submenu: [
         { role: 'reload' },
-        { role: 'toggledevtools' }
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        {
+          label: 'Reset All Data...',
+          click: () => {
+            dialog.showMessageBox({
+              message: 'This will reset all app data, are you sure?',
+              buttons: ['OK', 'Cancel']
+            }, (response) => {
+              if (response === 0) {
+                mainWindow.webContents.session.clearStorageData({}, () => {
+                  mainWindow.loadURL(appUrl);
+                });
+              }
+            });
+          }
+        }
       ]
     }
   ];

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -187,7 +187,7 @@ class SessionMenu extends Component {
 
     const items = [
       { id: 'export', label: 'Download Data', icon: 'menu-download-data', onClick: this.onExport },
-      { id: 'reset', label: 'Reset Session', icon: 'menu-purge-data', onClick: this.onReset },
+      { id: 'reset', label: 'Reset All Data', icon: 'menu-purge-data', onClick: this.onReset },
       { id: 'mock-data', label: 'Add mock nodes', icon: 'menu-custom-interface', onClick: addMockNodes },
       ...customItems,
     ];

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -158,7 +158,7 @@ class SessionMenu extends Component {
   };
 
   onReset = () => {
-    this.props.resetState();
+    this.props.openModal('CONFIRM_DELETE_DATA');
   };
 
   confirmUpdateDownload = () => {
@@ -235,6 +235,18 @@ class SessionMenu extends Component {
           onConfirm={() => {}}
         >
           <p>There was a problem exporting your data.</p>
+        </Dialog>
+        <Dialog
+          name="CONFIRM_DELETE_DATA"
+          title="Delete ALL data?"
+          type="warning"
+          confirmLabel="Yes, delete data"
+          onConfirm={this.props.resetState}
+        >
+          <p>
+            This will remove <strong>all</strong> data from the app.
+            Are you sure you want to continue?
+          </p>
         </Dialog>
         <Dialog
           name="UPDATE_DIALOG"

--- a/src/styles/components/_dialog.scss
+++ b/src/styles/components/_dialog.scss
@@ -17,7 +17,7 @@ $component-name: dialog;
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: var(--modal-overlay-bg-color);
+    background-color: var(--modal-overlay);
   }
 
   &__window {


### PR DESCRIPTION
- Renames reset menu item in web UI
- Adds native reset (redirects instead of reloading to clear path info)
- Uses "Develop" Menu to match Architect

Resolves #501.