### PR TITLE
Decode URI component for download urls for local paths

### DIFF
--- a/src/__mocks__/request-promise-native.js
+++ b/src/__mocks__/request-promise-native.js
@@ -1,0 +1,3 @@
+const request = ({ uri }) => Promise.resolve(`DUMMY DATA//${uri}`);
+
+module.exports = request;

--- a/src/utils/__mocks__/filesystem.js
+++ b/src/utils/__mocks__/filesystem.js
@@ -2,12 +2,14 @@
 /* eslint-env jest */
 
 const readFile = jest.fn(console.log);
+const writeFile = jest.fn(() => Promise.resolve());
 const ensurePathExists = jest.fn(console.log);
 const writeStream = jest.fn(console.log);
 const userDataPath = jest.fn(() => 'tmp/mock/user/path');
 
 export {
   readFile,
+  writeFile,
   ensurePathExists,
   writeStream,
   userDataPath,

--- a/src/utils/protocol/__tests__/downloadProtocol.test.js
+++ b/src/utils/protocol/__tests__/downloadProtocol.test.js
@@ -15,9 +15,11 @@ describe('downloadProtocol', () => {
       getEnvironment.mockReturnValue(environments.ELECTRON);
     });
 
-    it('returns a correct local path', () =>
-      expect(downloadProtocol('https://networkcanvas.com//foo bar.protocol')).resolves
-        .toEqual(`${electron.app.getPath()}/foo bar.protocol`),
-    );
+    it('returns a correct local path', () => {
+      const localPath = new RegExp(`${electron.app.getPath()}/[a-zA-Z0-9-]+$`);
+
+      return expect(downloadProtocol('https://networkcanvas.com//foo bar.protocol')).resolves
+        .toMatch(localPath);
+    });
   });
 });

--- a/src/utils/protocol/__tests__/downloadProtocol.test.js
+++ b/src/utils/protocol/__tests__/downloadProtocol.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+import electron from 'electron';
+import environments from '../../environments';
+import { getEnvironment } from '../../Environment';
+import downloadProtocol from '../downloadProtocol';
+
+jest.mock('electron');
+jest.mock('request-promise-native');
+jest.mock('../../filesystem');
+
+describe('downloadProtocol', () => {
+  describe('Electron', () => {
+    beforeAll(() => {
+      getEnvironment.mockReturnValue(environments.ELECTRON);
+    });
+
+    it('returns a correct local path', () => {
+      return expect(downloadProtocol('https://networkcanvas.com//foo bar.protocol')).resolves
+        .toEqual(`${electron.app.getPath()}/foo bar.protocol`);
+    });
+  });
+});

--- a/src/utils/protocol/__tests__/downloadProtocol.test.js
+++ b/src/utils/protocol/__tests__/downloadProtocol.test.js
@@ -15,9 +15,9 @@ describe('downloadProtocol', () => {
       getEnvironment.mockReturnValue(environments.ELECTRON);
     });
 
-    it('returns a correct local path', () => {
-      return expect(downloadProtocol('https://networkcanvas.com//foo bar.protocol')).resolves
-        .toEqual(`${electron.app.getPath()}/foo bar.protocol`);
-    });
+    it('returns a correct local path', () =>
+      expect(downloadProtocol('https://networkcanvas.com//foo bar.protocol')).resolves
+        .toEqual(`${electron.app.getPath()}/foo bar.protocol`),
+    );
   });
 });

--- a/src/utils/protocol/__tests__/loadProtocol.test.js
+++ b/src/utils/protocol/__tests__/loadProtocol.test.js
@@ -19,7 +19,7 @@ describe('loadProtocol', () => {
     it('returns the parsed protocol object', () => {
       expect(loadProtocol('bazz.protocol')).resolves.toEqual({
         foo: 'bar',
-      });
+      }); // TODO: This should return in order to work...
 
       expect(protocolPath.mock.calls[0]).toEqual(['bazz.protocol', 'protocol.json']);
       expect(readFile.mock.calls[0]).toEqual(['tmp/mock/path/protocols/bazz.protocol/protocol.json']);

--- a/src/utils/protocol/downloadProtocol.js
+++ b/src/utils/protocol/downloadProtocol.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 /* global window, FileTransfer */
-import { isEmpty } from 'lodash';
+import uuid from 'uuid/v4';
 import environments from '../environments';
 import inEnvironment from '../Environment';
 import { writeFile } from '../filesystem';
@@ -15,11 +15,7 @@ const getURL = uri =>
     }
   });
 
-const getProtocolNameFromUrl = (url) => {
-  const protocolName = url.pathname.split('/').pop();
-  if (isEmpty(protocolName)) { throw Error('Protocol name cannot be empty'); }
-  return decodeURIComponent(protocolName);
-};
+const getProtocolName = () => uuid(); // generate a filename
 
 const urlError = friendlyErrorMessage("The location you gave us doesn't seem to be valid. Check the location, and try again.");
 const networkError = friendlyErrorMessage("We weren't able to fetch your protocol at this time. Your device may not have an active network connection - connect to a network, and try again.");
@@ -36,7 +32,7 @@ const downloadProtocol = inEnvironment((environment) => {
 
       return getURL(uri)
         .then((url) => {
-          const destination = path.join(tempPath, getProtocolNameFromUrl(url));
+          const destination = path.join(tempPath, getProtocolName());
 
           return request({ method: 'GET', encoding: null, uri: url.href })
             .catch(networkError)
@@ -53,7 +49,7 @@ const downloadProtocol = inEnvironment((environment) => {
       getURL(uri)
         .then(url => [
           url.href,
-          `cdvfile://localhost/temporary/${getProtocolNameFromUrl(url)}`,
+          `cdvfile://localhost/temporary/${getProtocolName()}`,
         ])
         .catch(urlError)
         .then(([url, destination]) =>

--- a/src/utils/protocol/downloadProtocol.js
+++ b/src/utils/protocol/downloadProtocol.js
@@ -18,7 +18,7 @@ const getURL = uri =>
 const getProtocolNameFromUrl = (url) => {
   const protocolName = url.pathname.split('/').pop();
   if (isEmpty(protocolName)) { throw Error('Protocol name cannot be empty'); }
-  return protocolName;
+  return decodeURIComponent(protocolName);
 };
 
 const urlError = friendlyErrorMessage("The location you gave us doesn't seem to be valid. Check the location, and try again.");


### PR DESCRIPTION
Tiny fix to ensure downloaded urls generate URI decoded paths.

Is marked as WIP because this needs to be tested on devices,
which is waiting on PR https://github.com/codaco/Network-Canvas/pull/533