### PR TITLE
Feature/new start screen url import

### DIFF
--- a/src/components/Setup/ServerProtocolList.js
+++ b/src/components/Setup/ServerProtocolList.js
@@ -10,7 +10,7 @@ const EmptyProtocolList = (
   </div>
 );
 
-const ProtocolCardList = ({ protocols, download }) => {
+const ServerProtocolList = ({ protocols, download }) => {
   let leftBorderClass = 'protocol-card-list__left-border';
   if (!protocols.length) {
     return EmptyProtocolList;
@@ -41,9 +41,9 @@ const ProtocolCardList = ({ protocols, download }) => {
   );
 };
 
-ProtocolCardList.propTypes = {
+ServerProtocolList.propTypes = {
   download: PropTypes.func.isRequired,
   protocols: PropTypes.array.isRequired,
 };
 
-export default ProtocolCardList;
+export default ServerProtocolList;

--- a/src/components/Setup/__tests__/ServerProtocolList.test.js
+++ b/src/components/Setup/__tests__/ServerProtocolList.test.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ProtocolCardList from '../ProtocolCardList';
+import ServerProtocolList from '../ServerProtocolList';
 
-describe('<ProtocolCardList>', () => {
+describe('<ServerProtocolList>', () => {
   let component;
   let mockProtocols;
   let downloadHandler;
@@ -12,7 +12,9 @@ describe('<ProtocolCardList>', () => {
   beforeEach(() => {
     downloadHandler = jest.fn();
     mockProtocols = [{ name: 'my-mock-protocol', version: '1.0.1' }];
-    component = shallow(<ProtocolCardList download={downloadHandler} protocols={mockProtocols} />);
+    component = shallow((
+      <ServerProtocolList download={downloadHandler} protocols={mockProtocols} />
+    ));
   });
 
   it('renders a card for each protocol', () => {

--- a/src/components/Setup/index.js
+++ b/src/components/Setup/index.js
@@ -1,6 +1,6 @@
 export { default as PairingCodeInput } from './PairingCodeInput';
 export { default as ProtocolCard } from './ProtocolCard';
-export { default as ProtocolCardList } from './ProtocolCardList';
+export { default as ServerProtocolList } from './ServerProtocolList';
 export { default as ServerCard } from './ServerCard';
 export { default as ServerAddressForm } from './ServerAddressForm';
 export { default as ServerPairingForm } from './ServerPairingForm';

--- a/src/containers/Setup/ProtocolImport.js
+++ b/src/containers/Setup/ProtocolImport.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Link } from 'react-router-dom';
 
+import ProtocolUrlForm from './ProtocolUrlForm';
 import ServerList from './ServerList';
 import ServerPairing from './ServerPairing';
 import ServerProtocols from './ServerProtocols';
@@ -46,7 +47,13 @@ class ProtocolImport extends PureComponent {
   }
 
   contentAreas() {
-    const { manualEntry, pairedServer, previousSelectedServer: prev, selectedServer } = this.state;
+    const {
+      manualEntry,
+      pairedServer,
+      previousSelectedServer: prev,
+      selectedServer,
+      showUrlForm,
+    } = this.state;
     let content;
     let buttonContent = null;
     if (pairedServer) {
@@ -68,6 +75,12 @@ class ProtocolImport extends PureComponent {
           cancel={() => this.setState({ manualEntry: false })}
         />
       );
+    } else if (showUrlForm) {
+      content = (
+        <ProtocolUrlForm
+          onCancel={() => this.setState({ showUrlForm: false })}
+        />
+      );
     } else {
       content = (
         <ServerList
@@ -76,12 +89,20 @@ class ProtocolImport extends PureComponent {
         />
       );
       buttonContent = (
-        <Button
-          size="small"
-          color="platinum"
-          content="Enter manually"
-          onClick={() => this.setState({ manualEntry: true })}
-        />
+        <React.Fragment>
+          <Button
+            size="small"
+            color="platinum"
+            content="Import from URL"
+            onClick={() => this.setState({ showUrlForm: true })}
+          />
+          <Button
+            size="small"
+            color="platinum"
+            content="Enter manually"
+            onClick={() => this.setState({ manualEntry: true })}
+          />
+        </React.Fragment>
       );
     }
     return { buttonContent, mainContent: content };

--- a/src/containers/Setup/ProtocolUrlForm.js
+++ b/src/containers/Setup/ProtocolUrlForm.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+
+import Form from '../Form';
+import { Button, Icon } from '../../ui/components';
+import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
+
+const formConfig = {
+  formName: 'setup',
+  fields: [
+    {
+      label: 'Protocol URL',
+      name: 'protocol_url',
+      component: 'TextInput',
+      placeholder: 'Protocol URL',
+      required: true,
+    },
+  ],
+};
+
+const initialValues = {
+  protocol_url: 'https://github.com/codaco/example-protocols/raw/master/packaged/demo.netcanvas',
+};
+
+class ProtocolUrlForm extends Component {
+  onClickImportRemoteProtocol = (fields) => {
+    if (fields) {
+      this.props.addSession();
+      this.props.downloadProtocol(fields.protocol_url);
+      this.props.handleProtocolUpdate();
+    }
+  }
+
+  render() {
+    const { onCancel } = this.props;
+    return (
+      <Form
+        className="protocol-url-form"
+        form={formConfig.formName}
+        onSubmit={this.onClickImportRemoteProtocol}
+        initialValues={initialValues}
+        controls={[
+          <a onClick={onCancel} key="cancel" className="protocol-url-form__cancel protocol-url-form__cancel--small">
+            <Icon name="close" className="protocol-url-form__cancel-button" />
+            Cancel
+          </a>,
+          <Button size="small" key="submit">Import remote protocol</Button>,
+        ]}
+        {...formConfig}
+      />
+    );
+  }
+}
+
+ProtocolUrlForm.propTypes = {
+  addSession: PropTypes.func.isRequired,
+  downloadProtocol: PropTypes.func.isRequired,
+  handleProtocolUpdate: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+function mapDispatchToProps(dispatch) {
+  return {
+    addSession: bindActionCreators(sessionsActions.addSession, dispatch),
+    downloadProtocol: bindActionCreators(protocolActions.downloadProtocol, dispatch),
+    handleProtocolUpdate: () => {
+      dispatch(push('/'));
+    },
+  };
+}
+
+export default connect(null, mapDispatchToProps)(ProtocolUrlForm);

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -6,7 +6,7 @@ import { Redirect } from 'react-router-dom';
 
 import ApiClient from '../../utils/ApiClient';
 import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
-import { ProtocolCardList, ServerSetup } from '../../components/Setup';
+import { ServerProtocolList, ServerSetup } from '../../components/Setup';
 
 class ServerProtocols extends Component {
   constructor(props) {
@@ -43,7 +43,7 @@ class ServerProtocols extends Component {
     return (
       <ServerSetup server={server}>
         {
-          protocols && <ProtocolCardList protocols={protocols} download={downloadProtocol} />
+          protocols && <ServerProtocolList protocols={protocols} download={downloadProtocol} />
         }
       </ServerSetup>
     );

--- a/src/containers/Setup/index.js
+++ b/src/containers/Setup/index.js
@@ -1,4 +1,5 @@
 export { default as ProtocolImport } from './ProtocolImport';
+export { default as ProtocolUrlForm } from './ProtocolUrlForm';
 export { default as ServerList } from './ServerList';
 export { default as SetupScreen } from './SetupScreen';
 export { default as ProtocolList } from './ProtocolList';

--- a/src/styles/containers/_all.scss
+++ b/src/styles/containers/_all.scss
@@ -6,6 +6,7 @@
 @import 'setupScreen';
 @import 'protocol-import';
 @import 'protocol-list';
+@import 'protocol-url-form';
 @import 'server-list';
 @import 'session-list';
 @import 'sociogram-interface';

--- a/src/styles/containers/_protocol-import.scss
+++ b/src/styles/containers/_protocol-import.scss
@@ -20,5 +20,9 @@
 
   &__buttons {
     text-align: right;
+
+    .button {
+      margin-left: spacing(small);
+    }
   }
 }

--- a/src/styles/containers/_protocol-url-form.scss
+++ b/src/styles/containers/_protocol-url-form.scss
@@ -1,0 +1,13 @@
+.protocol-url-form {
+  &__cancel {
+    @include text-button;
+  }
+
+  &__cancel-button {
+    &[name='close'] { // specificity needed to override NC-UI
+      height: .5rem;
+      margin-right: .5rem;
+      width: .5rem;
+    }
+  }
+}

--- a/src/styles/containers/_setupScreen.scss
+++ b/src/styles/containers/_setupScreen.scss
@@ -66,22 +66,6 @@
     justify-content: center;
   }
 
-  &__custom-protocol {
-    display: flex;
-    flex-direction: row;
-
-    .input__container {
-      flex-basis: 65%;
-      margin-right: 40px;
-    }
-
-    .form__button-container {
-      display: flex;
-      flex-direction: column;
-      flex-grow: 1;
-    }
-  }
-
   &__server-button {
     @include floating-action-button;
   }


### PR DESCRIPTION
This adds the same "Import from URL" form/functionality (that used to be on the Setup Screen) to the Protocol Import screen, with an additional redirect to handle the session start.

I've also renamed `ProtocolCardList` to `ServerProtocolList`; it's the component that displays protocols available on server, and seemed potentially confusing with the `ProtocolList` on the setup screen.

The top copy is still Server-specific, but I think the import form is straightforward enough that it shouldn't be confusing for now.

To test:
1. Click import button in bottom right of Setup
2. Click "Import from URL"
