### PR TITLE
Fall back to address for server label

### DIFF
--- a/src/components/Setup/ServerSetup.js
+++ b/src/components/Setup/ServerSetup.js
@@ -9,7 +9,9 @@ import { ServerCard } from '../../components/Setup';
  */
 const ServerSetup = ({ children, server }) => (
   <div className="server-setup">
-    <ServerCard className="server-setup__card" data={server}>{server.host}</ServerCard>
+    <ServerCard className="server-setup__card" data={server}>
+      {server.host || server.addresses[0]}
+    </ServerCard>
     <React.Fragment>
       { children }
     </React.Fragment>
@@ -23,6 +25,7 @@ ServerSetup.defaultProps = {
 ServerSetup.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
   server: PropTypes.shape({
+    addresses: PropTypes.array.isRequired,
     apiUrl: PropTypes.string.isRequired,
     host: PropTypes.string,
   }).isRequired,

--- a/src/containers/Setup/ServerList.js
+++ b/src/containers/Setup/ServerList.js
@@ -98,7 +98,7 @@ class ServerList extends Component {
                 data={server}
                 selectServer={onSelect}
               >
-                {server.host}
+                {server.host || server.addresses[0]}
                 {isPaired && ' (paired)'}
               </ServerCard>
             );

--- a/src/containers/Setup/__tests__/ServerList.test.js
+++ b/src/containers/Setup/__tests__/ServerList.test.js
@@ -26,7 +26,7 @@ describe('ServerList component', () => {
   });
 
   it('displays servers', () => {
-    component.setState({ servers: [{ name: 'nc' }] });
+    component.setState({ servers: [{ name: 'nc', addresses: [] }] });
     expect(component.find('ServerCard')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
If a hostname is unavailable from mDNS resolution, display an IP address of the server on the Server Card instead.

Partial fix for #510 
