### PR TITLE
Use larger viewBox for Safari

### DIFF
--- a/src/components/Edge.js
+++ b/src/components/Edge.js
@@ -7,15 +7,15 @@ const getEdgeColor = makeGetEdgeColor();
 
 export class Edge extends PureComponent {
   render() {
-    const { from, to, color } = this.props;
+    const { from, to, color, viewBoxScale } = this.props;
     if (!from || !to) { return null; }
 
     return (
       <line
-        x1={from.x}
-        y1={from.y}
-        x2={to.x}
-        y2={to.y}
+        x1={from.x * viewBoxScale}
+        y1={from.y * viewBoxScale}
+        x2={to.x * viewBoxScale}
+        y2={to.y * viewBoxScale}
         stroke={`var(--${color})`}
       />
     );
@@ -32,6 +32,7 @@ Edge.propTypes = {
   color: PropTypes.string,
   from: PropTypes.object.isRequired,
   to: PropTypes.object.isRequired,
+  viewBoxScale: PropTypes.number.isRequired,
   /* eslint-disable react/no-unused-prop-types */
   type: PropTypes.string.isRequired,
 };

--- a/src/containers/ConcentricCircles/EdgeLayout.js
+++ b/src/containers/ConcentricCircles/EdgeLayout.js
@@ -4,6 +4,8 @@ import { connect } from 'react-redux';
 import { Edge } from '../../components';
 import { makeDisplayEdgesForPrompt } from '../../selectors/sociogram';
 
+const viewBoxScale = 100;
+
 export class EdgeLayout extends PureComponent {
   static propTypes = {
     displayEdges: PropTypes.array,
@@ -13,13 +15,15 @@ export class EdgeLayout extends PureComponent {
     displayEdges: [],
   };
 
-  renderEdge = ({ key, from, to, type }) => (<Edge key={key} from={from} to={to} type={type} />);
+  renderEdge = ({ key, from, to, type }) => (
+    <Edge key={key} from={from} to={to} type={type} viewBoxScale={viewBoxScale} />
+  );
 
   render() {
     const { displayEdges } = this.props;
     return (
       <div className="edge-layout">
-        <svg viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+        <svg viewBox={`0 0 ${viewBoxScale} ${viewBoxScale}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
           { displayEdges.map(this.renderEdge) }
         </svg>
       </div>

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/EdgeLayout.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/EdgeLayout.test.js.snap
@@ -42,7 +42,7 @@ ShallowWrapper {
     "props": Object {
       "children": <svg
         preserveAspectRatio="none"
-        viewBox="0 0 1 1"
+        viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"
       />,
       "className": "edge-layout",
@@ -55,7 +55,7 @@ ShallowWrapper {
       "props": Object {
         "children": Array [],
         "preserveAspectRatio": "none",
-        "viewBox": "0 0 1 1",
+        "viewBox": "0 0 100 100",
         "xmlns": "http://www.w3.org/2000/svg",
       },
       "ref": null,
@@ -72,7 +72,7 @@ ShallowWrapper {
       "props": Object {
         "children": <svg
           preserveAspectRatio="none"
-          viewBox="0 0 1 1"
+          viewBox="0 0 100 100"
           xmlns="http://www.w3.org/2000/svg"
         />,
         "className": "edge-layout",
@@ -85,7 +85,7 @@ ShallowWrapper {
         "props": Object {
           "children": Array [],
           "preserveAspectRatio": "none",
-          "viewBox": "0 0 1 1",
+          "viewBox": "0 0 100 100",
           "xmlns": "http://www.w3.org/2000/svg",
         },
         "ref": null,


### PR DESCRIPTION
Fixes #398.

I'm not sure exactly what the issue was here — seems like a loss of precision until a full repaint is done — but using a larger viewBox seems to make iOS happy. I've tested iOS 11.4 sim [edit: and device (iPad Air)].