### PR TITLE
Ignore string-based skip filters

### DIFF
--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -53,13 +53,10 @@ const convertRules = index => createSelector(
   ),
 );
 
-const functionize = method => new Function('query', `${method}`)(query); // eslint-disable-line no-new-func
-
 const getFilterFunction = index => createSelector(
-  getFilter(index),
   getJoinType(index),
   convertRules(index),
-  (filter, join, rules) => ((typeof filter === 'string') ? functionize(filter) : join(rules)),
+  (join, rules) => join(rules),
 );
 
 const filterNetwork = index => createSelector(


### PR DESCRIPTION
This removes support for defining skip filters as function strings until we can implement safely and/or restrict the attack surface.

Based on discussion in #472, the need for custom functions in skip filters is 'less important'.  Until there's a safer implementation, users should use the object-based filter interface, as in the demo protocol example.

If approved, we should probably also update the wiki to remove mention of the 'functionized' string for now.