### PR TITLE
Update Network Canvas to handle new orderBy syntax in protocols

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -947,12 +947,10 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": [
-              {
-                "property": "name",
-                "direction": "asc"
-              }
-            ],
+            "sortOrder": {
+              "property": "name",
+              "direction": "asc"
+            },
             "sortableProperties": [
               {
                 "label": "Pupil Name",
@@ -991,12 +989,10 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": [
-              {
-                "property": "nickname",
-                "direction": "desc"
-              }
-            ],
+            "sortOrder": {
+              "property": "nickname",
+              "direction": "desc"
+            },
             "sortableProperties": [
               {
                 "label": "Nickname",

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -876,19 +876,18 @@
           "//": "Ordinal variables have valid options defined in variable registry.",
           "bucketSortOrder": [
             {
-              "name": "nickname",
-              "dir": "desc"
+              "variable": "nickname",
+              "direction": "desc"
             }
           ],
           "binSortOrder": [
             {
-              "name": "nickname",
-              "dir": "desc"
+              "variable": "nickname",
+              "direction": "desc"
             },
             {
-              "name": "age",
-              "dir": "desc",
-              "type": "number"
+              "variable": "age",
+              "direction": "desc"
             }
           ]
         },
@@ -948,9 +947,12 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": {
-              "name": "ASC"
-            },
+            "sortOrder": [
+              {
+                "variable": "name",
+                "direction": "asc"
+              }
+            ],
             "sortableProperties": [
               {
                 "label": "Pupil Name",
@@ -989,9 +991,12 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": {
-              "nickname": "DESC"
-            },
+            "sortOrder": [
+              {
+                "variable": "nickname",
+                "direction": "desc"
+              }
+            ],
             "sortableProperties": [
               {
                 "label": "Nickname",
@@ -1051,9 +1056,12 @@
           },
           "disable":
             "return operator.or([\nselect.edge({ type: 'friend' }),\nselect.alter({ type: 'person', attribute: 'age', operator: 'LESS_THAN', value: 29 })]);",
-          "nodeBinSortOrder": {
-            "nickname": "DESC"
-          },
+          "nodeBinSortOrder": [
+            {
+              "variable": "nickname",
+              "order": "desc"
+            }
+          ],
           "background": {
             "image": "rubberduck.jpg",
             "concentricCircles": 4,

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -947,10 +947,10 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": {
+            "sortOrder": [{
               "property": "name",
               "direction": "asc"
-            },
+            }],
             "sortableProperties": [
               {
                 "label": "Pupil Name",
@@ -989,10 +989,10 @@
             ]
           },
           "sortOptions": {
-            "sortOrder": {
+            "sortOrder": [{
               "property": "nickname",
               "direction": "desc"
-            },
+            }],
             "sortableProperties": [
               {
                 "label": "Nickname",

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -876,17 +876,17 @@
           "//": "Ordinal variables have valid options defined in variable registry.",
           "bucketSortOrder": [
             {
-              "variable": "nickname",
+              "property": "nickname",
               "direction": "desc"
             }
           ],
           "binSortOrder": [
             {
-              "variable": "nickname",
+              "property": "nickname",
               "direction": "desc"
             },
             {
-              "variable": "age",
+              "property": "age",
               "direction": "desc"
             }
           ]
@@ -949,7 +949,7 @@
           "sortOptions": {
             "sortOrder": [
               {
-                "variable": "name",
+                "property": "name",
                 "direction": "asc"
               }
             ],
@@ -993,7 +993,7 @@
           "sortOptions": {
             "sortOrder": [
               {
-                "variable": "nickname",
+                "property": "nickname",
                 "direction": "desc"
               }
             ],
@@ -1058,8 +1058,8 @@
             "return operator.or([\nselect.edge({ type: 'friend' }),\nselect.alter({ type: 'person', attribute: 'age', operator: 'LESS_THAN', value: 29 })]);",
           "nodeBinSortOrder": [
             {
-              "variable": "nickname",
-              "order": "desc"
+              "property": "nickname",
+              "direction": "desc"
             }
           ],
           "background": {

--- a/public/protocols/education.netcanvas/protocol.json
+++ b/public/protocols/education.netcanvas/protocol.json
@@ -480,9 +480,12 @@
             "layoutVariable": "closenessLayout",
             "allowPositioning": true
           },
-          "nodeBinSortOrder": {
-            "*": "ASC"
-          }
+          "nodeBinSortOrder": [
+            {
+              "property": "*",
+              "direction": "asc"
+            }
+          ]
         }
       ]
     },
@@ -514,9 +517,12 @@
             "layoutVariable": "closenessLayout",
             "allowPositioning": true
           },
-          "nodeBinSortOrder": {
-            "*": "ASC"
-          },
+          "nodeBinSortOrder": [
+            {
+              "property": "*",
+              "direction": "asc"
+            }
+          ],
           "edges": {
             "display": ["friends"],
             "create": "friends"
@@ -533,9 +539,12 @@
             "layoutVariable": "closenessLayout",
             "allowPositioning": true
           },
-          "nodeBinSortOrder": {
-            "*": "ASC"
-          },
+          "nodeBinSortOrder": [
+            {
+              "property": "*",
+              "direction": "asc"
+            }
+          ],
           "edges": {
             "display": ["friends"]
           },
@@ -556,9 +565,12 @@
             "layoutVariable": "closenessLayout",
             "allowPositioning": true
           },
-          "nodeBinSortOrder": {
-            "*": "ASC"
-          },
+          "nodeBinSortOrder": [
+            {
+              "property": "*",
+              "direction": "asc"
+            }
+          ],
           "edges": {
             "display": ["friends"]
           },

--- a/src/components/ListSelect.js
+++ b/src/components/ListSelect.js
@@ -9,7 +9,7 @@ class ListSelect extends Component {
     super(props);
 
     this.state = {
-      ascending: this.props.initialSortDirection === 'ASC',
+      ascending: this.props.initialSortDirection === 'asc',
       filterValue: '',
       property: this.props.initialSortOrder || this.props.labelKey,
     };
@@ -23,7 +23,7 @@ class ListSelect extends Component {
     }
     if (nextProps.initialSortDirection !== this.props.initialSortDirection) {
       this.setState({
-        ascending: nextProps.initialSortDirection === 'ASC',
+        ascending: nextProps.initialSortDirection === 'asc',
       });
     }
   }

--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -25,8 +25,11 @@ class NodeList extends Component {
   constructor(props) {
     super(props);
 
+    const sorter = sortOrder(props.sortOrder);
+    const sortedNodes = sorter(props.nodes);
+
     this.state = {
-      nodes: props.nodes,
+      nodes: sortedNodes,
       stagger: true,
       exit: true,
     };

--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import { find, get, isEqual } from 'lodash';
-import sorty from '@zippytech/sorty';
 import cx from 'classnames';
 import { TransitionGroup } from 'react-transition-group';
 import { Node } from '../components';
@@ -15,6 +14,7 @@ import {
   MonitorDropTarget,
   MonitorDragSource,
 } from '../behaviours/DragAndDrop';
+import sortOrder from '../utils/sortOrder';
 
 const EnhancedNode = DragSource(selectable(Node));
 
@@ -42,16 +42,13 @@ class NodeList extends Component {
       return;
     }
 
-    const newSortedNodes = newProps.nodes;
-
-    if (newProps.sortOrder && newProps.sortOrder.length) {
-      sorty(newProps.sortOrder, newSortedNodes);
-    }
+    const sorter = sortOrder(newProps.sortOrder);
+    const sortedNodes = sorter(newProps.nodes);
 
     // if we provided the same id, then just update normally
     if (newProps.listId === this.props.listId) {
       this.setState({ exit: false }, () => {
-        this.setState({ nodes: newSortedNodes, stagger: false });
+        this.setState({ nodes: sortedNodes, stagger: false });
       });
       return;
     }
@@ -65,7 +62,7 @@ class NodeList extends Component {
         () => {
           this.refreshTimer = setTimeout(
             () => this.setState({
-              nodes: newSortedNodes,
+              nodes: sortedNodes,
               stagger: true,
             }),
             getCSSVariableAsNumber('--animation-duration-slow-ms'),

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -3,7 +3,6 @@ import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import { find, get, isEqual } from 'lodash';
 import cx from 'classnames';
-import sorty from '@zippytech/sorty';
 import { TransitionGroup } from 'react-transition-group';
 import { Node } from '../components';
 import { getCSSVariableAsString, getCSSVariableAsNumber } from '../utils/CSSVariables';
@@ -15,6 +14,7 @@ import {
   MonitorDropTarget,
   MonitorDragSource,
 } from '../behaviours/DragAndDrop';
+import sortOrder from '../utils/sortOrder';
 
 const EnhancedNode = DragSource(selectable(Node));
 
@@ -40,16 +40,13 @@ class OrdinalBinBucket extends Component {
       return;
     }
 
-    const newSortedNodes = newProps.nodes;
-
-    if (newProps.sortOrder && newProps.sortOrder.length) {
-      sorty(newProps.sortOrder, newSortedNodes);
-    }
+    const sorter = sortOrder(newProps.sortOrder);
+    const sortedNodes = sorter(newProps.nodes);
 
     // if we provided the same id, then just update normally
     if (newProps.listId === this.props.listId) {
       this.setState({ exit: false }, () => {
-        this.setState({ nodes: newSortedNodes, stagger: false });
+        this.setState({ nodes: sortedNodes, stagger: false });
       });
       return;
     }
@@ -64,7 +61,7 @@ class OrdinalBinBucket extends Component {
           if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
           this.refreshTimer = setTimeout(
             () => this.setState({
-              nodes: newSortedNodes,
+              nodes: sortedNodes,
               stagger: true,
             }),
             getCSSVariableAsNumber('--animation-duration-slow-ms'),

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -25,8 +25,11 @@ class OrdinalBinBucket extends Component {
   constructor(props) {
     super(props);
 
+    const sorter = sortOrder(props.sortOrder);
+    const sortedNodes = sorter(props.nodes);
+
     this.state = {
-      nodes: props.nodes,
+      nodes: sortedNodes,
       stagger: true,
       exit: true,
     };

--- a/src/containers/ConcentricCircles/Background.js
+++ b/src/containers/ConcentricCircles/Background.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Radar from './Radar';
-import { makeGetSociogramOptions, sociogramOptionsProps } from '../../selectors/sociogram';
+import { makeGetSociogramOptions } from '../../selectors/sociogram';
 import { BackgroundImage } from '../../components';
+import sociogramOptionsProps from './propTypes';
 
 class Background extends PureComponent {
   static propTypes = {

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -6,9 +6,10 @@ import { compose, withHandlers, withState } from 'recompose';
 import { isEqual, isEmpty, pick, isMatch, has } from 'lodash';
 import LayoutNode from './LayoutNode';
 import { withBounds } from '../../behaviours';
-import { makeGetSociogramOptions, makeGetPlacedNodes, sociogramOptionsProps } from '../../selectors/sociogram';
+import { makeGetSociogramOptions, makeGetPlacedNodes } from '../../selectors/sociogram';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { DropTarget } from '../../behaviours/DragAndDrop';
+import sociogramOptionsProps from './propTypes';
 
 const watchProps = ['width', 'height', 'dropCount'];
 

--- a/src/containers/ConcentricCircles/propTypes.js
+++ b/src/containers/ConcentricCircles/propTypes.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+export default {
+  layoutVariable: PropTypes.string.isRequired,
+  allowPositioning: PropTypes.bool.isRequired,
+  createEdge: PropTypes.string,
+  displayEdges: PropTypes.array.isRequired,
+  canCreateEdge: PropTypes.bool.isRequired,
+  allowHighlighting: PropTypes.bool.isRequired,
+  highlightAttributes: PropTypes.object,
+  nodeBinSortOrder: PropTypes.array.isRequired,
+};

--- a/src/containers/Interfaces/NameGeneratorList.js
+++ b/src/containers/Interfaces/NameGeneratorList.js
@@ -104,7 +104,7 @@ NameGeneratorList.propTypes = {
 
 NameGeneratorList.defaultProps = {
   initialSortOrder: '',
-  initialSortDirection: 'ASC',
+  initialSortDirection: 'asc',
 };
 
 function makeMapStateToProps() {

--- a/src/selectors/__tests__/name-generator.test.js
+++ b/src/selectors/__tests__/name-generator.test.js
@@ -12,7 +12,8 @@ const mockPrompt = {
   sortOptions: {
     sortableProperties: ['age'],
     sortOrder: {
-      name: 'asc',
+      property: 'name',
+      direction: 'asc',
     },
   },
   dataSource: 'schoolPupils',

--- a/src/selectors/__tests__/name-generator.test.js
+++ b/src/selectors/__tests__/name-generator.test.js
@@ -11,10 +11,10 @@ const mockPrompt = {
   },
   sortOptions: {
     sortableProperties: ['age'],
-    sortOrder: {
+    sortOrder: [{
       property: 'name',
       direction: 'asc',
-    },
+    }],
   },
   dataSource: 'schoolPupils',
 };

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -61,14 +61,18 @@ export const getSortFields = createSelector(
   sortOptions => (has(sortOptions, 'sortableProperties') ? sortOptions.sortableProperties : []),
 );
 
+// TODO: hard coded to select the first sortOrder rule,
+// until we add support for multi-property sorting
 export const getSortOrderDefault = createSelector(
   propSortOptions,
-  sortOptions => get(sortOptions, 'sortOrder.property', ''),
+  sortOptions => get(sortOptions, ['sortOrder', 0, 'property'], ''),
 );
 
+// TODO: hard coded to select the first sortOrder rule,
+// until we add support for multi-property sorting
 export const getSortDirectionDefault = createSelector(
   propSortOptions,
-  sortOptions => get(sortOptions, 'sortOrder.direction', ''),
+  sortOptions => get(sortOptions, ['sortOrder', 0, 'direction'], ''),
 );
 
 export const getDataByPrompt = createSelector(

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { createSelector } from 'reselect';
-import { has } from 'lodash';
+import { has, get } from 'lodash';
 import { makeGetSubject, makeGetIds, makeGetNodeType, makeGetAdditionalAttributes } from './interface';
 import { getExternalData, protocolRegistry } from './protocol';
 import { nextUid } from '../ducks/modules/network';
@@ -63,13 +63,12 @@ export const getSortFields = createSelector(
 
 export const getSortOrderDefault = createSelector(
   propSortOptions,
-  sortOptions => (has(sortOptions, 'sortOrder') ? Object.keys(sortOptions.sortOrder)[0] : ''),
+  sortOptions => get(sortOptions, 'sortOrder.property', ''),
 );
 
 export const getSortDirectionDefault = createSelector(
   propSortOptions,
-  getSortOrderDefault,
-  (sortOptions, key) => (has(sortOptions, 'sortOrder') ? sortOptions.sortOrder[key] : ''),
+  sortOptions => get(sortOptions, 'sortOrder.direction', ''),
 );
 
 export const getDataByPrompt = createSelector(

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -15,7 +15,6 @@ import {
   flow,
   isEmpty,
 } from 'lodash';
-import { PropTypes } from 'prop-types';
 import { networkEdges, makeGetDisplayVariable, makeNetworkNodesForSubject } from './interface';
 import { createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
@@ -178,17 +177,4 @@ export const makeGetPlacedNodes = () => {
     (nodes, { layoutVariable }) =>
       filter(nodes, node => has(node, layoutVariable)),
   );
-};
-
-// PropTypes
-
-export const sociogramOptionsProps = {
-  layoutVariable: PropTypes.string.isRequired,
-  allowPositioning: PropTypes.bool.isRequired,
-  createEdge: PropTypes.string,
-  displayEdges: PropTypes.array.isRequired,
-  canCreateEdge: PropTypes.bool.isRequired,
-  allowHighlighting: PropTypes.bool.isRequired,
-  highlightAttributes: PropTypes.object,
-  nodeBinSortOrder: PropTypes.object.isRequired,
 };

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -8,10 +8,6 @@ import {
   get,
   reject,
   first,
-  toPairs,
-  unzip,
-  orderBy,
-  lowerCase,
   groupBy,
   pick,
   values,
@@ -22,6 +18,7 @@ import {
 import { PropTypes } from 'prop-types';
 import { networkEdges, makeGetDisplayVariable, makeNetworkNodesForSubject } from './interface';
 import { createDeepEqualSelector } from './utils';
+import sortOrder from '../utils/sortOrder';
 
 // Selectors that are specific to the name generator
 
@@ -112,21 +109,14 @@ const makeGetUnplacedNodes = () => {
   );
 };
 
-const fifo = (node, index) => index;
-
 export const makeGetNextUnplacedNode = () => {
   const getUnplacedNodes = makeGetUnplacedNodes();
 
   return createSelector(
     getUnplacedNodes, getSortOptions,
     (nodes, sortOptions) => {
-      const [properties, orders] = unzip(toPairs(sortOptions.nodeBinSortOrder));
-      const sortedNodes = orderBy(
-        [...nodes],
-        properties.map(property => (property === '*' ? fifo : property)),
-        orders.map(lowerCase),
-      );
-      return first(sortedNodes);
+      const sorter = sortOrder(sortOptions.nodeBinSortOrder);
+      return first(sorter(nodes));
     },
   );
 };

--- a/src/utils/__tests__/sortOrder.test.js
+++ b/src/utils/__tests__/sortOrder.test.js
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+import sortOrder from '../sortOrder';
+
+const mockItems = [
+  {
+    name: 'abigail',
+    age: 20,
+    favouriteColor: 'red',
+  },
+  {
+    name: 'benjamin',
+    age: 50,
+    favouriteColor: 'green',
+  },
+  {
+    name: 'carolyn',
+    age: 30,
+    favouriteColor: 'blue',
+  },
+  {
+    name: 'eugine',
+    age: 20,
+    favouriteColor: 'green',
+  },
+  {
+    name: 'dave',
+    age: 20,
+    favouriteColor: 'blue',
+  },
+];
+
+
+describe('sortOrder', () => {
+  it('it does not change order when rules are empty', () => {
+    const sorter = sortOrder();
+    expect(sorter(mockItems)).toMatchObject(mockItems);
+  });
+
+  describe('order direction', () => {
+    it('orders ascending with "asc"', () => {
+      const sorter = sortOrder([{
+        property: 'age',
+        direction: 'asc',
+      }]);
+
+      expect(sorter(mockItems)).toMatchObject([
+        { name: 'abigail' },
+        { name: 'eugine' },
+        { name: 'dave' },
+        { name: 'carolyn' },
+        { name: 'benjamin' },
+      ]);
+    });
+
+    it('orders descending with "desc"', () => {
+      const sorter = sortOrder([{
+        property: 'age',
+        direction: 'desc',
+      }]);
+
+      expect(sorter(mockItems)).toMatchObject([
+        { name: 'benjamin' },
+        { name: 'carolyn' },
+        { name: 'abigail' },
+        { name: 'eugine' },
+        { name: 'dave' },
+      ]);
+    });
+  });
+
+  it('can order multiple properties and directions', () => {
+    const sorter = sortOrder([
+      {
+        property: 'age',
+        direction: 'asc',
+      },
+      {
+        property: 'name',
+        direction: 'desc',
+      },
+    ]);
+
+    expect(sorter(mockItems)).toMatchObject([
+      { name: 'eugine' },
+      { name: 'dave' },
+      { name: 'abigail' },
+      { name: 'carolyn' },
+      { name: 'benjamin' },
+    ]);
+  });
+
+  it('treats "*" property as fifo ordering', () => {
+    const sorter = sortOrder([{
+      property: '*',
+      direction: 'desc',
+    }]);
+
+    expect(sorter(mockItems)).toMatchObject([
+      { name: 'dave' },
+      { name: 'eugine' },
+      { name: 'carolyn' },
+      { name: 'benjamin' },
+      { name: 'abigail' },
+    ]);
+  });
+});

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -1,9 +1,13 @@
 import { orderBy } from 'lodash';
 
+const fifo = (node, index) => index;
+
 // TODO: Use variable registry to respect variable type?
 const sortOrder = (sortConfiguration, variableRegistry) => {
-  const iteratees = sortConfiguration.map(item => item.variable);
-  const orders = sortConfiguration.map(item => item.direction);
+  const iteratees = sortConfiguration.map(rule => rule.property)
+    .map(property => (property === '*' ? fifo : property));
+
+  const orders = sortConfiguration.map(rule => rule.direction);
 
   return items =>
     orderBy(items, iteratees, orders);

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -3,7 +3,8 @@ import { orderBy } from 'lodash';
 const fifo = (node, index) => index;
 
 // TODO: Use variable registry to respect variable type?
-const sortOrder = (sortConfiguration, variableRegistry) => {
+// eslint-disable-next-line
+const sortOrder = (sortConfiguration, variableRegistry = {}) => {
   const iteratees = sortConfiguration.map(rule => rule.property)
     .map(property => (property === '*' ? fifo : property));
 

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -1,16 +1,28 @@
 import { orderBy } from 'lodash';
 
+/* Maps a `createdIndex` index value to all items in an array */
 const withCreatedIndex = items => items.map((item, createdIndex) => ({ ...item, createdIndex }));
+
+/* property iteratee for the special case "*" property, which sorteds by `createdIndex` */
 const fifo = ({ createdIndex }) => createdIndex;
 
-// TODO: Use variable registry to respect variable type?
-// eslint-disable-next-line
-const sortOrder = (sortConfiguration, variableRegistry = {}) => {
+/**
+ * Returns a configured sorting function
+ * @param {array} sortConfiguration - The title of the book.
+ * @param {object} variableRegistry - an object containing variables for the node type as specified
+ * at: `variableRegistry.node[nodeType]variables`
+ * TODO: Use variable registry to respect variable type?
+ */
+const sortOrder = (sortConfiguration = [], variableRegistry = {}) => { // eslint-disable-line
   const iteratees = sortConfiguration.map(rule => rule.property)
     .map(property => (property === '*' ? fifo : property));
 
   const orders = sortConfiguration.map(rule => rule.direction);
 
+  /**
+   * Returns a list of sorted items
+   * @param {array} items - A list of items (nodes) to be sorted
+   */
   return items =>
     orderBy(
       withCreatedIndex(items),

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -1,0 +1,12 @@
+import { orderBy } from 'lodash';
+
+// TODO: Use variable registry to respect variable type?
+const sortOrder = (sortConfiguration, variableRegistry) => {
+  const iteratees = sortConfiguration.map(item => item.variable);
+  const orders = sortConfiguration.map(item => item.direction);
+
+  return items =>
+    orderBy(items, iteratees, orders);
+};
+
+export default sortOrder;

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -1,6 +1,7 @@
 import { orderBy } from 'lodash';
 
-const fifo = (node, index) => index;
+const withCreatedIndex = items => items.map((item, createdIndex) => ({ ...item, createdIndex }));
+const fifo = ({ createdIndex }) => createdIndex;
 
 // TODO: Use variable registry to respect variable type?
 // eslint-disable-next-line
@@ -11,7 +12,11 @@ const sortOrder = (sortConfiguration, variableRegistry = {}) => {
   const orders = sortConfiguration.map(rule => rule.direction);
 
   return items =>
-    orderBy(items, iteratees, orders);
+    orderBy(
+      withCreatedIndex(items),
+      iteratees,
+      orders,
+    );
 };
 
 export default sortOrder;


### PR DESCRIPTION
This adds a new sort generator in utils/sortBy, usage:

```
const sorter = sortBy([{property: 'name', direction: 'asc'}]);
const sortedItems = sorter(items);
```

The app has been updated to use this sort object everywhere orderBy-type
configuration is currently defined, with the exception of
NameGeneratorList which appears to sort by a single property and has
only been updated to accept the new object syntax: `{ property, direction }`.

Partially resolves: #108