### PR TITLE
Fix PropType definition for markdown

### DIFF
--- a/src/utils/markdownRenderers.js
+++ b/src/utils/markdownRenderers.js
@@ -12,7 +12,7 @@ const externalLinkRenderer = ({ href, children }) => (
 
 externalLinkRenderer.propTypes = {
   href: PropTypes.string.isRequired,
-  children: PropTypes.oneOfType(PropTypes.element, PropTypes.array).isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]).isRequired,
 };
 
 const defaultMarkdownRenderers = {


### PR DESCRIPTION
Fixes a mistake I made in #504; `oneOfType` takes an array, not an arg list. I don't think this caused any issues at the user level, but was issuing console warnings/errors.