### PR TITLE
Sort nodes in list before render

### DIFF
--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -42,10 +42,16 @@ class NodeList extends Component {
       return;
     }
 
+    const newSortedNodes = newProps.nodes;
+
+    if (newProps.sortOrder && newProps.sortOrder.length) {
+      sorty(newProps.sortOrder, newSortedNodes);
+    }
+
     // if we provided the same id, then just update normally
     if (newProps.listId === this.props.listId) {
       this.setState({ exit: false }, () => {
-        this.setState({ nodes: newProps.nodes, stagger: false });
+        this.setState({ nodes: newSortedNodes, stagger: false });
       });
       return;
     }
@@ -59,7 +65,7 @@ class NodeList extends Component {
         () => {
           this.refreshTimer = setTimeout(
             () => this.setState({
-              nodes: newProps.nodes,
+              nodes: newSortedNodes,
               stagger: true,
             }),
             getCSSVariableAsNumber('--animation-duration-slow-ms'),
@@ -84,7 +90,6 @@ class NodeList extends Component {
       willAccept,
       meta,
       hoverColor,
-      sortOrder,
     } = this.props;
 
     const {
@@ -103,11 +108,6 @@ class NodeList extends Component {
     );
 
     const styles = isHovering ? { backgroundColor: hoverColor } : {};
-
-    if (sortOrder && sortOrder.length) {
-      // TODO: review; may need to use a stable sort
-      sorty(sortOrder, nodes);
-    }
 
     return (
       <TransitionGroup

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -40,10 +40,16 @@ class OrdinalBinBucket extends Component {
       return;
     }
 
+    const newSortedNodes = newProps.nodes;
+
+    if (newProps.sortOrder && newProps.sortOrder.length) {
+      sorty(newProps.sortOrder, newSortedNodes);
+    }
+
     // if we provided the same id, then just update normally
     if (newProps.listId === this.props.listId) {
       this.setState({ exit: false }, () => {
-        this.setState({ nodes: newProps.nodes, stagger: false });
+        this.setState({ nodes: newSortedNodes, stagger: false });
       });
       return;
     }
@@ -58,7 +64,7 @@ class OrdinalBinBucket extends Component {
           if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
           this.refreshTimer = setTimeout(
             () => this.setState({
-              nodes: newProps.nodes,
+              nodes: newSortedNodes,
               stagger: true,
             }),
             getCSSVariableAsNumber('--animation-duration-slow-ms'),
@@ -78,7 +84,6 @@ class OrdinalBinBucket extends Component {
       isOver,
       willAccept,
       meta,
-      sortOptions,
     } = this.props;
 
     const {
@@ -99,8 +104,6 @@ class OrdinalBinBucket extends Component {
     const backgroundColor = getCSSVariableAsString('--light-background');
 
     const styles = isHovering ? { backgroundColor } : {};
-
-    sorty(sortOptions, nodes);
 
     return (
       <TransitionGroup
@@ -146,7 +149,7 @@ OrdinalBinBucket.propTypes = {
   meta: PropTypes.object,
   listId: PropTypes.string.isRequired,
   scrollTop: PropTypes.func,
-  sortOptions: PropTypes.array,
+  sortOrder: PropTypes.array,
 };
 
 OrdinalBinBucket.defaultProps = {
@@ -162,7 +165,7 @@ OrdinalBinBucket.defaultProps = {
   isDragging: false,
   meta: {},
   scrollTop: () => {},
-  sortOptions: [],
+  sortOrder: [],
 };
 
 export default compose(

--- a/src/containers/Interfaces/OrdinalBin.js
+++ b/src/containers/Interfaces/OrdinalBin.js
@@ -45,7 +45,7 @@ class OrdinalBin extends Component {
             id={'NODE_BUCKET'}
             itemType="EXISTING_NODE"
             onDrop={this.onDrop}
-            sortOptions={prompt.bucketSortOrder}
+            sortOrder={prompt.bucketSortOrder}
           />
         </div>
         <div className="ordinal-bin-interface__bins">


### PR DESCRIPTION
This change to NodeList sorts the nodes every time the props change, rather than on each render pass. I think this still covers the intended use case, and arguably sort no longer needs to be stable.

If this seems OK, we could do something similar with the ordinal bin (see #527).

Follow-up to #525. Fixes #524.