### PR TITLE
Position list-select to capture interaction

### DIFF
--- a/src/styles/components/_list-select.scss
+++ b/src/styles/components/_list-select.scss
@@ -8,6 +8,7 @@
   }
   max-height: inherit;
   overflow: hidden;
+  position: relative;
 
   &__sort {
     button {


### PR DESCRIPTION
Prompt text may overflow the top container; it should remain as
readable as possible but not capture click events from the main area.

Fixes #465

To test:
- optionally make a long prompt on the deom protocol's "NameGeneratorList"
- and/or view on a narrow screen

Tapping prompt text that overflows into filter controls on the list should no longer cause prompt to change.