### PR TITLE
Render server instance name, not hostname

### DIFF
--- a/src/components/Setup/ServerCard.js
+++ b/src/components/Setup/ServerCard.js
@@ -6,35 +6,50 @@ import logo from '../../images/Srv-Flat.svg';
 
 const noClick = () => {};
 
-const ServerCard = ({ children, data, selectServer, isPaired, className, ...props }) => {
+/**
+ * Renders a server icon & label. The label defaults to server name, falling back
+ * to its first address (both provided via the `data` prop). If `secondaryLabel`
+ * is provided, then it will be appended.
+ */
+const ServerCard = ({ data, secondaryLabel, selectServer, isPaired, className, ...props }) => {
   const cssClass = classNames(
     'server-card',
     { 'server-card--paired': isPaired },
     { 'server-card--clickable': selectServer !== noClick },
     className,
   );
+  const { name, addresses = [] } = data;
+  let label = name || addresses[0];
+  if (secondaryLabel) {
+    label += ` ${secondaryLabel}`;
+  }
   return (
     <div className={cssClass} onClick={() => selectServer(data)} {...props} >
-      <img src={logo} className="server-card__icon" alt={children} />
-      <h6 className="server-card__label">{children}</h6>
+      <img src={logo} className="server-card__icon" alt="Available Server" />
+      <h6 className="server-card__label">
+        {label}
+      </h6>
     </div>
   );
 };
 
 ServerCard.propTypes = {
-  data: PropTypes.object,
-  children: PropTypes.any,
+  data: PropTypes.shape({
+    name: PropTypes.string,
+    addresses: PropTypes.array,
+  }),
   className: PropTypes.string,
   isPaired: PropTypes.bool,
   selectServer: PropTypes.func,
+  secondaryLabel: PropTypes.string,
 };
 
 ServerCard.defaultProps = {
   data: {},
-  children: null,
   className: '',
   isPaired: false,
   selectServer: noClick,
+  secondaryLabel: null,
 };
 
 export default ServerCard;

--- a/src/components/Setup/ServerSetup.js
+++ b/src/components/Setup/ServerSetup.js
@@ -9,9 +9,7 @@ import { ServerCard } from '../../components/Setup';
  */
 const ServerSetup = ({ children, server }) => (
   <div className="server-setup">
-    <ServerCard className="server-setup__card" data={server}>
-      {server.host || server.addresses[0]}
-    </ServerCard>
+    <ServerCard className="server-setup__card" data={server} />
     <React.Fragment>
       { children }
     </React.Fragment>

--- a/src/components/Setup/__tests__/ServerCard.test.js
+++ b/src/components/Setup/__tests__/ServerCard.test.js
@@ -5,12 +5,26 @@ import { shallow } from 'enzyme';
 import ServerCard from '../ServerCard';
 
 describe('<ServerCard>', () => {
+  let serverData;
   let component;
   let selectHandler;
 
   beforeEach(() => {
     selectHandler = jest.fn();
-    component = shallow(<ServerCard selectServer={selectHandler} />);
+    serverData = {
+      name: 'MyInstance',
+      addresses: ['10.1.x.x'],
+    };
+    component = shallow(<ServerCard data={serverData} selectServer={selectHandler} />);
+  });
+
+  it('renders the server name', () => {
+    expect(component.text()).toMatch(serverData.name);
+  });
+
+  it('renders address if name unavailable', () => {
+    component = shallow(<ServerCard data={{ ...serverData, name: null }} />);
+    expect(component.text()).toMatch(serverData.addresses[0]);
   });
 
   it('allows selection', () => {

--- a/src/containers/Setup/ServerList.js
+++ b/src/containers/Setup/ServerList.js
@@ -97,10 +97,8 @@ class ServerList extends Component {
                 key={server.apiUrl}
                 data={server}
                 selectServer={onSelect}
-              >
-                {server.host || server.addresses[0]}
-                {isPaired && ' (paired)'}
-              </ServerCard>
+                secondaryLabel={isPaired && '(paired)'}
+              />
             );
           })
         }


### PR DESCRIPTION
- Use instance from MDNS advert, as hostname isn't always available
- Refactor: ServerCard knows how to render the primary server label
- Use secondaryLabel (string) instead of children

To get the updated advertisement from Server, see the `fix/instance-name` branch there (https://github.com/codaco/Server/pull/103).

Fixes #510