### PR TITLE
Open content URLs in default browser

### DIFF
--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu } = require('electron');
+const { app, BrowserWindow, Menu, shell } = require('electron');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -58,6 +58,12 @@ function createWindow() {
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     mainWindow = null;
+  });
+
+  // Open any new windows in default browser (not electron)
+  mainWindow.webContents.on('new-window', (evt, newUrl) => {
+    evt.preventDefault();
+    shell.openExternal(newUrl);
   });
 }
 

--- a/src/containers/Interfaces/Information.js
+++ b/src/containers/Interfaces/Information.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
-import emoji from 'emoji-dictionary';
 import { Audio, Image, Video } from '../../components';
+import defaultMarkdownRenderers from '../../utils/markdownRenderers';
 
 const TAGS = [
   'break',
@@ -16,8 +16,6 @@ const TAGS = [
   'thematicBreak',
 ];
 
-const emojiSupport = text => text.replace(/:\w+:/gi, name => emoji.getUnicode(name));
-
 const renderItem = (item) => {
   switch (item.type) {
     case 'text':
@@ -25,7 +23,7 @@ const renderItem = (item) => {
         <ReactMarkdown
           source={item.content}
           allowedTypes={TAGS}
-          renderers={{ text: emojiSupport }}
+          renderers={defaultMarkdownRenderers}
         />
       );
     case 'image':

--- a/src/utils/__tests__/markdownRenderers.test.js
+++ b/src/utils/__tests__/markdownRenderers.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import { shallow } from 'enzyme';
+
+import markdownRenderers from '../markdownRenderers';
+
+describe('markdownRenderers', () => {
+  describe('externalLinkRenderer', () => {
+    it('renders links in with a _blank target', () => {
+      const a = shallow(markdownRenderers.link({ href: '', children: [] }));
+      expect(a.prop('target')).toEqual('_blank');
+    });
+
+    it('adds emoji support to text', () => {
+      const text = markdownRenderers.text(':100:');
+      expect(text).toEqual('💯');
+    });
+  });
+});

--- a/src/utils/markdownRenderers.js
+++ b/src/utils/markdownRenderers.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import emoji from 'emoji-dictionary';
+
+const emojiTextRenderer = text => text.replace(/:\w+:/gi, name => emoji.getUnicode(name));
+
+const externalLinkRenderer = ({ href, children }) => (
+  <a href={href} target="_blank">
+    {children}
+  </a>
+);
+
+externalLinkRenderer.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType(PropTypes.element, PropTypes.array).isRequired,
+};
+
+const defaultMarkdownRenderers = {
+  text: emojiTextRenderer,
+  link: externalLinkRenderer,
+};
+
+export default defaultMarkdownRenderers;
+
+export {
+  emojiTextRenderer,
+  externalLinkRenderer,
+};


### PR DESCRIPTION
This adds:

1. a markdown link renderer to open anchor URLs in new windows. ReactMarkdown's link transformer already sanitizes things like `javascript:` URLs.
2. `new-window` handling so that URLs are opened in the user's default browser instead of a new electron window

Fixes #432.