### PR TITLE
Work around Safari width issue

### DIFF
--- a/src/styles/components/_panels.scss
+++ b/src/styles/components/_panels.scss
@@ -14,6 +14,7 @@
   }
 
   &--minimise {
+    display: block; // Override flex to fix Safari layout issue (#407)
     margin-right: 0;
     width: 0;
     opacity: 0;


### PR DESCRIPTION
Safari gives width to the flex child with display:flex, even when
there's no visible content inside.

Changing to block fixes the issue; flex isn't needed prior to
minimizing, since there's only a single panel containing the last
removable node.

Fixes #407.

Note: the issue does seem to be with nested flex layouts. In [another branch](https://github.com/codaco/Network-Canvas/tree/demo/safari-fix), I removed the nesting, which fixed the issue as well. Making that work with BEM would take more effort, but if the workaround in this PR is too hacky, there's at least that alternative.