### PR TITLE
Update sessions for new start screen

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -8,8 +8,10 @@ import cx from 'classnames';
 class Card extends PureComponent {
   render() {
     const {
+      compact,
       details,
       label,
+      multiselect,
       selected,
     } = this.props;
 
@@ -17,7 +19,7 @@ class Card extends PureComponent {
       (detail, index) => {
         const key = Object.keys(detail)[0];
         return (
-          <h5 key={index} className="card__attribute">
+          <h5 key={index} className={cx('card__attribute', { 'card__attribute--compact': compact })}>
             {key}: {detail[key]}
           </h5>
         );
@@ -31,17 +33,19 @@ class Card extends PureComponent {
 
     return (
       <div className={classes}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          x="0px"
-          y="0px"
-          viewBox="0 0 100 100"
-          className="card__indicator"
-        >
-          <path d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z" />
-          <polygon className="tick" points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6" />
-        </svg>
-
+        {
+          multiselect &&
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            x="0px"
+            y="0px"
+            viewBox="0 0 100 100"
+            className="card__indicator"
+          >
+            <path d="M100,50c0,27.6-22.4,50-50,50s-50-22.4-50-50S22.5,0,50,0S100,22.4,100,50z M50,8.3C27,8.3,8.4,27,8.4,50S27,91.6,50,91.6 S91.7,73,91.7,50S73,8.3,50,8.3z" />
+            <polygon className="tick" points="30.8,43 45.3,57.2 69,32.1 77.4,40.6 46.3,73.8 22.7,51.6" />
+          </svg>
+        }
         <div>
           <h1 className="card__label">
             { label }
@@ -56,14 +60,18 @@ class Card extends PureComponent {
 }
 
 Card.propTypes = {
+  compact: PropTypes.bool,
   details: PropTypes.array,
   label: PropTypes.string,
+  multiselect: PropTypes.bool,
   selected: PropTypes.bool,
 };
 
 Card.defaultProps = {
+  compact: false,
   details: [],
   label: '',
+  multiselect: true,
   selected: false,
 };
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -14,8 +14,10 @@ const EnhancedCard = selectable(Card);
 const CardList = (props) => {
   const {
     className,
+    compact,
     details,
     label,
+    multiselect,
     nodes,
     onToggleCard,
     selected,
@@ -31,6 +33,8 @@ const CardList = (props) => {
           <span key={uid(node)}>
             <EnhancedCard
               label={label(node)}
+              multiselect={multiselect}
+              compact={compact}
               selected={selected(node)}
               details={details(node)}
               onSelected={() => onToggleCard(node)}
@@ -44,8 +48,10 @@ const CardList = (props) => {
 
 CardList.propTypes = {
   className: PropTypes.string,
+  compact: PropTypes.bool,
   details: PropTypes.func,
   label: PropTypes.func,
+  multiselect: PropTypes.bool,
   nodes: PropTypes.array.isRequired,
   onToggleCard: PropTypes.func,
   selected: PropTypes.func,
@@ -54,8 +60,10 @@ CardList.propTypes = {
 
 CardList.defaultProps = {
   className: '',
+  compact: false,
   details: () => (''),
   label: () => (''),
+  multiselect: true,
   nodes: [],
   onToggleCard: () => {},
   selected: () => false,

--- a/src/components/__tests__/__snapshots__/Card-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Card-test.js.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Card
+    compact={false}
     details={
       Array [
         Object {
@@ -16,6 +17,7 @@ ShallowWrapper {
       ]
     }
     label="name"
+    multiselect={true}
     selected={true}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -478,6 +480,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Card
+    compact={false}
     details={
       Array [
         Object {
@@ -486,6 +489,7 @@ ShallowWrapper {
       ]
     }
     label="name"
+    multiselect={true}
     selected={false}
   />,
   Symbol(enzyme.__renderer__): Object {

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -43,8 +43,10 @@ ShallowWrapper {
     "props": Object {
       "children": <CardList
         className=""
+        compact={false}
         details={[Function]}
         label={[Function]}
+        multiselect={true}
         nodes={
           Array [
             Object {
@@ -78,8 +80,10 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "className": "",
+        "compact": false,
         "details": [Function],
         "label": [Function],
+        "multiselect": true,
         "nodes": Array [
           Object {
             "age": "22",
@@ -116,8 +120,10 @@ ShallowWrapper {
       "props": Object {
         "children": <CardList
           className=""
+          compact={false}
           details={[Function]}
           label={[Function]}
+          multiselect={true}
           nodes={
             Array [
               Object {
@@ -151,8 +157,10 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "className": "",
+          "compact": false,
           "details": [Function],
           "label": [Function],
+          "multiselect": true,
           "nodes": Array [
             Object {
               "age": "22",

--- a/src/containers/SessionMenu.js
+++ b/src/containers/SessionMenu.js
@@ -5,9 +5,11 @@ import { push } from 'react-router-redux';
 import { bindActionCreators } from 'redux';
 import { withHandlers, compose } from 'recompose';
 import xss from 'xss';
+
 import { actionCreators as mockActions } from '../ducks/modules/mock';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { actionCreators as modalActions } from '../ducks/modules/modals';
+import { actionCreators as sessionActions } from '../ducks/modules/session';
 import { getNetwork } from '../selectors/interface';
 import { sessionMenuIsOpen } from '../selectors/session';
 import { isCordova, isElectron } from '../utils/Environment';
@@ -186,6 +188,7 @@ class SessionMenu extends Component {
 
 
     const items = [
+      { id: 'main-menu', label: 'Return to Start', icon: 'menu-quit', onClick: this.props.endSession },
       { id: 'export', label: 'Download Data', icon: 'menu-download-data', onClick: this.onExport },
       { id: 'reset', label: 'Reset All Data', icon: 'menu-purge-data', onClick: this.onReset },
       { id: 'mock-data', label: 'Add mock nodes', icon: 'menu-custom-interface', onClick: addMockNodes },
@@ -268,6 +271,7 @@ SessionMenu.propTypes = {
   addMockNodes: PropTypes.func.isRequired,
   currentNetwork: PropTypes.object.isRequired,
   customItems: PropTypes.array.isRequired,
+  endSession: PropTypes.func.isRequired,
   hideButton: PropTypes.bool,
   isOpen: PropTypes.bool,
   openModal: PropTypes.func.isRequired,
@@ -291,6 +295,10 @@ function mapStateToProps(state) {
 const mapDispatchToProps = dispatch => ({
   generateNodes: bindActionCreators(mockActions.generateNodes, dispatch),
   openModal: bindActionCreators(modalActions.openModal, dispatch),
+  endSession: () => {
+    dispatch(sessionActions.endSession());
+    dispatch(push('/'));
+  },
   resetState: () => dispatch(push('/reset')),
   toggleMenu: bindActionCreators(menuActions.toggleSessionMenu, dispatch),
 });

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -2,6 +2,7 @@
 
 import { ActionsObservable } from 'redux-observable';
 import reducer, { actionCreators, epics } from '../protocol';
+import { actionTypes as SessionActionTypes } from '../session';
 import environments from '../../../utils/environments';
 import { getEnvironment } from '../../../utils/Environment';
 
@@ -105,6 +106,19 @@ describe('protocol module', () => {
         isLoaded: false,
         isLoading: true,
       });
+    });
+
+    it('should clear protocol state when session ends', () => {
+      const newState = reducer(
+        initialState,
+        actionCreators.setProtocol(
+          '/tmp/foo/mockPath.protocol',
+          { stages: [{ foo: 'bar' }] },
+        ),
+      );
+      expect(
+        reducer(newState, { type: SessionActionTypes.END_SESSION }),
+      ).toEqual(initialState);
     });
   });
 

--- a/src/ducks/modules/__tests__/session.test.js
+++ b/src/ducks/modules/__tests__/session.test.js
@@ -15,11 +15,20 @@ describe('session reducer', () => {
     const newState = reducer(initialState, { type: actionTypes.SET_SESSION, sessionId: 'a' });
     expect(newState).toEqual('a');
   });
+
+  it('should handle END_SESSION', () => {
+    const newState = reducer(initialState, { type: actionTypes.SET_SESSION, sessionId: 'a' });
+    expect(reducer(newState, { type: actionTypes.END_SESSION })).toEqual(initialState);
+  });
 });
 
 describe('session actionCreators', () => {
   it('should provide a method to set session', () => {
     const expectedAction = { type: actionTypes.SET_SESSION, sessionId: 'a' };
     expect(actionCreators.setSession('a')).toEqual(expectedAction);
+  });
+
+  it('should provide a method to end the session', () => {
+    expect(actionCreators.endSession()).toEqual({ type: actionTypes.END_SESSION });
   });
 });

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -24,7 +24,7 @@ describe('network reducer', () => {
       },
     );
 
-    expect(newState).toEqual({
+    expect(newState).toMatchObject({
       undefined: {
         path: 'path/to/session',
         network: { ego: {}, nodes: [], edges: [] },
@@ -49,7 +49,7 @@ describe('network reducer', () => {
       },
     );
 
-    expect(newState.session1).toEqual({
+    expect(newState.session1).toMatchObject({
       path: 'new/path/to/session',
       network: {},
       promptIndex: 0,
@@ -73,7 +73,7 @@ describe('network reducer', () => {
       },
     );
 
-    expect(newState.session1).toEqual({
+    expect(newState.session1).toMatchObject({
       path: 'path/to/session',
       network: {},
       promptIndex: 2,

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -1,6 +1,10 @@
 import { combineEpics } from 'redux-observable';
 import { Observable } from 'rxjs';
 import { loadProtocol, importProtocol, downloadProtocol, loadFactoryProtocol } from '../../utils/protocol';
+import { actionTypes as SessionActionTypes } from './session';
+
+const END_SESSION = SessionActionTypes.END_SESSION;
+const SET_SESSION = SessionActionTypes.SET_SESSION;
 
 const DOWNLOAD_PROTOCOL = 'PROTOCOL/DOWNLOAD_PROTOCOL';
 const DOWNLOAD_PROTOCOL_FAILED = Symbol('PROTOCOL/DOWNLOAD_PROTOCOL_FAILED');
@@ -10,7 +14,6 @@ const LOAD_PROTOCOL = 'LOAD_PROTOCOL';
 const LOAD_FACTORY_PROTOCOL = 'LOAD_FACTORY_PROTOCOL';
 const LOAD_PROTOCOL_FAILED = Symbol('LOAD_PROTOCOL_FAILED');
 const SET_PROTOCOL = 'SET_PROTOCOL';
-const SET_SESSION = 'SET_SESSION';
 
 const initialState = {
   isLoaded: false,
@@ -43,6 +46,8 @@ export default function reducer(state = initialState, action = {}) {
         };
       }
       return state;
+    case END_SESSION:
+      return initialState;
     case DOWNLOAD_PROTOCOL:
     case IMPORT_PROTOCOL:
     case LOAD_PROTOCOL:

--- a/src/ducks/modules/session.js
+++ b/src/ducks/modules/session.js
@@ -1,5 +1,6 @@
 const SET_SESSION = 'SET_SESSION';
 const ADD_SESSION = 'ADD_SESSION';
+const END_SESSION = 'END_SESSION';
 
 const initialState = 'CREATE_NEW';
 
@@ -8,6 +9,8 @@ export default function reducer(state = initialState, action = {}) {
     case SET_SESSION:
     case ADD_SESSION:
       return action.sessionId;
+    case END_SESSION:
+      return initialState;
     default:
       return state;
   }
@@ -21,11 +24,19 @@ function setSession(id, protocolType) {
   };
 }
 
+function endSession() {
+  return {
+    type: END_SESSION,
+  };
+}
+
 const actionCreators = {
+  endSession,
   setSession,
 };
 
 const actionTypes = {
+  END_SESSION,
   SET_SESSION,
 };
 

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -10,6 +10,11 @@ const REMOVE_SESSION = 'REMOVE_SESSION';
 
 const initialState = {};
 
+const withTimestamp = session => ({
+  ...session,
+  updatedAt: Date.now(),
+});
+
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case ADD_NODES:
@@ -23,36 +28,36 @@ export default function reducer(state = initialState, action = {}) {
     case UNSET_EGO:
       return {
         ...state,
-        [action.sessionId]: {
+        [action.sessionId]: withTimestamp({
           ...state[action.sessionId],
           network: network(state[action.sessionId].network, action),
-        },
+        }),
       };
     case ADD_SESSION:
       return {
         ...state,
-        [action.sessionId]: {
+        [action.sessionId]: withTimestamp({
           path: action.path,
           promptIndex: 0,
           network: network(state.network, action),
-        },
+        }),
       };
     case UPDATE_SESSION:
       return {
         ...state,
-        [action.sessionId]: {
+        [action.sessionId]: withTimestamp({
           ...state[action.sessionId],
           path: action.path,
           promptIndex: 0,
-        },
+        }),
       };
     case UPDATE_PROMPT:
       return {
         ...state,
-        [action.sessionId]: {
+        [action.sessionId]: withTimestamp({
           ...state[action.sessionId],
           promptIndex: action.promptIndex,
-        },
+        }),
       };
     case REMOVE_SESSION:
       return omit(state, [action.sessionId]);

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -38,5 +38,9 @@
 
   &__attribute {
     font-weight: 300;
+
+    &--compact {
+      margin-bottom: .5rem;
+    }
   }
 }

--- a/src/styles/containers/_setupScreen.scss
+++ b/src/styles/containers/_setupScreen.scss
@@ -30,10 +30,12 @@
   }
 
   &__main {
-    // note: preprocessor can't handle shorthand + calc + custom prop
-    flex-basis: calc(100vh - var(--setup-header-height));
-    flex-grow: 1;
-    flex-shrink: 1;
+    flex: 1 1 auto;
+    height: calc(100vh - var(--setup-header-height));
+
+    .scrollable {
+      height: 100%; // TODO: should this be on component?
+    }
   }
 
   &__start {


### PR DESCRIPTION
- Add "Return to start" item to sessions menu
- Add updatedAt timestamps to sessions; this seemed like a valuable data point to identify a session
- Other data matched from path
- Minor additions to CardList to accommodate display here (defaults are unchanged)
- Fix scrolling inside flex layout
- Card labels: I truncated the UUIDs for display; not sure if there's something better to display?
- Update UI submodule

![screen shot 2018-05-30 at 5 28 42 pm](https://user-images.githubusercontent.com/39674/40748634-0d1d9040-642f-11e8-874f-1c3a8ef8bc37.png)

![screen shot 2018-05-30 at 5 31 37 pm](https://user-images.githubusercontent.com/39674/40748722-5d475eca-642f-11e8-85b0-cd595f605a71.png)
