### PR TITLE
Add 'Finish' interface

### DIFF
--- a/config/jest/automock.js
+++ b/config/jest/automock.js
@@ -3,5 +3,6 @@
 jest.mock('electron');
 jest.mock('fs');
 jest.mock('../../src/utils/Environment');
+jest.mock('../../src/utils/uuid');
 
 global.console.error = jest.fn();

--- a/public/protocols/education.netcanvas/protocol.json
+++ b/public/protocols/education.netcanvas/protocol.json
@@ -607,16 +607,16 @@
       "items": [
         { "type": "text", "content": "This is the end of the data collection stage. As you can imagine there are many more possible kinds of data that you can add to such a questionnaire." },
         { "type": "text", "content": "Network Canvas is currently adding many new screens to capture a variety of data types. This example was just the beginning." },
-        { "type": "text", "content": "To export this data and continue with some further analysis, please use the \"Download Data\" option in the settings menu." }
+        { "type": "text", "content": "To export this data and continue with some further analysis, please use the \"Download\" option on the final stage before finishing." }
       ]
     },
     {
       "id": "finalInstruction",
-      "label": "Finished",
+      "label": "Learn More",
       "type": "Information",
       "title": "Thank you!",
       "items": [
-        { "type": "text", "content": "To learn more about Network Canvas, please visit our website at <http://www.networkcanvas.com/>." }
+        { "type": "text", "content": "To learn more about Network Canvas, please visit our website at <https://networkcanvas.com>." }
       ]
     }
   ]

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -84,7 +84,7 @@ class FinishSession extends Component {
           </h1>
           <div className="finish-session-interface__section finish-session-interface__section--instructions">
             <p>
-              You have reached all stages of this interview.
+              You have reached the end of the interview.
               If you’ve completed all input, you may finish the interview now.
             </p>
           </div>

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -1,0 +1,138 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { push } from 'react-router-redux';
+
+import { Button } from '../../ui/components';
+import { actionCreators as sessionActions } from '../../ducks/modules/session';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
+
+const ExportSection = ({ defaultServer, children }) => (
+  <div className="finish-session-interface__section finish-session-interface__section--export">
+    <div>
+      <h2>Data Export</h2>
+      <p>
+        Export this interview to {defaultServer.name} <br />
+        <small>{defaultServer.apiUrl}</small>
+      </p>
+    </div>
+    <div>
+      { children }
+    </div>
+  </div>
+);
+
+class FinishSession extends Component {
+  get exportSection() {
+    const { currentSession, defaultServer } = this.props;
+    if (currentSession.lastExportedAt) {
+      return (
+        <ExportSection defaultServer={defaultServer}>
+          <p>Export Successful</p>
+          <p><small>{new Date(currentSession.lastExportedAt).toLocaleString()}</small></p>
+        </ExportSection>
+      );
+    } else if (this.currentSessionisExportable) {
+      return (
+        <ExportSection defaultServer={defaultServer}>
+          <Button size="small" onClick={() => this.export(currentSession)}>
+            Export
+          </Button>
+        </ExportSection>
+      );
+    } else if (this.currentSessionBelongsToProtocol) {
+      // This is a rare case...
+      return <p>This session is not exportable: there is no paired Server.</p>;
+    }
+
+    return <p>This session is not exportable: it is not associated with any Server.</p>;
+  }
+
+  get serverApiUrl() {
+    const { defaultServer } = this.props;
+    return defaultServer && defaultServer.apiUrl;
+  }
+
+  get currentSessionBelongsToProtocol() {
+    return !!this.props.currentSession.protocolIdentifier;
+  }
+
+  get currentSessionisExportable() {
+    return this.currentSessionBelongsToProtocol && this.serverApiUrl;
+  }
+
+  export(currentSession) {
+    const { sessionId } = this.props;
+    const sessionData = currentSession.network;
+    const protocolIdentifier = currentSession.protocolIdentifier;
+    if (this.serverApiUrl) {
+      this.props.exportSession(this.serverApiUrl, protocolIdentifier, sessionId, sessionData);
+    }
+  }
+
+  render() {
+    return (
+      <div className="interface finish-session-interface">
+        <div className="finish-session-interface__frame">
+          <h1 className="finish-session-interface__title type--title-1">
+            Finish Interview
+          </h1>
+          <div className="finish-session-interface__section finish-session-interface__section--instructions">
+            <p>
+              You have reached all stages of this interview.
+              If you’ve completed all input, you may finish the interview now.
+            </p>
+          </div>
+
+          { this.exportSection }
+
+          <div className="finish-session-interface__section finish-session-interface__section--buttons">
+            <Button onClick={this.props.endSession}>
+              Finish
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+FinishSession.propTypes = {
+  currentSession: PropTypes.object.isRequired,
+  defaultServer: PropTypes.object,
+  endSession: PropTypes.func.isRequired,
+  exportSession: PropTypes.func.isRequired,
+  sessionId: PropTypes.string.isRequired,
+};
+
+FinishSession.defaultProps = {
+  defaultServer: null,
+};
+
+ExportSection.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string]).isRequired,
+  defaultServer: PropTypes.object.isRequired,
+};
+
+function mapStateToProps(state) {
+  return {
+    currentSession: state.sessions[state.session],
+    sessionId: state.session,
+    defaultServer: state.servers && state.servers.paired[0],
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    exportSession: bindActionCreators(sessionsActions.exportSession, dispatch),
+    endSession: () => {
+      dispatch(sessionActions.endSession());
+      dispatch(push('/'));
+    },
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FinishSession);
+
+export { FinishSession as UnconnectedFinishSession };

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -4,9 +4,13 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
 
+import createGraphML from '../../utils/ExportData';
+import Dialog from '../../containers/Dialog';
 import { Button } from '../../ui/components';
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
+import { actionCreators as modalActions } from '../../ducks/modules/modals';
+import { getCurrentSession, getNetwork } from '../../selectors/interface';
 
 const ExportSection = ({ defaultServer, children }) => (
   <div className="finish-session-interface__section finish-session-interface__section--export">
@@ -87,6 +91,28 @@ class FinishSession extends Component {
 
           { this.exportSection }
 
+          <div className="finish-session-interface__section finish-session-interface__section--download">
+            <div>
+              <h2>Data Download</h2>
+              <p>Download network as a <code>.graphml</code> file</p>
+            </div>
+            <div>
+              <Button size="small" onClick={() => createGraphML(this.props.currentNetwork, () => this.props.openModal('EXPORT_DATA'))}>
+                Download
+              </Button>
+            </div>
+            <Dialog
+              name="EXPORT_DATA"
+              title="Export Error"
+              type="error"
+              hasCancelButton={false}
+              confirmLabel="Okay"
+              onConfirm={() => {}}
+            >
+              <p>There was a problem exporting your data.</p>
+            </Dialog>
+          </div>
+
           <div className="finish-session-interface__section finish-session-interface__section--buttons">
             <Button onClick={this.props.endSession}>
               Finish
@@ -99,10 +125,12 @@ class FinishSession extends Component {
 }
 
 FinishSession.propTypes = {
+  currentNetwork: PropTypes.object.isRequired,
   currentSession: PropTypes.object.isRequired,
   defaultServer: PropTypes.object,
   endSession: PropTypes.func.isRequired,
   exportSession: PropTypes.func.isRequired,
+  openModal: PropTypes.func.isRequired,
   sessionId: PropTypes.string.isRequired,
 };
 
@@ -117,7 +145,8 @@ ExportSection.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    currentSession: state.sessions[state.session],
+    currentNetwork: getNetwork(state),
+    currentSession: getCurrentSession(state),
     sessionId: state.session,
     defaultServer: state.servers && state.servers.paired[0],
   };
@@ -130,6 +159,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(sessionActions.endSession());
       dispatch(push('/'));
     },
+    openModal: bindActionCreators(modalActions.openModal, dispatch),
   };
 }
 

--- a/src/containers/Interfaces/__tests__/FinishSession.test.js
+++ b/src/containers/Interfaces/__tests__/FinishSession.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+import React from 'react';
+import { render, shallow } from 'enzyme';
+
+import { UnconnectedFinishSession as FinishSession } from '../FinishSession';
+
+const findButtonMatching = (text, container) => (
+  container.find('Button').filterWhere(b => b.prop('children') === text)
+);
+
+describe('the Finish Interface', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      currentSession: { protocolIdentifier: '1' },
+      defaultServer: { apiUrl: 'x.x.x.x' },
+    };
+  });
+
+  it('Renders a Finish button', () => {
+    const elem = shallow(<FinishSession {...mockProps} />);
+    expect(findButtonMatching('Finish', elem)).toHaveLength(1);
+  });
+
+  it('Renders an export button when session is exportable', () => {
+    const elem = shallow(<FinishSession {...mockProps} />);
+    expect(findButtonMatching('Export', elem)).toHaveLength(1);
+  });
+
+  it('Renders confirmation after export', () => {
+    mockProps.currentSession.lastExportedAt = 1529686211439;
+    const elem = render(<FinishSession {...mockProps} />);
+    expect(elem.text()).toMatch('Export Success');
+  });
+
+  it('Skips the export button when session is not exportable', () => {
+    mockProps.currentSession.protocolIdentifier = null;
+    const elem = shallow(<FinishSession {...mockProps} />);
+    expect(elem.find('Button').filterWhere(b => b.prop('children') === 'Export')).toHaveLength(0);
+  });
+
+  it('Skips the export button when there is no paired server', () => {
+    mockProps.defaultServer = null;
+    const elem = shallow(<FinishSession {...mockProps} />);
+    expect(elem.find('Button').filterWhere(b => b.prop('children') === 'Export')).toHaveLength(0);
+  });
+});

--- a/src/containers/Interfaces/__tests__/FinishSession.test.js
+++ b/src/containers/Interfaces/__tests__/FinishSession.test.js
@@ -4,6 +4,8 @@ import { render, shallow } from 'enzyme';
 
 import { UnconnectedFinishSession as FinishSession } from '../FinishSession';
 
+jest.mock('../../../behaviours/modal', () => wrapped => wrapped);
+
 const findButtonMatching = (text, container) => (
   container.find('Button').filterWhere(b => b.prop('children') === text)
 );

--- a/src/containers/Interfaces/index.js
+++ b/src/containers/Interfaces/index.js
@@ -9,6 +9,7 @@ import NameGeneratorList from './NameGeneratorList';
 import Sociogram from './Sociogram';
 import Quiz from './Quiz';
 import Information from './Information';
+import FinishSession from './FinishSession';
 
 const interfaces = {
   NameGenerator,
@@ -18,6 +19,7 @@ const interfaces = {
   Quiz,
   Information,
   OrdinalBin,
+  FinishSession,
 };
 
 const getInterface = (interfaceConfig) => {

--- a/src/containers/SettingsMenu.js
+++ b/src/containers/SettingsMenu.js
@@ -10,11 +10,9 @@ import { actionCreators as mockActions } from '../ducks/modules/mock';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import { actionCreators as modalActions } from '../ducks/modules/modals';
 import { actionCreators as sessionActions } from '../ducks/modules/session';
-import { getNetwork } from '../selectors/interface';
 import { anySessionIsActive, settingsMenuIsOpen } from '../selectors/session';
 import { isCordova, isElectron } from '../utils/Environment';
 import { Menu } from '../components';
-import createGraphML from '../utils/ExportData';
 import { Dialog } from '../containers/';
 import Updater from '../utils/Updater';
 import getVersion from '../utils/getVersion';
@@ -145,10 +143,6 @@ class SettingsMenu extends Component {
     });
   }
 
-  onExport = () => {
-    createGraphML(this.props.currentNetwork, () => this.props.openModal('EXPORT_DATA'));
-  };
-
   onQuit = () => {
     if (isCordova()) {
       // cordova
@@ -188,7 +182,6 @@ class SettingsMenu extends Component {
 
     const items = [
       { id: 'main-menu', label: 'Return to Start', icon: 'menu-quit', onClick: this.props.endSession },
-      { id: 'export', label: 'Download Data', icon: 'menu-download-data', onClick: this.onExport },
       { id: 'reset', label: 'Reset All Data', icon: 'menu-purge-data', onClick: this.onReset },
       ...customItems,
     ];
@@ -234,16 +227,6 @@ class SettingsMenu extends Component {
       >
         <div style={{ position: 'fixed', top: 0, right: 0, display: 'inline', padding: '10px', zIndex: 1000 }}>{ version }</div>
         <Dialog
-          name="EXPORT_DATA"
-          title="Export Error"
-          type="error"
-          hasCancelButton={false}
-          confirmLabel="Okay"
-          onConfirm={() => {}}
-        >
-          <p>There was a problem exporting your data.</p>
-        </Dialog>
-        <Dialog
           name="CONFIRM_DELETE_DATA"
           title="Delete ALL data?"
           type="warning"
@@ -273,7 +256,6 @@ class SettingsMenu extends Component {
 
 SettingsMenu.propTypes = {
   addMockNodes: PropTypes.func.isRequired,
-  currentNetwork: PropTypes.object.isRequired,
   customItems: PropTypes.array.isRequired,
   endSession: PropTypes.func.isRequired,
   hideButton: PropTypes.bool,
@@ -294,7 +276,6 @@ function mapStateToProps(state) {
   return {
     customItems: state.menu.customMenuItems,
     isOpen: settingsMenuIsOpen(state),
-    currentNetwork: getNetwork(state),
     sessionExists: anySessionIsActive(state),
   };
 }

--- a/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
+++ b/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
@@ -27,8 +27,6 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "class",
     "props": Object {
-      "defaultServer": null,
-      "exportSession": [Function],
       "getSessionPath": [Function],
       "loadSession": [Function],
       "removeSession": [Function],
@@ -97,8 +95,6 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "defaultServer": null,
-        "exportSession": [Function],
         "getSessionPath": [Function],
         "loadSession": [Function],
         "removeSession": [Function],

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -9,7 +9,6 @@ import environments from '../../../utils/environments';
 import { getEnvironment } from '../../../utils/Environment';
 
 jest.mock('../../../utils/protocol/index');
-jest.mock('../../../utils/uuid');
 
 const initialState = {
   isLoaded: false,

--- a/src/selectors/__tests__/skip-logic.test.js
+++ b/src/selectors/__tests__/skip-logic.test.js
@@ -2,6 +2,10 @@
 
 import { getNextIndex, isStageSkipped } from '../skip-logic';
 
+import { stages as getStages } from '../session';
+
+jest.mock('../session');
+
 const mockState = {
   session: 'a',
   sessions: {
@@ -172,6 +176,10 @@ const mockState = {
 };
 
 describe('skip-logic selector', () => {
+  beforeAll(() => {
+    getStages.mockImplementation(() => mockState.protocol.stages);
+  });
+
   describe('getNextIndex()', () => {
     it('returns the index if valid', () => {
       const index = getNextIndex(1)(mockState);

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -21,13 +21,12 @@ const propStageId = (_, props) => props.stage.id;
 const propPromptId = (_, props) => props.prompt.id;
 
 // State selectors
+export const getCurrentSession = state => state.sessions[state.session];
 
 // MemoedSelectors
-
 export const getNetwork = createDeepEqualSelector(
-  state => (state.sessions[state.session] && state.sessions[state.session].network) ||
-    { nodes: [], edges: [] },
-  network => network,
+  getCurrentSession,
+  session => (session && session.network) || { nodes: [], edges: [] },
 );
 
 export const networkNodes = createDeepEqualSelector(

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -1,9 +1,12 @@
 /* eslint-disable no-shadow */
 import { createSelector } from 'reselect';
 
+import uuidv4 from '../utils/uuid';
 import { initialState } from '../ducks/modules/session';
 
 const DefaultFinishStage = {
+  // `id` is used as component key; must be unique from user input
+  id: uuidv4(),
   type: 'FinishSession',
   label: 'Finish Interview',
 };

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -9,6 +9,7 @@ const DefaultFinishStage = {
 };
 
 const protocol = state => state.protocol;
+const withFinishStage = stages => (stages.length ? [...stages, DefaultFinishStage] : []);
 
 export const anySessionIsActive = state => state.session && state.session !== initialState;
 export const settingsMenuIsOpen = state => state.menu.settingsMenuIsOpen;
@@ -22,7 +23,7 @@ export const getPromptForCurrentSession = createSelector(
 
 export const stages = createSelector(
   protocol,
-  protocol => [...protocol.stages, DefaultFinishStage],
+  protocol => withFinishStage(protocol.stages),
 );
 
 export const filteredStages = createSelector(

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -3,6 +3,11 @@ import { createSelector } from 'reselect';
 
 import { initialState } from '../ducks/modules/session';
 
+const DefaultFinishStage = {
+  type: 'FinishSession',
+  label: 'Finish Interview',
+};
+
 const protocol = state => state.protocol;
 
 export const anySessionIsActive = state => state.session && state.session !== initialState;
@@ -17,7 +22,7 @@ export const getPromptForCurrentSession = createSelector(
 
 export const stages = createSelector(
   protocol,
-  protocol => protocol.stages,
+  protocol => [...protocol.stages, DefaultFinishStage],
 );
 
 export const filteredStages = createSelector(

--- a/src/styles/containers/_all.scss
+++ b/src/styles/containers/_all.scss
@@ -1,4 +1,5 @@
 @import 'app';
+@import 'finish-session-interface';
 @import 'interfaces';
 @import 'name-generator-interface';
 @import 'name-generator-auto-complete-interface';

--- a/src/styles/containers/_finish-session-interface.scss
+++ b/src/styles/containers/_finish-session-interface.scss
@@ -1,0 +1,31 @@
+.finish-session-interface {
+  align-items: center;
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+
+  &__frame {
+    max-width: 800px;
+    width: 100%;
+  }
+
+  &__title {
+    text-align: center;
+  }
+
+  &__section {
+    margin-top: spacing(large);
+    padding-bottom: spacing(medium);
+    padding-top: spacing(medium);
+
+    &--export {
+      border-top: 1px solid var(--color-white);
+      display: flex;
+      justify-content: space-between;
+    }
+
+    &--buttons {
+      text-align: center;
+    }
+  }
+}

--- a/src/styles/containers/_finish-session-interface.scss
+++ b/src/styles/containers/_finish-session-interface.scss
@@ -14,12 +14,12 @@
   }
 
   &__section {
-    margin-top: spacing(large);
-    padding-bottom: spacing(medium);
-    padding-top: spacing(medium);
+    margin-top: spacing(medium);
+    padding-bottom: spacing(small);
+    padding-top: spacing(small);
 
-    &--export {
-      border-top: 1px solid var(--color-white);
+    &--export,
+    &--download {
       display: flex;
       justify-content: space-between;
     }

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -6,7 +6,7 @@ const ApiErrorStatus = 'error';
 
 // Error message to display when there's no usable message from server
 const UnexpectedResponseMessage = 'Unexpected Response';
-const NoResponseMessage = 'Unexpected Response';
+const NoResponseMessage = 'Server could not be reached';
 
 // A throwable 'friendly' error containing message from server
 const apiError = (respJson) => {


### PR DESCRIPTION
Resolves #544.

- Adds a built-in 'Finish' interface to the end of all sessions
- Move 'export' functionality this interface
- Move 'download data' from menu to this interface
- Update session cards to display 'exported at' times

Notes:
- 'Download' always appears
- there are variants of Export display, but button only appears if a Server is paired & the session is exportable (has a remote protocol ID)


<img width="1015" alt="finish" src="https://user-images.githubusercontent.com/39674/41812711-d226881e-76f5-11e8-9473-c5c192d0ec9d.png">

<img width="770" alt="session-cards" src="https://user-images.githubusercontent.com/39674/41812713-d5455e3a-76f5-11e8-94d5-4b48355c5b9b.png">

