### PR TITLE
Fix session menu errors

### DIFF
--- a/src/behaviours/modal.js
+++ b/src/behaviours/modal.js
@@ -28,6 +28,13 @@ function modal(WrappedComponent) {
       this.props.registerModal(this.props.name);
     }
 
+    componentDidUpdate(prevProps) {
+      if (prevProps.isRegistered && !this.props.isRegistered) {
+        // registration was removed (e.g., from app reset), but component is still mounted
+        this.props.registerModal(this.props.name);
+      }
+    }
+
     componentWillUnmount() {
       this.props.unregisterModal(this.props.name);
     }
@@ -55,6 +62,7 @@ function modal(WrappedComponent) {
   }
 
   Modal.propTypes = {
+    isRegistered: PropTypes.bool.isRequired,
     registerModal: PropTypes.func.isRequired,
     unregisterModal: PropTypes.func.isRequired,
     name: PropTypes.oneOfType([
@@ -79,6 +87,7 @@ function modal(WrappedComponent) {
     return function mapStateToProps(state, props) {
       return {
         show: modalIsOpen(state, props),
+        isRegistered: state.modals.some(m => m.name === props.name),
       };
     };
   }

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -9,7 +9,7 @@ import { actionCreators as mockActions } from '../ducks/modules/mock';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { actionCreators as modalActions } from '../ducks/modules/modals';
 import { getNetwork } from '../selectors/interface';
-import { sessionMenuIsOpen } from '../selectors/session';
+import { anySessionIsActive, sessionMenuIsOpen } from '../selectors/session';
 import { isCordova, isElectron } from '../utils/Environment';
 import { Menu } from '../components';
 import createGraphML from '../utils/ExportData';
@@ -177,20 +177,24 @@ class SessionMenu extends Component {
 
   render() {
     const {
-      customItems, hideButton, isOpen, toggleMenu, addMockNodes,
+      sessionExists, customItems, hideButton, isOpen, toggleMenu, addMockNodes,
     } = this.props;
 
     const { version } = this.state;
 
     const menuType = 'settings';
 
-
     const items = [
       { id: 'export', label: 'Download Data', icon: 'menu-download-data', onClick: this.onExport },
       { id: 'reset', label: 'Reset All Data', icon: 'menu-purge-data', onClick: this.onReset },
-      { id: 'mock-data', label: 'Add mock nodes', icon: 'menu-custom-interface', onClick: addMockNodes },
       ...customItems,
     ];
+
+    if (sessionExists) {
+      items.push(
+        { id: 'mock-data', label: 'Add mock nodes', icon: 'menu-custom-interface', onClick: addMockNodes },
+      );
+    }
 
     if (isElectron()) {
       items.push({
@@ -272,10 +276,12 @@ SessionMenu.propTypes = {
   isOpen: PropTypes.bool,
   openModal: PropTypes.func.isRequired,
   resetState: PropTypes.func.isRequired,
+  sessionExists: PropTypes.bool,
   toggleMenu: PropTypes.func.isRequired,
 };
 
 SessionMenu.defaultProps = {
+  sessionExists: false,
   hideButton: false,
   isOpen: false,
 };
@@ -285,6 +291,7 @@ function mapStateToProps(state) {
     customItems: state.menu.customMenuItems,
     isOpen: sessionMenuIsOpen(state),
     currentNetwork: getNetwork(state),
+    sessionExists: anySessionIsActive(state),
   };
 }
 

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -9,9 +9,19 @@ const mockStore = configureMockStore(middlewares);
 
 const mockState = {};
 
+const mockSessionId = 'session1';
+
+const mockStateWithSession = {
+  ...mockState,
+  [mockSessionId]: {
+    path: 'path/to/session',
+    network: { ego: {}, nodes: [], edges: [] },
+  },
+};
+
 const UIDPattern = /([A-Za-z0-9]+-[A-Za-z0-9]*)+/;
 
-describe('network reducer', () => {
+describe('sessions reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual(mockState);
   });
@@ -34,14 +44,7 @@ describe('network reducer', () => {
   });
 
   it('should handle UPDATE_SESSION', () => {
-    const newState = reducer(
-      {
-        ...mockState,
-        session1: {
-          path: 'path/to/session',
-          network: {},
-        },
-      },
+    const newState = reducer(mockStateWithSession,
       {
         type: actionTypes.UPDATE_SESSION,
         sessionId: 'session1',
@@ -49,7 +52,7 @@ describe('network reducer', () => {
       },
     );
 
-    expect(newState.session1).toEqual({
+    expect(newState.session1).toMatchObject({
       path: 'new/path/to/session',
       network: {},
       promptIndex: 0,
@@ -58,14 +61,7 @@ describe('network reducer', () => {
 
 
   it('should handle UPDATE_PROMPT', () => {
-    const newState = reducer(
-      {
-        ...mockState,
-        session1: {
-          path: 'path/to/session',
-          network: {},
-        },
-      },
+    const newState = reducer(mockStateWithSession,
       {
         type: actionTypes.UPDATE_PROMPT,
         sessionId: 'session1',
@@ -73,7 +69,7 @@ describe('network reducer', () => {
       },
     );
 
-    expect(newState.session1).toEqual({
+    expect(newState.session1).toMatchObject({
       path: 'path/to/session',
       network: {},
       promptIndex: 2,
@@ -81,14 +77,7 @@ describe('network reducer', () => {
   });
 
   it('should handle REMOVE_SESSION', () => {
-    const newState = reducer(
-      {
-        ...mockState,
-        session1: {
-          path: 'path/to/session',
-          network: {},
-        },
-      },
+    const newState = reducer(mockStateWithSession,
       {
         type: actionTypes.REMOVE_SESSION,
         sessionId: 'session1',
@@ -96,6 +85,27 @@ describe('network reducer', () => {
     );
 
     expect(newState.session1).toEqual(undefined);
+  });
+
+  it('should handle ADD_NODES', () => {
+    const newState = reducer(mockStateWithSession,
+      {
+        type: actionTypes.ADD_NODES,
+        sessionId: mockSessionId,
+        nodes: [{}],
+      },
+    );
+    expect(newState[mockSessionId].network.nodes).toHaveLength(1);
+  });
+
+  it('should throw if ADD_NODES called without an active session', () => {
+    expect(() => reducer(mockState,
+      {
+        type: actionTypes.ADD_NODES,
+        sessionId: 'a',
+        nodes: [{}],
+      },
+    )).toThrowError(/property.*undefined/);
   });
 });
 

--- a/src/ducks/modules/session.js
+++ b/src/ducks/modules/session.js
@@ -32,4 +32,5 @@ const actionTypes = {
 export {
   actionCreators,
   actionTypes,
+  initialState,
 };

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -1,8 +1,11 @@
 /* eslint-disable no-shadow */
 import { createSelector } from 'reselect';
 
+import { initialState } from '../ducks/modules/session';
+
 const protocol = state => state.protocol;
 
+export const anySessionIsActive = state => state.session && state.session !== initialState;
 export const sessionMenuIsOpen = state => state.menu.sessionMenuIsOpen;
 export const stageMenuIsOpen = state => state.menu.stageMenuIsOpen;
 export const stageSearchTerm = state => state.menu.stageSearchTerm;


### PR DESCRIPTION
Fixes #512 and fixes #513.

- The "add mock nodes" button is hidden if there's no session/network to add them to
- Test coverage added for this case in the sessions reducer; failure state is still a throw
- A modal re-registers if (during component update) it detects it was unregistered while mounted. I think this is OK; the only case should be app data reset.

See issues for testing steps.