### PR TITLE
Fix android MDNS discovery after remount

### DIFF
--- a/src/utils/serverDiscoverer.js
+++ b/src/utils/serverDiscoverer.js
@@ -22,7 +22,8 @@ class ServerDiscoverer {
     }
 
     if (isCordova() && this.zeroconf) {
-      this.zeroconf.unwatch('_network-canvas._tcp.', 'local.');
+      // 'zeroconf.unwatch' is insufficient for cleanup
+      this.zeroconf.close();
     }
   }
 


### PR DESCRIPTION
Replaces zeroconf `unwatch` with `close`. This does additional teardown in JmDNS, and seems to fix service discovery after the component remounts. I did a little testing with reInit(), but I think this suffices, and is lighter touch.

I tested on a Nexus 5x phone; needs testing on at least a real tablet or two.

Edit: also tested iOS (iPad).

Assuming my original report (failed discovery on initial mount) is limited to emulators, this fixes #482.