### PR TITLE
Skip sort if no criteria given

### DIFF
--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -104,7 +104,10 @@ class NodeList extends Component {
 
     const styles = isHovering ? { backgroundColor: hoverColor } : {};
 
-    sorty(sortOrder, nodes);
+    if (sortOrder && sortOrder.length) {
+      // TODO: review; may need to use a stable sort
+      sorty(sortOrder, nodes);
+    }
 
     return (
       <TransitionGroup


### PR DESCRIPTION
Fixes common case of #524.

If underlying sort isn't stable, and this isn't just a library issue, then this will need further refinement to prevent edge cases from cropping up.