### PR TITLE
skip ordinal bin bucket sorting if no configuration object is provided

### DIFF
--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -78,7 +78,7 @@ class OrdinalBinBucket extends Component {
       isOver,
       willAccept,
       meta,
-      sortOptions,
+      sortOrder,
     } = this.props;
 
     const {
@@ -100,7 +100,10 @@ class OrdinalBinBucket extends Component {
 
     const styles = isHovering ? { backgroundColor } : {};
 
-    sorty(sortOptions, nodes);
+    if (sortOrder && sortOrder.length) {
+      // TODO: review; may need to use a stable sort
+      sorty(sortOrder, nodes);
+    }
 
     return (
       <TransitionGroup
@@ -146,7 +149,7 @@ OrdinalBinBucket.propTypes = {
   meta: PropTypes.object,
   listId: PropTypes.string.isRequired,
   scrollTop: PropTypes.func,
-  sortOptions: PropTypes.array,
+  sortOrder: PropTypes.array,
 };
 
 OrdinalBinBucket.defaultProps = {
@@ -162,7 +165,7 @@ OrdinalBinBucket.defaultProps = {
   isDragging: false,
   meta: {},
   scrollTop: () => {},
-  sortOptions: [],
+  sortOrder: [],
 };
 
 export default compose(

--- a/src/containers/Interfaces/OrdinalBin.js
+++ b/src/containers/Interfaces/OrdinalBin.js
@@ -45,7 +45,7 @@ class OrdinalBin extends Component {
             id={'NODE_BUCKET'}
             itemType="EXISTING_NODE"
             onDrop={this.onDrop}
-            sortOOrder={prompt.bucketSortOrder}
+            sortOrder={prompt.bucketSortOrder}
           />
         </div>
         <div className="ordinal-bin-interface__bins">

--- a/src/containers/Interfaces/OrdinalBin.js
+++ b/src/containers/Interfaces/OrdinalBin.js
@@ -45,7 +45,7 @@ class OrdinalBin extends Component {
             id={'NODE_BUCKET'}
             itemType="EXISTING_NODE"
             onDrop={this.onDrop}
-            sortOptions={prompt.bucketSortOrder}
+            sortOOrder={prompt.bucketSortOrder}
           />
         </div>
         <div className="ordinal-bin-interface__bins">


### PR DESCRIPTION
Mirrors the fix provided here: #525 

This component should perhaps be refactored as a HOC of node list, but for now this will suffice. 