### PR TITLE
Fix/app menu items

### DIFF
--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -67,6 +67,12 @@ function createWindow() {
   });
 }
 
+function reopenMainWindow() {
+  if (mainWindow === null) {
+    createWindow();
+  }
+}
+
 function createMenu() {
   const template = [
     {
@@ -117,7 +123,20 @@ function createMenu() {
       ]
     }
   ];
-  if (!isMacOS()) {
+  if (isMacOS()) {
+    template.push({
+      role: 'window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'close' },
+        { type: 'separator' },
+        {
+          label: 'Main Window',
+          click: reopenMainWindow
+        }
+      ]
+    });
+  } else {
     template[0].label = 'File';
   }
 
@@ -142,10 +161,6 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('activate', () => {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow();
-  }
-});
+// On OS X it's common to re-create a window in the app when the
+// dock icon is clicked and there are no other windows open.
+app.on('activate', reopenMainWindow);

--- a/src/containers/SettingsMenu.js
+++ b/src/containers/SettingsMenu.js
@@ -212,7 +212,7 @@ class SettingsMenu extends Component {
       items.push({ id: 'toggle-dev-tools', label: 'Toggle DevTools', onClick: this.toggleDevTools });
     }
 
-    if (isElectron() || (navigator.app && navigator.app.exitApp)) {
+    if (!isCordova() || (navigator.app && navigator.app.exitApp)) {
       items.push({ id: 'quit', label: 'Quit Network Canvas', icon: 'menu-quit', onClick: this.onQuit });
     }
 

--- a/src/containers/SettingsMenu.js
+++ b/src/containers/SettingsMenu.js
@@ -151,8 +151,10 @@ class SettingsMenu extends Component {
 
   onQuit = () => {
     if (isCordova()) {
-      // cordova
-      navigator.app.exitApp();
+      // Android supports exiting
+      if (navigator.app && navigator.app.exitApp) {
+        navigator.app.exitApp();
+      }
     } else {
       // note: this will only close windows opened by the app, not a new tab the user opened
       window.close();
@@ -210,7 +212,9 @@ class SettingsMenu extends Component {
       items.push({ id: 'toggle-dev-tools', label: 'Toggle DevTools', onClick: this.toggleDevTools });
     }
 
-    items.push({ id: 'quit', label: 'Quit Network Canvas', icon: 'menu-quit', onClick: this.onQuit });
+    if (isElectron() || (navigator.app && navigator.app.exitApp)) {
+      items.push({ id: 'quit', label: 'Quit Network Canvas', icon: 'menu-quit', onClick: this.onQuit });
+    }
 
     items.map((item) => {
       const temp = item;


### PR DESCRIPTION
- Fixes #486: [iOS] Remove "Quit" menu item causing crash
- Resolves #487: [macOS] Add window menu with standard controls + item to re-open main window