### PR TITLE
Remove looping on swiper

### DIFF
--- a/src/containers/Setup/ProtocolList.js
+++ b/src/containers/Setup/ProtocolList.js
@@ -48,7 +48,7 @@ class ProtocolList extends Component {
         nextEl: '.swiper-button-next.swiper-button-white',
         prevEl: '.swiper-button-prev.swiper-button-white',
       },
-      loop: true,
+      loop: false,
       shouldSwiperUpdate: true,
       rebuildOnUpdate: true,
     };

--- a/src/styles/containers/_protocol-list.scss
+++ b/src/styles/containers/_protocol-list.scss
@@ -6,4 +6,8 @@
     align-items: center;
     justify-content: center;
   }
+
+  &.swiper-container {
+    width: 100%; // ensure Swiper plugin initializes layout correctly
+  }
 }


### PR DESCRIPTION
Looped nodes are cloned in DOM (outside of React). Fixes #557.

This removes looping from the protocol list. I experimented unsuccessfully with other settings in [swiper](http://idangero.us/swiper/api/). I'd like to avoid additional event handling outside of React, but if looping is required, then I can add that as described in the issue.