### PR TITLE
Empty sessions view & setting menu

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -28,6 +28,7 @@ class Card extends PureComponent {
 
     const classes = cx({
       card: true,
+      'card--multiselect': multiselect,
       'card--selected': selected,
     });
 

--- a/src/components/__tests__/__snapshots__/Card-test.js.snap
+++ b/src/components/__tests__/__snapshots__/Card-test.js.snap
@@ -74,7 +74,7 @@ ShallowWrapper {
           </div>
         </div>,
       ],
-      "className": "card card--selected",
+      "className": "card card--multiselect card--selected",
     },
     "ref": null,
     "rendered": Array [
@@ -293,7 +293,7 @@ ShallowWrapper {
             </div>
           </div>,
         ],
-        "className": "card card--selected",
+        "className": "card card--multiselect card--selected",
       },
       "ref": null,
       "rendered": Array [
@@ -539,7 +539,7 @@ ShallowWrapper {
           </div>
         </div>,
       ],
-      "className": "card",
+      "className": "card card--multiselect",
     },
     "ref": null,
     "rendered": Array [
@@ -717,7 +717,7 @@ ShallowWrapper {
             </div>
           </div>,
         ],
-        "className": "card",
+        "className": "card card--multiselect",
       },
       "ref": null,
       "rendered": Array [

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -5,9 +5,9 @@ import { compose } from 'redux';
 import { withRouter } from 'react-router';
 import cx from 'classnames';
 import '../styles/main.scss';
-import { sessionMenuIsOpen, stageMenuIsOpen } from '../selectors/session';
+import { settingsMenuIsOpen, stageMenuIsOpen } from '../selectors/session';
 import { isElectron, isWindows, isMacOS, isLinux } from '../utils/Environment';
-import { SessionMenu, StageMenu, LoadScreen } from '../containers';
+import { SettingsMenu, StageMenu, LoadScreen } from '../containers';
 import { ErrorMessage } from '../components';
 
 /**
@@ -21,11 +21,11 @@ const App = props => (
     'app--windows': isWindows(),
     'app--macos': isMacOS(),
     'app--linux': isLinux(),
-    'app--session': props.isSessionMenu,
+    'app--settings-open': props.isSettingsMenuOpen,
   })}
   >
     <div className="electron-titlebar" />
-    <SessionMenu hideButton={props.isMenuOpen} />
+    <SettingsMenu hideButton={props.isMenuOpen} />
     <StageMenu hideButton={props.isMenuOpen} />
     <div
       id="page-wrap"
@@ -45,19 +45,19 @@ const App = props => (
 App.propTypes = {
   children: PropTypes.any,
   isMenuOpen: PropTypes.bool,
-  isSessionMenu: PropTypes.bool,
+  isSettingsMenuOpen: PropTypes.bool,
 };
 
 App.defaultProps = {
   children: null,
   isMenuOpen: false,
-  isSessionMenu: false,
+  isSettingsMenuOpen: false,
 };
 
 function mapStateToProps(state) {
   return {
-    isMenuOpen: sessionMenuIsOpen(state) || stageMenuIsOpen(state),
-    isSessionMenu: sessionMenuIsOpen(state),
+    isMenuOpen: settingsMenuIsOpen(state) || stageMenuIsOpen(state),
+    isSettingsMenuOpen: settingsMenuIsOpen(state),
   };
 }
 

--- a/src/containers/SettingsMenu.js
+++ b/src/containers/SettingsMenu.js
@@ -11,7 +11,7 @@ import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { actionCreators as modalActions } from '../ducks/modules/modals';
 import { actionCreators as sessionActions } from '../ducks/modules/session';
 import { getNetwork } from '../selectors/interface';
-import { sessionMenuIsOpen } from '../selectors/session';
+import { settingsMenuIsOpen } from '../selectors/session';
 import { isCordova, isElectron } from '../utils/Environment';
 import { Menu } from '../components';
 import createGraphML from '../utils/ExportData';
@@ -67,7 +67,7 @@ function createMarkup(htmlString) {
   * Renders a Menu using stages to construct items in the menu
   * @extends Component
   */
-class SessionMenu extends Component {
+class SettingsMenu extends Component {
   constructor() {
     super();
 
@@ -225,7 +225,7 @@ class SessionMenu extends Component {
         icon={menuType}
         isOpen={isOpen}
         items={items}
-        title="Session"
+        title="Settings"
         toggleMenu={toggleMenu}
       >
         <div style={{ position: 'fixed', top: 0, right: 0, display: 'inline', padding: '10px', zIndex: 1000 }}>{ version }</div>
@@ -267,7 +267,7 @@ class SessionMenu extends Component {
   }
 }
 
-SessionMenu.propTypes = {
+SettingsMenu.propTypes = {
   addMockNodes: PropTypes.func.isRequired,
   currentNetwork: PropTypes.object.isRequired,
   customItems: PropTypes.array.isRequired,
@@ -279,7 +279,7 @@ SessionMenu.propTypes = {
   toggleMenu: PropTypes.func.isRequired,
 };
 
-SessionMenu.defaultProps = {
+SettingsMenu.defaultProps = {
   hideButton: false,
   isOpen: false,
 };
@@ -287,7 +287,7 @@ SessionMenu.defaultProps = {
 function mapStateToProps(state) {
   return {
     customItems: state.menu.customMenuItems,
-    isOpen: sessionMenuIsOpen(state),
+    isOpen: settingsMenuIsOpen(state),
     currentNetwork: getNetwork(state),
   };
 }
@@ -300,7 +300,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(push('/'));
   },
   resetState: () => dispatch(push('/reset')),
-  toggleMenu: bindActionCreators(menuActions.toggleSessionMenu, dispatch),
+  toggleMenu: bindActionCreators(menuActions.toggleSettingsMenu, dispatch),
 });
 
 export default compose(
@@ -310,4 +310,4 @@ export default compose(
       props.generateNodes(20);
     },
   }),
-)(SessionMenu);
+)(SettingsMenu);

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
-import { matchPath } from 'react-router-dom';
+import { Link, matchPath } from 'react-router-dom';
+import { isEmpty } from 'lodash';
 
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
 import { CardList } from '../../components';
@@ -26,6 +27,17 @@ const pathInfo = (sessionPath) => {
   return info;
 };
 
+const emptyView = (
+  <div className="session-list--empty">
+    <h1 className="session-list__header">No previous interviews found</h1>
+    <p>
+      To begin one, select a protocol from <Link to="/">Start new interview</Link>,
+      or import a protocol from Network Canvas Server by using the
+      button in the lower-right corner of this screen.
+    </p>
+  </div>
+);
+
 /**
   * Display stored sessions
   */
@@ -38,6 +50,10 @@ class SessionList extends Component {
 
   render() {
     const { sessions } = this.props;
+
+    if (isEmpty(sessions)) {
+      return emptyView;
+    }
 
     // Display most recent first
     const sessionList = Object.keys(sessions).map(key => ({ uid: key, value: sessions[key] }));

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -1,5 +1,5 @@
 export { default as App } from './App';
-export { default as SessionMenu } from './SessionMenu';
+export { default as SettingsMenu } from './SettingsMenu';
 export { default as StageMenu } from './StageMenu';
 export { default as OrdinalBins } from './OrdinalBins';
 export { default as Stage } from './Stage';

--- a/src/ducks/modules/__tests__/menu.test.js
+++ b/src/ducks/modules/__tests__/menu.test.js
@@ -4,7 +4,7 @@ import reducer, { actionCreators } from '../menu';
 
 const initialState = {
   customMenuItems: [],
-  sessionMenuIsOpen: false,
+  settingsMenuIsOpen: false,
   stageMenuIsOpen: false,
   stageSearchTerm: '',
 };
@@ -27,22 +27,22 @@ describe('menu reducer', () => {
   });
 
   it('should toggle the session menu', () => {
-    expect(reducer(initialState, actionCreators.toggleSessionMenu())).toEqual({
+    expect(reducer(initialState, actionCreators.toggleSettingsMenu())).toEqual({
       ...initialState,
-      sessionMenuIsOpen: true,
+      settingsMenuIsOpen: true,
     });
 
     expect(
       reducer(
         {
           ...initialState,
-          sessionMenuIsOpen: true,
+          settingsMenuIsOpen: true,
         },
-        actionCreators.toggleSessionMenu(),
+        actionCreators.toggleSettingsMenu(),
       ),
     ).toEqual({
       ...initialState,
-      sessionMenuIsOpen: false,
+      settingsMenuIsOpen: false,
     });
   });
 

--- a/src/ducks/modules/menu.js
+++ b/src/ducks/modules/menu.js
@@ -1,13 +1,13 @@
 const REGISTER_MENU_ITEM = 'REGISTER_MENU_ITEM';
 const RESET_STATE = 'RESET_STATE';
-const TOGGLE_SESSION_MENU = 'TOGGLE_SESSION_MENU';
+const TOGGLE_SETTINGS_MENU = 'TOGGLE_SETTINGS_MENU';
 const TOGGLE_STAGE_MENU = 'TOGGLE_STAGE_MENU';
 const UPDATE_STAGE_SEARCH = 'UPDATE_STAGE_SEARCH';
 const UNREGISTER_MENU_ITEM = 'UNREGISTER_MENU_ITEM';
 
 const initialState = {
   customMenuItems: [],
-  sessionMenuIsOpen: false,
+  settingsMenuIsOpen: false,
   stageMenuIsOpen: false,
   stageSearchTerm: '',
 };
@@ -20,10 +20,10 @@ export default function reducer(state = initialState, action = {}) {
         customMenuItems: state.customMenuItems.concat(action.menuItem),
       };
     }
-    case TOGGLE_SESSION_MENU: {
+    case TOGGLE_SETTINGS_MENU: {
       return {
         ...state,
-        sessionMenuIsOpen: !state.sessionMenuIsOpen,
+        settingsMenuIsOpen: !state.settingsMenuIsOpen,
       };
     }
     case TOGGLE_STAGE_MENU: {
@@ -62,9 +62,9 @@ function resetState() {
   };
 }
 
-function toggleSessionMenu() {
+function toggleSettingsMenu() {
   return {
-    type: TOGGLE_SESSION_MENU,
+    type: TOGGLE_SETTINGS_MENU,
   };
 }
 
@@ -91,7 +91,7 @@ function unregisterMenuItem(id) {
 const actionCreators = {
   registerMenuItem,
   resetState,
-  toggleSessionMenu,
+  toggleSettingsMenu,
   toggleStageMenu,
   updateStageSearch,
   unregisterMenuItem,
@@ -100,7 +100,7 @@ const actionCreators = {
 const actionTypes = {
   REGISTER_MENU_ITEM,
   RESET_STATE,
-  TOGGLE_SESSION_MENU,
+  TOGGLE_SETTINGS_MENU,
   TOGGLE_STAGE_MENU,
   UPDATE_STAGE_SEARCH,
   UNREGISTER_MENU_ITEM,

--- a/src/selectors/__tests__/session.test.js
+++ b/src/selectors/__tests__/session.test.js
@@ -11,7 +11,7 @@ const mockStage = {
 
 const mockState = {
   menu: {
-    sessionMenuIsOpen: false,
+    settingsMenuIsOpen: false,
     stageMenuIsOpen: true,
     stageSearchTerm: 'elc',
   },
@@ -25,7 +25,7 @@ const mockState = {
 describe('session selector', () => {
   describe('memoed selectors', () => {
     it('should get session menu is open', () => {
-      expect(Session.sessionMenuIsOpen(mockState)).toEqual(false);
+      expect(Session.settingsMenuIsOpen(mockState)).toEqual(false);
     });
 
     it('should get stage menu is open', () => {

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 const protocol = state => state.protocol;
 
-export const sessionMenuIsOpen = state => state.menu.sessionMenuIsOpen;
+export const settingsMenuIsOpen = state => state.menu.settingsMenuIsOpen;
 export const stageMenuIsOpen = state => state.menu.stageMenuIsOpen;
 export const stageSearchTerm = state => state.menu.stageSearchTerm;
 

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -2,9 +2,14 @@
   align-items: center;
   border: 2px solid palette('text-dark');
   border-radius: .5rem;
+  cursor: pointer;
   display: flex;
   margin: 1rem;
   padding: 1rem;
+
+  &--multiselect {
+    cursor: default;
+  }
 
   &__indicator {
     box-sizing: content-box;

--- a/src/styles/containers/_all.scss
+++ b/src/styles/containers/_all.scss
@@ -7,5 +7,6 @@
 @import 'protocol-import';
 @import 'protocol-list';
 @import 'server-list';
+@import 'session-list';
 @import 'sociogram-interface';
 

--- a/src/styles/containers/_app.scss
+++ b/src/styles/containers/_app.scss
@@ -25,7 +25,7 @@
     }
   }
 
-  &--session {
+  &--settings-open {
     background: palette('settings');
     transition: none;
   }

--- a/src/styles/containers/_session-list.scss
+++ b/src/styles/containers/_session-list.scss
@@ -1,0 +1,9 @@
+.session-list {
+  &--empty {
+    padding: spacing(huge) 0;
+
+    .session-list__header {
+      text-align: center;
+    }
+  }
+}

--- a/src/styles/containers/_setupScreen.scss
+++ b/src/styles/containers/_setupScreen.scss
@@ -1,4 +1,6 @@
 .setup {
+  $active-border-color: rgba(255, 255, 255, .5);
+  --active-border-color: $active-border-color;
   --setup-header-height: 30vh;
   display: flex;
   flex-direction: column;
@@ -36,7 +38,7 @@
     transition: border-color var(--animation-duration-fast) var(--animation-easing);
 
     &--active {
-      border-color: rgba(255, 255, 255, 0.5);
+      border-color: var(--active-border-color);
       font-weight: 600;
     }
   }

--- a/src/styles/containers/_setupScreen.scss
+++ b/src/styles/containers/_setupScreen.scss
@@ -14,8 +14,6 @@
     height: var(--setup-header-height);
     justify-content: center;
     text-align: center;
-
-
   }
 
   .header-content {
@@ -33,6 +31,7 @@
 
   &__link {
     border-bottom: 3px solid transparent;
+    cursor: pointer;
     margin: 0 1rem;
     padding-bottom: .5rem;
     transition: border-color var(--animation-duration-fast) var(--animation-easing);


### PR DESCRIPTION
- Rename session menu -> settings
- Add empty view for sessions (setup screen)
- Fix some small styling issues

<img width="894" alt="screen shot 2018-05-31 at 9 48 23 am" src="https://user-images.githubusercontent.com/39674/40785933-ca28b77c-64b7-11e8-9d7e-5260439cca44.png">
