### PR TITLE
Initial data export

### DIFF
--- a/src/components/Setup/ProtocolCard.js
+++ b/src/components/Setup/ProtocolCard.js
@@ -20,7 +20,7 @@ const ProtocolCard = ({ protocol, selectProtocol, className, size }) => {
       <Icon className="protocol-card__icon" name="add-a-screen" />
       <div className="protocol-card__labels">
         <h2 className={sized('protocol-card__name')}>{protocol.name}</h2>
-        <p className="protocol-card__version">{protocol.version}</p>
+        <p className="protocol-card__description">{protocol.description}</p>
       </div>
     </div>
   );
@@ -30,6 +30,7 @@ ProtocolCard.defaultProps = {
   className: '',
   selectProtocol: () => {},
   size: '',
+  description: '',
 };
 
 ProtocolCard.propTypes = {
@@ -37,9 +38,9 @@ ProtocolCard.propTypes = {
   selectProtocol: PropTypes.func,
   protocol: PropTypes.shape({
     name: PropTypes.string.isRequired,
-    version: PropTypes.string.isRequired,
+    description: PropTypes.string,
   }).isRequired,
-  size: PropTypes.oneOf([largeVariant]),
+  size: PropTypes.oneOf([largeVariant, '']),
 };
 
 export default ProtocolCard;

--- a/src/components/Setup/ServerProtocolList.js
+++ b/src/components/Setup/ServerProtocolList.js
@@ -10,7 +10,7 @@ const EmptyProtocolList = (
   </div>
 );
 
-const ServerProtocolList = ({ protocols, download }) => {
+const ServerProtocolList = ({ protocols, selectProtocol }) => {
   let leftBorderClass = 'protocol-card-list__left-border';
   if (!protocols.length) {
     return EmptyProtocolList;
@@ -26,11 +26,11 @@ const ServerProtocolList = ({ protocols, download }) => {
         <div key="left-border" className={leftBorderClass} />
         {
           protocols.map(protocol => (
-            <div className="protocol-card-list__bordered-card" key={protocol.downloadUrl}>
+            <div className="protocol-card-list__bordered-card" key={protocol.id}>
               <div className="protocol-card-list__card-border" />
               <ProtocolCard
                 className="protocol-card-list__card"
-                selectProtocol={p => download(p.downloadUrl)}
+                selectProtocol={p => selectProtocol(p)}
                 protocol={protocol}
               />
             </div>
@@ -42,7 +42,7 @@ const ServerProtocolList = ({ protocols, download }) => {
 };
 
 ServerProtocolList.propTypes = {
-  download: PropTypes.func.isRequired,
+  selectProtocol: PropTypes.func.isRequired,
   protocols: PropTypes.array.isRequired,
 };
 

--- a/src/components/Setup/__tests__/ProtocolCard.test.js
+++ b/src/components/Setup/__tests__/ProtocolCard.test.js
@@ -11,7 +11,7 @@ describe('<ProtocolCard>', () => {
 
   beforeEach(() => {
     selectHandler = jest.fn();
-    mockProtocol = { name: 'my-mock-protocol', version: '1.0.1' };
+    mockProtocol = { name: 'my-mock-protocol', description: '1.0.1' };
     component = shallow(<ProtocolCard selectProtocol={selectHandler} protocol={mockProtocol} />);
   });
 
@@ -19,9 +19,9 @@ describe('<ProtocolCard>', () => {
     expect(component.find('Icon')).toHaveLength(1);
   });
 
-  it('renders name & version', () => {
+  it('renders name & description', () => {
     expect(component.text()).toMatch(mockProtocol.name);
-    expect(component.text()).toMatch(mockProtocol.version);
+    expect(component.text()).toMatch(mockProtocol.description);
   });
 
   it('downloads on click', () => {

--- a/src/components/Setup/__tests__/ServerProtocolList.test.js
+++ b/src/components/Setup/__tests__/ServerProtocolList.test.js
@@ -13,7 +13,7 @@ describe('<ServerProtocolList>', () => {
     downloadHandler = jest.fn();
     mockProtocols = [{ name: 'my-mock-protocol', version: '1.0.1' }];
     component = shallow((
-      <ServerProtocolList download={downloadHandler} protocols={mockProtocols} />
+      <ServerProtocolList selectProtocol={downloadHandler} protocols={mockProtocols} />
     ));
   });
 

--- a/src/containers/Setup/ProtocolList.js
+++ b/src/containers/Setup/ProtocolList.js
@@ -20,7 +20,7 @@ class ProtocolList extends Component {
     if (protocol.type === 'factory') {
       this.loadFactoryProtocol(protocol.path);
     } else {
-      this.loadRemoteProtocol(protocol.path);
+      this.loadRemoteProtocol(protocol.path, protocol.remoteId);
     }
   }
 
@@ -29,12 +29,11 @@ class ProtocolList extends Component {
     this.props.loadFactoryProtocol(protocolPath);
   }
 
-  loadRemoteProtocol = (protocolPath) => {
+  loadRemoteProtocol = (protocolPath, remoteId) => {
     if (protocolPath) {
-      this.props.loadProtocol(protocolPath);
+      this.props.loadProtocol(protocolPath, null, remoteId);
     }
   }
-
 
   render() {
     const { protocols } = this.props;
@@ -95,3 +94,5 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProtocolList);
+
+export { ProtocolList as UnconnectedProtocolList };

--- a/src/containers/Setup/ServerList.js
+++ b/src/containers/Setup/ServerList.js
@@ -97,7 +97,7 @@ class ServerList extends Component {
                 key={server.apiUrl}
                 data={server}
                 selectServer={onSelect}
-                secondaryLabel={isPaired && '(paired)'}
+                secondaryLabel={isPaired ? '(paired)' : ''}
               />
             );
           })

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -43,7 +43,11 @@ class ServerProtocols extends Component {
     return (
       <ServerSetup server={server}>
         {
-          protocols && <ServerProtocolList protocols={protocols} download={downloadProtocol} />
+          protocols &&
+          <ServerProtocolList
+            protocols={protocols}
+            selectProtocol={p => downloadProtocol(p.downloadUrl, p.id)}
+          />
         }
       </ServerSetup>
     );

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -50,7 +50,7 @@ class SessionList extends Component {
   }
 
   render() {
-    const { removeSession, sessions } = this.props;
+    const { defaultServer, exportSession, removeSession, sessions } = this.props;
 
     if (isEmpty(sessions)) {
       return emptyView;
@@ -66,8 +66,13 @@ class SessionList extends Component {
           compact
           multiselect={false}
           onDeleteCard={(data) => {
+            const serverApiUrl = defaultServer && defaultServer.apiUrl;
             // eslint-disable-next-line no-alert
-            if (confirm('Delete this interview?')) {
+            if (serverApiUrl && confirm('Export & delete this interview?')) {
+              const sessionData = sessions[data.uid].network;
+              const protocolId = 't9aiIsVrRY2PUFub'; // FIXME: placeholder
+              exportSession(serverApiUrl, protocolId, data.uid, sessionData);
+            } else if (confirm('Delete this interview?')) { // eslint-disable-line no-alert
               removeSession(data.uid);
             }
           }}
@@ -92,6 +97,8 @@ class SessionList extends Component {
 }
 
 SessionList.propTypes = {
+  defaultServer: PropTypes.shape({ apiUrl: PropTypes.string.isRequired }),
+  exportSession: PropTypes.func.isRequired,
   getSessionPath: PropTypes.func.isRequired,
   loadSession: PropTypes.func.isRequired,
   removeSession: PropTypes.func.isRequired,
@@ -100,12 +107,14 @@ SessionList.propTypes = {
 };
 
 SessionList.defaultProps = {
+  defaultServer: null,
 };
 
 function mapStateToProps(state) {
   return {
     getSessionPath: sessionId => state.sessions[sessionId].path,
     sessions: state.sessions,
+    defaultServer: state.servers && state.servers.paired[0],
   };
 }
 
@@ -114,6 +123,7 @@ function mapDispatchToProps(dispatch) {
     loadSession: path => dispatch(push(path)),
     removeSession: bindActionCreators(sessionsActions.removeSession, dispatch),
     setSession: bindActionCreators(sessionActions.setSession, dispatch),
+    exportSession: bindActionCreators(sessionsActions.exportSession, dispatch),
   };
 }
 

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -66,13 +66,23 @@ class SessionList extends Component {
           compact
           multiselect={false}
           onDeleteCard={(data) => {
+            // Example session export:
+            // - For now, export to the first (or only) paired server
+            // - Session must have been created with a protocolIdentifier
+            // Otherwise, prompt to delete.
             const serverApiUrl = defaultServer && defaultServer.apiUrl;
+            const sessionData = sessions[data.uid].network;
+            const protocolIdentifier = sessions[data.uid].protocolIdentifier;
+            if (serverApiUrl && protocolIdentifier) {
+              // eslint-disable-next-line no-alert
+              if (confirm('Export & delete this interview?')) {
+                exportSession(serverApiUrl, protocolIdentifier, data.uid, sessionData);
+              }
+              return;
+            }
+
             // eslint-disable-next-line no-alert
-            if (serverApiUrl && confirm('Export & delete this interview?')) {
-              const sessionData = sessions[data.uid].network;
-              const protocolId = 't9aiIsVrRY2PUFub'; // FIXME: placeholder
-              exportSession(serverApiUrl, protocolId, data.uid, sessionData);
-            } else if (confirm('Delete this interview?')) { // eslint-disable-line no-alert
+            if (confirm('Delete this interview?')) {
               removeSession(data.uid);
             }
           }}

--- a/src/containers/Setup/__tests__/ProtocolList.test.js
+++ b/src/containers/Setup/__tests__/ProtocolList.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { createStore } from 'redux';
 
-import ProtocolList from '../ProtocolList';
+import ProtocolList, { UnconnectedProtocolList } from '../ProtocolList';
 
 const mockProps = {
   addSession: jest.fn(),
@@ -12,9 +12,11 @@ const mockProps = {
   loadProtocol: jest.fn(),
 };
 
+const mockProtocols = [{ name: 'Sample', path: 'sample.netcanvas', type: 'factory' }];
+
 const mockStore = () =>
   createStore(() => ({
-    protocols: [{ name: 'Sample', path: 'sample.netcanvas', type: 'factory' }],
+    protocols: mockProtocols,
   }));
 
 describe('<ProtocolList />', () => {
@@ -22,5 +24,27 @@ describe('<ProtocolList />', () => {
     const component = shallow(<ProtocolList {...mockProps} store={mockStore()} />);
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('click handler', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<UnconnectedProtocolList {...mockProps} protocols={mockProtocols} />);
+      mockProps.loadFactoryProtocol.mockClear();
+      mockProps.loadProtocol.mockClear();
+    });
+
+    it('loads a remote protocol', () => {
+      wrapper.instance().onClickNewProtocol(mockProtocols[0]);
+      expect(mockProps.loadFactoryProtocol).toHaveBeenCalled();
+    });
+
+    it('loads a remote protocol', () => {
+      const protocol = { ...mockProtocols[0], type: 'download', remoteId: '1' };
+      wrapper.instance().onClickNewProtocol(protocol);
+      expect(mockProps.loadFactoryProtocol).not.toHaveBeenCalled();
+      expect(mockProps.loadProtocol).toHaveBeenCalledWith(protocol.path, null, protocol.remoteId);
+    });
   });
 });

--- a/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
+++ b/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
@@ -27,6 +27,8 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "class",
     "props": Object {
+      "defaultServer": null,
+      "exportSession": [Function],
       "getSessionPath": [Function],
       "loadSession": [Function],
       "removeSession": [Function],
@@ -95,6 +97,8 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
+        "defaultServer": null,
+        "exportSession": [Function],
         "getSessionPath": [Function],
         "loadSession": [Function],
         "removeSession": [Function],

--- a/src/ducks/modules/__tests__/protocols.test.js
+++ b/src/ducks/modules/__tests__/protocols.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import reducer, { actionCreators, actionTypes } from '../protocols';
+import { actionTypes as ProtocolActionTypes } from '../protocol';
 
 const initialState = [
   {
@@ -36,6 +37,34 @@ describe('protocols reducer', () => {
     const newState = reducer(initialState,
       { type: actionTypes.ADD_PROTOCOL, protocol: testProtocol });
     expect(newState).toEqual([...initialState, testProtocol]);
+  });
+
+  describe('LOAD_PROTOCOL', () => {
+    const makeAction = attrs => ({ ...attrs, type: ProtocolActionTypes.LOAD_PROTOCOL });
+    const actionAttrs = { path: 'path', protocolType: 'download' };
+    const expectedProtocol = { name: 'path', path: 'path', type: 'download' };
+
+    it('should add a new protocol', () => {
+      const state = reducer(initialState, makeAction(actionAttrs));
+      expect(state).toContainEqual(expectedProtocol);
+    });
+
+    it('should persist remoteId if available', () => {
+      const state = reducer(initialState, makeAction({ ...actionAttrs, remoteId: '1' }));
+      expect(state).toContainEqual({ ...expectedProtocol, remoteId: '1' });
+    });
+
+    it('should not duplicate protocols with matching paths', () => {
+      let state = reducer(initialState, makeAction(actionAttrs));
+      state = reducer(state, makeAction(actionAttrs));
+      expect(state).toHaveLength(initialState.length + 1);
+    });
+
+    it('should not duplicate protocols with matching remoteIds', () => {
+      let state = reducer(initialState, makeAction({ path: '1', remoteId: '1' }));
+      state = reducer(state, makeAction({ path: '2', remoteId: '1' }));
+      expect(state).toHaveLength(initialState.length + 1);
+    });
   });
 });
 

--- a/src/ducks/modules/errors.js
+++ b/src/ducks/modules/errors.js
@@ -1,5 +1,6 @@
 import { actionTypes as errorActionTypes } from './protocol';
-import { actionTypes as pairingErrorTypes } from './servers';
+import { actionTypes as serverActionTypes } from './servers';
+import { actionTypes as sessionsActionTypes } from './sessions';
 
 const ERROR = 'ERRORS/ERROR';
 const ACKNOWLEDGE_ERROR = 'ERRORS/ACKNOWLEDGE_ERROR';
@@ -15,7 +16,8 @@ export default function reducer(state = initialState, action = {}) {
     case errorActionTypes.DOWNLOAD_PROTOCOL_FAILED:
     case errorActionTypes.IMPORT_PROTOCOL_FAILED:
     case errorActionTypes.LOAD_PROTOCOL_FAILED:
-    case pairingErrorTypes.SERVER_PAIRING_FAILED:
+    case serverActionTypes.SERVER_PAIRING_FAILED:
+    case sessionsActionTypes.EXPORT_SESSION_FAILED:
       // eslint-disable-next-line no-console
       console.error(action.error);
       return {

--- a/src/ducks/modules/protocols.js
+++ b/src/ducks/modules/protocols.js
@@ -31,7 +31,12 @@ export default function reducer(state = initialState, action = {}) {
       }
       return [
         ...state,
-        { name: action.path, path: action.path, type: action.type },
+        {
+          name: action.path,
+          path: action.path,
+          type: action.protocolType,
+          remoteId: action.remoteId,
+        },
       ];
     case ADD_PROTOCOL:
       return [

--- a/src/ducks/modules/protocols.js
+++ b/src/ducks/modules/protocols.js
@@ -1,5 +1,3 @@
-import { some } from 'lodash';
-
 import { actionTypes as ProtocolActionTypes } from './protocol';
 
 const LOAD_PROTOCOL = ProtocolActionTypes.LOAD_PROTOCOL;
@@ -25,8 +23,13 @@ const initialState = [
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case LOAD_PROTOCOL:
-      if (some(state, { path: action.path, type: action.type })) {
+    case LOAD_PROTOCOL: {
+      // Downloaded protocols always have unique paths, so check remote ID as well.
+      const matchesCurrentAction = protocol => protocol.type === action.protocolType &&
+        (protocol.path === action.path ||
+          (protocol.remoteId && protocol.remoteId === action.remoteId));
+
+      if (state.some(matchesCurrentAction)) {
         return state;
       }
       return [
@@ -38,6 +41,7 @@ export default function reducer(state = initialState, action = {}) {
           remoteId: action.remoteId,
         },
       ];
+    }
     case ADD_PROTOCOL:
       return [
         ...state,

--- a/src/ducks/modules/rootEpic.js
+++ b/src/ducks/modules/rootEpic.js
@@ -1,6 +1,8 @@
 import { combineEpics } from 'redux-observable';
 import { epics as protocolEpics } from './protocol';
+import { epics as sessionsEpics } from './sessions';
 
 export default combineEpics(
   protocolEpics,
+  sessionsEpics,
 );

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -220,10 +220,8 @@ const exportSession = (apiUrl, protocolIdentifier, sessionUuid, sessionData) => 
   sessionData,
 });
 
-const sessionExportPromise = ({ apiUrl, protocolIdentifier, sessionUuid, sessionData }) => {
-  const session = { ...sessionData, uuid: sessionUuid };
-  return new ApiClient(apiUrl).exportSession(protocolIdentifier, session);
-};
+const sessionExportPromise = ({ apiUrl, protocolIdentifier, sessionUuid, sessionData }) =>
+  new ApiClient(apiUrl).exportSession(protocolIdentifier, sessionUuid, sessionData);
 
 const exportSessionEpic = action$ => (
   action$.ofType(EXPORT_SESSION)

--- a/src/styles/components/_protocol-card.scss
+++ b/src/styles/components/_protocol-card.scss
@@ -45,7 +45,7 @@
     }
   }
 
-  &__version {
+  &__description {
     @include typography(copy-small);
     margin-bottom: 0;
   }

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -61,6 +61,9 @@ class ApiClient {
     this.cancelTokenSource = axios.CancelToken.source();
     this.client = axios.create({
       baseURL: apiUrl.replace(/\/$/, ''),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
   }
 
@@ -132,6 +135,21 @@ class ApiClient {
    */
   getProtocols() {
     return this.client.get('/protocols', { cancelToken: this.cancelTokenSource.token })
+      .then(resp => resp.data)
+      .then(json => json.data)
+      .catch(handleError);
+  }
+
+  /**
+   * @async
+   * @param {string} protocolId ID of the protocol this session belongs to
+   * @param {Object} sessionData
+   * @param {String} sessionData.uuid (required)
+   * @return {Object}
+   * @throws {Error}
+   */
+  exportSession(protocolId, sessionData) {
+    return this.client.post(`/protocols/${protocolId}/sessions`, sessionData)
       .then(resp => resp.data)
       .then(json => json.data)
       .catch(handleError);

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -143,6 +143,7 @@ class ApiClient {
   /**
    * @async
    * @param {string} protocolId ID of the protocol this session belongs to
+   *                            (a sha256 digest of the protocol name, as hex)
    * @param {Object} sessionData
    * @param {String} sessionData.uuid (required)
    * @return {Object}

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -149,8 +149,12 @@ class ApiClient {
    * @return {Object}
    * @throws {Error}
    */
-  exportSession(protocolId, sessionData) {
-    return this.client.post(`/protocols/${protocolId}/sessions`, sessionData)
+  exportSession(protocolId, sessionId, sessionData) {
+    const payload = {
+      uuid: sessionId,
+      data: sessionData,
+    };
+    return this.client.post(`/protocols/${protocolId}/sessions`, payload)
       .then(resp => resp.data)
       .then(json => json.data)
       .catch(handleError);


### PR DESCRIPTION
This implements the session export API call, part of #543.

We still need to design UI around export (which is #544, or possibly part of #543 if the 'resume' screen is migrating to a 'management' screen, and needs to coordinate with #529). For now, I've just added this to the existing 'remove' button as an example. If you've paired a server, and the protocol has a remote identifier, then the button will prompt you to export before removing.

To make this work for now, I've added a 'remoteId' to protocol actions, which gets picked up by the sessions reducer. As discussed in #545, sessions & protocols could be simplified where there are overlaps. We can tackle that here, but it may conflict with other related work.

To test this: use with the latest server branch `feature/protocol-versions`.