### PR TITLE
Add delete button to session cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ See Cordova's [iOS docs](http://cordova.apache.org/docs/en/latest/guide/platform
 
 Starting the web app: If you have a running webpack dev server (started with `npm start`), you can run dev cordova builds on devices & emulators with live reloading.
 
-Starting a device or simulator: Run `npm run [android|ios]:dev`. This is a thin wrapper around `cordova run [android|ios]`; you can pass arguments to the cordova script with an extra pair of dashes. For example: `npm run android:dev -- --emulator`, or `npm run ios:dev -- --target="iPad-Pro, 11.3"`. Changes will be picked up from the dev server.
+Starting a device or simulator: Run `npm run [android|ios]:dev`. This is a thin wrapper around `cordova run [android|ios]`; you can pass arguments to the cordova script with an extra pair of dashes. For example: `npm run android:dev -- --emulator`, or `npm run ios:dev -- --target="iPad-Pro, 11.4"`. Changes will be picked up from the dev server.
 
-This assumes you have the relevant platform development tools installed. For a list of Apple simulator types ("iPad-Pro") and runtimes ("11.3"), try `xcrun simctl list`.
+This assumes you have the relevant platform development tools installed. For a list of Apple simulator types ("iPad-Pro") and runtimes ("11.4"), try `xcrun simctl list`.
 
 *Known issue & caveat*: this requires temporarily changing `config.xml` contents to build a development app; if everything goes well, the changes are cleaned up upon completion. However, a Cordova build error (for example) can leave config.xml in this 'development' state.
 

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -5,6 +5,7 @@ import cx from 'classnames';
 
 import { scrollable, selectable } from '../behaviours';
 import { Card } from '.';
+import { Icon } from '../ui/components';
 
 const EnhancedCard = selectable(Card);
 
@@ -19,6 +20,7 @@ const CardList = (props) => {
     label,
     multiselect,
     nodes,
+    onDeleteCard,
     onToggleCard,
     selected,
     uid,
@@ -30,7 +32,7 @@ const CardList = (props) => {
     <div className={classNames}>
       {
         nodes.map(node => (
-          <span key={uid(node)}>
+          <span className="card-list__content" key={uid(node)}>
             <EnhancedCard
               label={label(node)}
               multiselect={multiselect}
@@ -39,6 +41,10 @@ const CardList = (props) => {
               details={details(node)}
               onSelected={() => onToggleCard(node)}
             />
+            {
+              onDeleteCard &&
+              <Icon className="card-list__delete-button" name="close" onClick={() => onDeleteCard(node)} />
+            }
           </span>
         ))
       }
@@ -53,6 +59,7 @@ CardList.propTypes = {
   label: PropTypes.func,
   multiselect: PropTypes.bool,
   nodes: PropTypes.array.isRequired,
+  onDeleteCard: PropTypes.func,
   onToggleCard: PropTypes.func,
   selected: PropTypes.func,
   uid: PropTypes.func,
@@ -65,6 +72,7 @@ CardList.defaultProps = {
   label: () => (''),
   multiselect: true,
   nodes: [],
+  onDeleteCard: null,
   onToggleCard: () => {},
   selected: () => false,
   uid: node => node.uid,

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -66,6 +66,7 @@ ShallowWrapper {
             },
           ]
         }
+        onDeleteCard={null}
         onToggleCard={[Function]}
         scrollTop={[Function]}
         selected={[Function]}
@@ -101,6 +102,7 @@ ShallowWrapper {
             "uid": "c",
           },
         ],
+        "onDeleteCard": null,
         "onToggleCard": [Function],
         "scrollTop": [Function],
         "selected": [Function],
@@ -143,6 +145,7 @@ ShallowWrapper {
               },
             ]
           }
+          onDeleteCard={null}
           onToggleCard={[Function]}
           scrollTop={[Function]}
           selected={[Function]}
@@ -178,6 +181,7 @@ ShallowWrapper {
               "uid": "c",
             },
           ],
+          "onDeleteCard": null,
           "onToggleCard": [Function],
           "scrollTop": [Function],
           "selected": [Function],

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -7,6 +7,7 @@ import { Link, matchPath } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { CardList } from '../../components';
 
 const shortUid = uid => (uid || '').replace(/-.*/, '');
@@ -49,7 +50,7 @@ class SessionList extends Component {
   }
 
   render() {
-    const { sessions } = this.props;
+    const { removeSession, sessions } = this.props;
 
     if (isEmpty(sessions)) {
       return emptyView;
@@ -60,24 +61,32 @@ class SessionList extends Component {
     sessionList.sort((a, b) => b.value.updatedAt - a.value.updatedAt);
 
     return (
-      <CardList
-        compact
-        multiselect={false}
-        label={sessionInfo => shortUid(sessionInfo.uid)}
-        nodes={sessionList}
-        onToggleCard={this.onClickLoadSession}
-        details={(sessionInfo) => {
-          const info = pathInfo(sessionInfo.value.path);
-          return [
-            { Protocol: info.protocol },
-            { 'Last Changed': displayDate(sessionInfo.value.updatedAt) },
-            { Stage: oneBasedIndex(info.stageIndex) },
-            { Prompt: oneBasedIndex(sessionInfo.value.promptIndex) },
-            { 'Number of Nodes': sessionInfo.value.network.nodes.length },
-            { 'Number of Edges': sessionInfo.value.network.edges.length },
-          ];
-        }}
-      />
+      <React.Fragment>
+        <CardList
+          compact
+          multiselect={false}
+          onDeleteCard={(data) => {
+            // eslint-disable-next-line no-alert
+            if (confirm('Delete this interview?')) {
+              removeSession(data.uid);
+            }
+          }}
+          label={sessionInfo => shortUid(sessionInfo.uid)}
+          nodes={sessionList}
+          onToggleCard={this.onClickLoadSession}
+          details={(sessionInfo) => {
+            const info = pathInfo(sessionInfo.value.path);
+            return [
+              { Protocol: info.protocol },
+              { 'Last Changed': displayDate(sessionInfo.value.updatedAt) },
+              { Stage: oneBasedIndex(info.stageIndex) },
+              { Prompt: oneBasedIndex(sessionInfo.value.promptIndex) },
+              { 'Number of Nodes': sessionInfo.value.network.nodes.length },
+              { 'Number of Edges': sessionInfo.value.network.edges.length },
+            ];
+          }}
+        />
+      </React.Fragment>
     );
   }
 }
@@ -85,6 +94,7 @@ class SessionList extends Component {
 SessionList.propTypes = {
   getSessionPath: PropTypes.func.isRequired,
   loadSession: PropTypes.func.isRequired,
+  removeSession: PropTypes.func.isRequired,
   sessions: PropTypes.object.isRequired,
   setSession: PropTypes.func.isRequired,
 };
@@ -102,6 +112,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     loadSession: path => dispatch(push(path)),
+    removeSession: bindActionCreators(sessionsActions.removeSession, dispatch),
     setSession: bindActionCreators(sessionActions.setSession, dispatch),
   };
 }

--- a/src/styles/components/_card-list.scss
+++ b/src/styles/components/_card-list.scss
@@ -14,4 +14,25 @@
     display: flex;
     flex-direction: column;
   }
+
+  &__content {
+    position: relative;
+  }
+
+  &__delete-button {
+    --button-size: 1rem;
+    --button-padding: #{spacing(small)};
+    --card-margin: 1rem;
+
+    cursor: pointer;
+    position: absolute;
+    right: var(--card-margin);
+    top: var(--card-margin);
+    padding: var(--button-padding);
+
+    &[name='close'] {
+      height: calc(var(--button-size) + 2 * var(--button-padding));
+      width: calc(var(--button-size) + 2 * var(--button-padding));
+    }
+  }
 }


### PR DESCRIPTION
Provides a temporary interface ("x" button + confirm dialog) for removing interviews from the SessionList.

We expect to eventually re-work this interface to support dragging to a trash bin, so the "delete" functionality in Card doesn't need to stay, long-term.