### PR TITLE
Update redux for protocols & sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ Troubleshooting:
 - If a dev cordova build is interrupted, you may find that `config.xml` has changes, and that there's a `config.xml.original` file (ignored by git). You may restore the contents of `config.xml` from git or the original, and delete the '.original' file.
 - The webpack dev server writes a `.devserver` file on startup, which is removed when it exits. The file is used by the cordova dev build; it should contain the LAN URL of the running dev server.
 
+### Dev tools
+
+Electron supports [extensions to Chrome devtools](https://electronjs.org/docs/tutorial/devtools-extension) such as Redux DevTools.
+
+In the development environment, these will be loaded if you provide one or more paths to your extensions (semicolon-separated) in the `NC_DEVTOOLS_EXENSION_PATH` environment variable. The electron docs describe how to find the filepath for an extension once installed.
+
+Example: enabling Redux Devtools on macOS:
+```bash
+NC_DEVTOOLS_EXENSION_PATH=~/Library/Application\ Support/Google/Chrome/Default/Extensions/lmhkpmbekcpmknklioeibfkpmmfibljd/2.15.2_0 npm run electron:dev
+```
+
 ## Application Structure
 
 ```

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -144,12 +144,21 @@ function createMenu() {
   Menu.setApplicationMenu(appMenu);
 }
 
+function loadDevToolsExtensions() {
+  const extensions = process.env.NC_DEVTOOLS_EXENSION_PATH;
+  if (process.env.NODE_ENV !== 'development' || !extensions) {
+    return;
+  }
+  extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   createMenu();
   createWindow();
+  loadDevToolsExtensions();
 });
 
 // Quit when all windows are closed.

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -10,7 +10,9 @@ import { Button } from '../../ui/components';
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { actionCreators as modalActions } from '../../ducks/modules/modals';
-import { getCurrentSession, getNetwork } from '../../selectors/interface';
+import { getNetwork } from '../../selectors/interface';
+import { getCurrentSession } from '../../selectors/session';
+import { getRemoteProtocolId } from '../../selectors/protocol';
 
 const ExportSection = ({ defaultServer, children }) => (
   <div className="finish-session-interface__section finish-session-interface__section--export">
@@ -59,7 +61,7 @@ class FinishSession extends Component {
   }
 
   get currentSessionBelongsToProtocol() {
-    return !!this.props.currentSession.protocolIdentifier;
+    return !!this.props.remoteProtocolId;
   }
 
   get currentSessionisExportable() {
@@ -67,11 +69,10 @@ class FinishSession extends Component {
   }
 
   export(currentSession) {
-    const { sessionId } = this.props;
+    const { remoteProtocolId, sessionId } = this.props;
     const sessionData = currentSession.network;
-    const protocolIdentifier = currentSession.protocolIdentifier;
     if (this.serverApiUrl) {
-      this.props.exportSession(this.serverApiUrl, protocolIdentifier, sessionId, sessionData);
+      this.props.exportSession(this.serverApiUrl, remoteProtocolId, sessionId, sessionData);
     }
   }
 
@@ -131,11 +132,13 @@ FinishSession.propTypes = {
   endSession: PropTypes.func.isRequired,
   exportSession: PropTypes.func.isRequired,
   openModal: PropTypes.func.isRequired,
+  remoteProtocolId: PropTypes.string,
   sessionId: PropTypes.string.isRequired,
 };
 
 FinishSession.defaultProps = {
   defaultServer: null,
+  remoteProtocolId: null,
 };
 
 ExportSection.propTypes = {
@@ -147,6 +150,7 @@ function mapStateToProps(state) {
   return {
     currentNetwork: getNetwork(state),
     currentSession: getCurrentSession(state),
+    remoteProtocolId: getRemoteProtocolId(state),
     sessionId: state.session,
     defaultServer: state.servers && state.servers.paired[0],
   };

--- a/src/containers/Interfaces/__tests__/FinishSession.test.js
+++ b/src/containers/Interfaces/__tests__/FinishSession.test.js
@@ -15,8 +15,9 @@ describe('the Finish Interface', () => {
 
   beforeEach(() => {
     mockProps = {
-      currentSession: { protocolIdentifier: '1' },
+      currentSession: {},
       defaultServer: { apiUrl: 'x.x.x.x' },
+      remoteProtocolId: 'mockProtocolId',
     };
   });
 
@@ -37,7 +38,7 @@ describe('the Finish Interface', () => {
   });
 
   it('Skips the export button when session is not exportable', () => {
-    mockProps.currentSession.protocolIdentifier = null;
+    mockProps.remoteProtocolId = null;
     const elem = shallow(<FinishSession {...mockProps} />);
     expect(elem.find('Button').filterWhere(b => b.prop('children') === 'Export')).toHaveLength(0);
   });

--- a/src/containers/LoadParamsRoute.js
+++ b/src/containers/LoadParamsRoute.js
@@ -34,7 +34,7 @@ class LoadParamsRoute extends Component {
       if (params.protocolType === 'factory') {
         this.props.loadFactoryProtocol(params.protocolId);
       } else {
-        this.props.loadProtocol(params.protocolId, params.sessionId);
+        this.props.loadProtocol(params.protocolId);
       }
     }
   }

--- a/src/containers/Setup/ProtocolList.js
+++ b/src/containers/Setup/ProtocolList.js
@@ -13,25 +13,15 @@ import { actionCreators as sessionsActions } from '../../ducks/modules/sessions'
   */
 class ProtocolList extends Component {
   onClickNewProtocol = (protocol) => {
-    if (!(protocol.type || protocol.path)) {
+    if (!(protocol.isFactoryProtocol || protocol.path)) {
       return;
     }
 
-    if (protocol.type === 'factory') {
-      this.loadFactoryProtocol(protocol.path);
-    } else {
-      this.loadRemoteProtocol(protocol.path, protocol.remoteId);
-    }
-  }
-
-  loadFactoryProtocol = (protocolPath) => {
     this.props.addSession();
-    this.props.loadFactoryProtocol(protocolPath);
-  }
-
-  loadRemoteProtocol = (protocolPath, remoteId) => {
-    if (protocolPath) {
-      this.props.loadProtocol(protocolPath, null, remoteId);
+    if (protocol.isFactoryProtocol) {
+      this.props.loadFactoryProtocol(protocol.path);
+    } else if (protocol.path) {
+      this.props.loadProtocol(protocol.path);
     }
   }
 

--- a/src/containers/Setup/ProtocolUrlForm.js
+++ b/src/containers/Setup/ProtocolUrlForm.js
@@ -23,7 +23,7 @@ const formConfig = {
 };
 
 const initialValues = {
-  protocol_url: 'https://github.com/codaco/example-protocols/raw/master/packaged/demo.netcanvas',
+  protocol_url: 'https://github.com/codaco/example-protocols/raw/957429a/packaged/demo.netcanvas',
 };
 
 class ProtocolUrlForm extends Component {

--- a/src/containers/Setup/ProtocolUrlForm.js
+++ b/src/containers/Setup/ProtocolUrlForm.js
@@ -7,6 +7,7 @@ import { push } from 'react-router-redux';
 import Form from '../Form';
 import { Button, Icon } from '../../ui/components';
 import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 
 const formConfig = {
   formName: 'setup',
@@ -28,6 +29,7 @@ const initialValues = {
 class ProtocolUrlForm extends Component {
   onClickImportRemoteProtocol = (fields) => {
     if (fields) {
+      this.props.addSession();
       this.props.downloadProtocol(fields.protocol_url);
       this.props.handleProtocolUpdate();
     }
@@ -55,6 +57,7 @@ class ProtocolUrlForm extends Component {
 }
 
 ProtocolUrlForm.propTypes = {
+  addSession: PropTypes.func.isRequired,
   downloadProtocol: PropTypes.func.isRequired,
   handleProtocolUpdate: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
@@ -62,6 +65,7 @@ ProtocolUrlForm.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   return {
+    addSession: bindActionCreators(sessionsActions.addSession, dispatch),
     downloadProtocol: bindActionCreators(protocolActions.downloadProtocol, dispatch),
     handleProtocolUpdate: () => {
       dispatch(push('/'));

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -6,6 +6,7 @@ import { Redirect } from 'react-router-dom';
 
 import ApiClient from '../../utils/ApiClient';
 import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { ServerProtocolList, ServerSetup } from '../../components/Setup';
 
 class ServerProtocols extends Component {
@@ -38,7 +39,7 @@ class ServerProtocols extends Component {
     }
 
     const { protocols } = this.state;
-    const { server, downloadProtocol } = this.props;
+    const { addSession, server, downloadProtocol } = this.props;
 
     return (
       <ServerSetup server={server}>
@@ -46,7 +47,10 @@ class ServerProtocols extends Component {
           protocols &&
           <ServerProtocolList
             protocols={protocols}
-            selectProtocol={p => downloadProtocol(p.downloadUrl, p.id)}
+            selectProtocol={(p) => {
+              addSession();
+              downloadProtocol(p.downloadUrl);
+            }}
           />
         }
       </ServerSetup>
@@ -60,6 +64,7 @@ ServerProtocols.defaultProps = {
 };
 
 ServerProtocols.propTypes = {
+  addSession: PropTypes.func.isRequired,
   downloadProtocol: PropTypes.func.isRequired,
   downloadProtocolFailed: PropTypes.func.isRequired,
   isProtocolLoaded: PropTypes.bool.isRequired,
@@ -83,6 +88,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
+    addSession: bindActionCreators(sessionsActions.addSession, dispatch),
     downloadProtocol: bindActionCreators(protocolActions.downloadProtocol, dispatch),
     downloadProtocolFailed: bindActionCreators(protocolActions.downloadProtocolFailed, dispatch),
   };

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { push } from 'react-router-redux';
-import { Link, matchPath } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { CardList } from '../../components';
+import { matchSessionPath } from '../../utils/matchSessionPath';
 
 const shortUid = uid => (uid || '').replace(/-.*/, '');
 
@@ -18,7 +19,7 @@ const oneBasedIndex = i => parseInt(i || 0, 10) + 1;
 
 const pathInfo = (sessionPath) => {
   const info = { path: sessionPath };
-  const matchedPath = matchPath(sessionPath, { path: '/session/:sessionId/:protocolType/:protocolId/:stageIndex' });
+  const matchedPath = matchSessionPath(sessionPath);
   if (matchedPath) {
     info.sessionId = matchedPath.params.sessionId;
     info.protocol = matchedPath.params.protocolId;

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -54,13 +54,15 @@ class SessionList extends Component {
   render() {
     const { protocolData, removeSession, sessions } = this.props;
 
-    if (isEmpty(sessions)) {
+    // Display most recent first, and filter out any session that doesn't have a protocol
+    const sessionList = Object.keys(sessions)
+      .map(key => ({ uid: key, value: sessions[key] }))
+      .filter(s => s.value.protocolPath);
+    sessionList.sort((a, b) => b.value.updatedAt - a.value.updatedAt);
+
+    if (isEmpty(sessionList)) {
       return emptyView;
     }
-
-    // Display most recent first
-    const sessionList = Object.keys(sessions).map(key => ({ uid: key, value: sessions[key] }));
-    sessionList.sort((a, b) => b.value.updatedAt - a.value.updatedAt);
 
     return (
       <React.Fragment>

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -81,9 +81,10 @@ class SessionList extends Component {
             const info = pathInfo(session.path);
             const exportedAt = session.lastExportedAt;
             const exportedDisplay = exportedAt ? new Date(exportedAt).toLocaleString() : 'never';
-            const proto = protocolData[session.protocolPath] || {};
+            const protocol = protocolData[session.protocolPath] || {};
+            const protocolLabel = protocol.name || '[version out of date]';
             return [
-              { Protocol: proto.name },
+              { Protocol: protocolLabel },
               { 'Last Changed': displayDate(session.updatedAt) },
               { Stage: oneBasedIndex(info.stageIndex) },
               { Prompt: oneBasedIndex(session.promptIndex) },

--- a/src/containers/Setup/SessionList.js
+++ b/src/containers/Setup/SessionList.js
@@ -8,6 +8,7 @@ import { isEmpty } from 'lodash';
 
 import { actionCreators as sessionActions } from '../../ducks/modules/session';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
+import { protocolsByPath } from '../../selectors/protocols';
 import { CardList } from '../../components';
 import { matchSessionPath } from '../../utils/matchSessionPath';
 
@@ -51,7 +52,7 @@ class SessionList extends Component {
   }
 
   render() {
-    const { removeSession, sessions } = this.props;
+    const { protocolData, removeSession, sessions } = this.props;
 
     if (isEmpty(sessions)) {
       return emptyView;
@@ -76,16 +77,18 @@ class SessionList extends Component {
           nodes={sessionList}
           onToggleCard={this.onClickLoadSession}
           details={(sessionInfo) => {
-            const info = pathInfo(sessionInfo.value.path);
-            const exportedAt = sessionInfo.value.lastExportedAt;
+            const session = sessionInfo.value;
+            const info = pathInfo(session.path);
+            const exportedAt = session.lastExportedAt;
             const exportedDisplay = exportedAt ? new Date(exportedAt).toLocaleString() : 'never';
+            const proto = protocolData[session.protocolPath] || {};
             return [
-              { Protocol: shortUid(info.protocol) },
-              { 'Last Changed': displayDate(sessionInfo.value.updatedAt) },
+              { Protocol: proto.name },
+              { 'Last Changed': displayDate(session.updatedAt) },
               { Stage: oneBasedIndex(info.stageIndex) },
-              { Prompt: oneBasedIndex(sessionInfo.value.promptIndex) },
-              { 'Number of Nodes': sessionInfo.value.network.nodes.length },
-              { 'Number of Edges': sessionInfo.value.network.edges.length },
+              { Prompt: oneBasedIndex(session.promptIndex) },
+              { 'Number of Nodes': session.network.nodes.length },
+              { 'Number of Edges': session.network.edges.length },
               { Exported: exportedDisplay },
             ];
           }}
@@ -98,6 +101,7 @@ class SessionList extends Component {
 SessionList.propTypes = {
   getSessionPath: PropTypes.func.isRequired,
   loadSession: PropTypes.func.isRequired,
+  protocolData: PropTypes.object.isRequired,
   removeSession: PropTypes.func.isRequired,
   sessions: PropTypes.object.isRequired,
   setSession: PropTypes.func.isRequired,
@@ -105,6 +109,7 @@ SessionList.propTypes = {
 
 function mapStateToProps(state) {
   return {
+    protocolData: protocolsByPath(state),
     getSessionPath: sessionId => state.sessions[sessionId].path,
     sessions: state.sessions,
   };

--- a/src/containers/Setup/__tests__/ProtocolList.test.js
+++ b/src/containers/Setup/__tests__/ProtocolList.test.js
@@ -12,7 +12,7 @@ const mockProps = {
   loadProtocol: jest.fn(),
 };
 
-const mockProtocols = [{ name: 'Sample', path: 'sample.netcanvas', type: 'factory' }];
+const mockProtocols = [{ name: 'Sample', path: 'sample.netcanvas', isFactoryProtocol: true }];
 
 const mockStore = () =>
   createStore(() => ({
@@ -35,16 +35,16 @@ describe('<ProtocolList />', () => {
       mockProps.loadProtocol.mockClear();
     });
 
-    it('loads a remote protocol', () => {
+    it('loads a factory protocol', () => {
       wrapper.instance().onClickNewProtocol(mockProtocols[0]);
       expect(mockProps.loadFactoryProtocol).toHaveBeenCalled();
     });
 
     it('loads a remote protocol', () => {
-      const protocol = { ...mockProtocols[0], type: 'download', remoteId: '1' };
+      const protocol = { ...mockProtocols[0], isFactoryProtocol: undefined };
       wrapper.instance().onClickNewProtocol(protocol);
       expect(mockProps.loadFactoryProtocol).not.toHaveBeenCalled();
-      expect(mockProps.loadProtocol).toHaveBeenCalledWith(protocol.path, null, protocol.remoteId);
+      expect(mockProps.loadProtocol).toHaveBeenCalledWith(protocol.path);
     });
   });
 });

--- a/src/containers/Setup/__tests__/SessionList.test.js
+++ b/src/containers/Setup/__tests__/SessionList.test.js
@@ -7,6 +7,7 @@ import { createStore } from 'redux';
 import SessionList from '../SessionList';
 
 const mockReduxState = {
+  protocols: [],
   sessions: { a: { name: 'a name', network: { nodes: [0, 1, 2], edges: [0] }, path: '/path/to/a', promptIndex: 2, updatedAt: 1528213062793 },
     b: { name: 'b name', network: { nodes: [], edges: [] }, path: '/path/to/b', promptIndex: 1, updatedAt: 1528218451710 } },
 };

--- a/src/containers/Setup/__tests__/SessionList.test.js
+++ b/src/containers/Setup/__tests__/SessionList.test.js
@@ -8,8 +8,10 @@ import SessionList from '../SessionList';
 
 const mockReduxState = {
   protocols: [],
-  sessions: { a: { name: 'a name', network: { nodes: [0, 1, 2], edges: [0] }, path: '/path/to/a', promptIndex: 2, updatedAt: 1528213062793 },
-    b: { name: 'b name', network: { nodes: [], edges: [] }, path: '/path/to/b', promptIndex: 1, updatedAt: 1528218451710 } },
+  sessions: {
+    a: { protocolPath: 'p', name: 'a name', network: { nodes: [0, 1, 2], edges: [0] }, path: '/path/to/a', promptIndex: 2, updatedAt: 1528213062793 },
+    b: { protocolPath: 'p', name: 'b name', network: { nodes: [], edges: [] }, path: '/path/to/b', promptIndex: 1, updatedAt: 1528218451710 },
+  },
 };
 
 describe('<SessionList />', () => {
@@ -18,9 +20,16 @@ describe('<SessionList />', () => {
     expect(component).toMatchSnapshot();
   });
 
-  const somestore = createStore(() => mockReduxState);
-  const component = mount(<SessionList store={somestore} />);
   it('shows sessions as cards', () => {
+    const component = mount(<SessionList store={createStore(() => mockReduxState)} />);
     expect(component.find('.card').length).toBe(2);
+  });
+
+  it('hides sessions without protocols', () => {
+    const validSessions = mockReduxState.sessions;
+    const invalidSession = { name: 'no-protocol' };
+    const state = { protocols: [], sessions: { ...validSessions, invalidSession } };
+    const component = mount(<SessionList store={createStore(() => state)} />);
+    expect(component.find('.card').length).toBe(Object.values(validSessions).length);
   });
 });

--- a/src/containers/Setup/__tests__/__snapshots__/ProtocolList.test.js.snap
+++ b/src/containers/Setup/__tests__/__snapshots__/ProtocolList.test.js.snap
@@ -35,9 +35,9 @@ ShallowWrapper {
       "loadProtocol": [Function],
       "protocols": Array [
         Object {
+          "isFactoryProtocol": true,
           "name": "Sample",
           "path": "sample.netcanvas",
-          "type": "factory",
         },
       ],
       "store": Object {
@@ -81,9 +81,9 @@ ShallowWrapper {
         "loadProtocol": [Function],
         "protocols": Array [
           Object {
+            "isFactoryProtocol": true,
             "name": "Sample",
             "path": "sample.netcanvas",
-            "type": "factory",
           },
         ],
         "store": Object {

--- a/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
+++ b/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
@@ -29,6 +29,7 @@ ShallowWrapper {
     "props": Object {
       "getSessionPath": [Function],
       "loadSession": [Function],
+      "protocolData": Object {},
       "removeSession": [Function],
       "sessions": Object {
         "a": Object {
@@ -97,6 +98,7 @@ ShallowWrapper {
       "props": Object {
         "getSessionPath": [Function],
         "loadSession": [Function],
+        "protocolData": Object {},
         "removeSession": [Function],
         "sessions": Object {
           "a": Object {

--- a/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
+++ b/src/containers/Setup/__tests__/__snapshots__/SessionList.test.js.snap
@@ -46,6 +46,7 @@ ShallowWrapper {
           },
           "path": "/path/to/a",
           "promptIndex": 2,
+          "protocolPath": "p",
           "updatedAt": 1528213062793,
         },
         "b": Object {
@@ -56,6 +57,7 @@ ShallowWrapper {
           },
           "path": "/path/to/b",
           "promptIndex": 1,
+          "protocolPath": "p",
           "updatedAt": 1528218451710,
         },
       },
@@ -115,6 +117,7 @@ ShallowWrapper {
             },
             "path": "/path/to/a",
             "promptIndex": 2,
+            "protocolPath": "p",
             "updatedAt": 1528213062793,
           },
           "b": Object {
@@ -125,6 +128,7 @@ ShallowWrapper {
             },
             "path": "/path/to/b",
             "promptIndex": 1,
+            "protocolPath": "p",
             "updatedAt": 1528218451710,
           },
         },

--- a/src/ducks/modules/__tests__/protocol.test.js
+++ b/src/ducks/modules/__tests__/protocol.test.js
@@ -59,7 +59,6 @@ describe('protocol module', () => {
         ...initialState,
         isLoaded: false,
         isLoading: true,
-        type: 'download',
       });
     });
 
@@ -75,7 +74,6 @@ describe('protocol module', () => {
         ...initialState,
         isLoaded: false,
         isLoading: true,
-        type: 'download',
       });
     });
 
@@ -160,6 +158,7 @@ describe('protocol module', () => {
       const expectedActions = [actionCreators.setProtocol(
         '/app/data/protocol/path',
         { fake: { protocol: { json: true } } },
+        false,
       )];
       return epics(action$).toArray().toPromise().then((result) => {
         expect(result).toEqual(expectedActions);
@@ -174,6 +173,7 @@ describe('protocol module', () => {
       const expectedActions = [actionCreators.setProtocol(
         'factory_protocol_name',
         { fake: { factory: { protocol: { json: true } } } },
+        true,
       )];
       return epics(action$).toArray().toPromise().then((result) => {
         expect(result).toEqual(expectedActions);

--- a/src/ducks/modules/__tests__/protocols.test.js
+++ b/src/ducks/modules/__tests__/protocols.test.js
@@ -1,30 +1,22 @@
 /* eslint-env jest */
 
-import reducer, { actionCreators, actionTypes } from '../protocols';
+import reducer from '../protocols';
 import { actionTypes as ProtocolActionTypes } from '../protocol';
 
 const initialState = [
   {
-    name: 'Education Protocol',
-    version: '4.0.0',
-    description: 'This is the education protocol.',
-    type: 'factory',
+    name: 'Teaching Protocol',
+    description: 'version 4.0.0',
     path: 'education.netcanvas',
+    isFactoryProtocol: true,
   },
   {
     name: 'Development Protocol',
-    version: '4.0.0',
-    description: 'This is the development protocol.',
-    type: 'factory',
+    description: 'version 4.0.0',
     path: 'development.netcanvas',
+    isFactoryProtocol: true,
   },
 ];
-
-const testProtocol = {
-  name: 'path',
-  path: 'path',
-  type: 'type',
-};
 
 describe('protocols reducer', () => {
   it('should return the initial state', () => {
@@ -33,44 +25,16 @@ describe('protocols reducer', () => {
     ).toEqual(initialState);
   });
 
-  it('should handle ADD_PROTOCOL', () => {
-    const newState = reducer(initialState,
-      { type: actionTypes.ADD_PROTOCOL, protocol: testProtocol });
-    expect(newState).toEqual([...initialState, testProtocol]);
-  });
-
-  describe('LOAD_PROTOCOL', () => {
-    const makeAction = attrs => ({ ...attrs, type: ProtocolActionTypes.LOAD_PROTOCOL });
-    const actionAttrs = { path: 'path', protocolType: 'download' };
-    const expectedProtocol = { name: 'path', path: 'path', type: 'download' };
-
-    it('should add a new protocol', () => {
-      const state = reducer(initialState, makeAction(actionAttrs));
-      expect(state).toContainEqual(expectedProtocol);
+  describe('SET_PROTOCOL', () => {
+    it('adds a new protocol', () => {
+      const setProtocolAction = { type: ProtocolActionTypes.SET_PROTOCOL, protocol: { name: 'new' } };
+      expect(reducer(initialState, setProtocolAction)).toHaveLength(initialState.length + 1);
     });
 
-    it('should persist remoteId if available', () => {
-      const state = reducer(initialState, makeAction({ ...actionAttrs, remoteId: '1' }));
-      expect(state).toContainEqual({ ...expectedProtocol, remoteId: '1' });
+    it('does not add an existing protocol', () => {
+      const setProtocolAction = { type: ProtocolActionTypes.SET_PROTOCOL, protocol: { name: 'new' } };
+      const newState = reducer(initialState, setProtocolAction);
+      expect(reducer(newState, setProtocolAction)).toHaveLength(newState.length);
     });
-
-    it('should not duplicate protocols with matching paths', () => {
-      let state = reducer(initialState, makeAction(actionAttrs));
-      state = reducer(state, makeAction(actionAttrs));
-      expect(state).toHaveLength(initialState.length + 1);
-    });
-
-    it('should not duplicate protocols with matching remoteIds', () => {
-      let state = reducer(initialState, makeAction({ path: '1', remoteId: '1' }));
-      state = reducer(state, makeAction({ path: '2', remoteId: '1' }));
-      expect(state).toHaveLength(initialState.length + 1);
-    });
-  });
-});
-
-describe('protocols actionCreators', () => {
-  it('should provide a method to add a protocol', () => {
-    const expectedAction = { type: actionTypes.ADD_PROTOCOL, protocol: {} };
-    expect(actionCreators.addProtocol({})).toEqual(expectedAction);
   });
 });

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -1,19 +1,33 @@
 import { combineEpics } from 'redux-observable';
 import { Observable } from 'rxjs';
 import { loadProtocol, importProtocol, downloadProtocol, loadFactoryProtocol } from '../../utils/protocol';
-import uuidv4 from '../../utils/uuid';
 import { actionTypes as SessionActionTypes } from './session';
 
+/**
+ * `protocol` maintains information about the currently-loaded protocol for session, and
+ * provides actions for downloading, importing, etc. It does a reference to data in `./protocols`.
+ *
+ * Typical action flow:
+ *
+ * 1. Download: Fetch a remote .netcanvas file from network, save to tmp dir
+ * 2. Import: extract .netcanvas contents & move files to user data dir
+ * 3. Load: Read & parse protocol.json from imported files
+ * 4. Set Protocol: store parsed protocol JSON in state
+ *   - Side effect: if this is a new protocol, persist data & metadata (see ./protocols)
+ *
+ * Notes:
+ * - As a side effect of END_SESSION, clear out the current protocol contents here
+ * - Typically, an interface will call addSession() to begin a new session before a protocol
+ *   is loaded; loading state is maintained here.
+ */
 
 const END_SESSION = SessionActionTypes.END_SESSION;
-const SET_SESSION = SessionActionTypes.SET_SESSION;
 
 const DOWNLOAD_PROTOCOL = 'PROTOCOL/DOWNLOAD_PROTOCOL';
 const DOWNLOAD_PROTOCOL_FAILED = Symbol('PROTOCOL/DOWNLOAD_PROTOCOL_FAILED');
 const IMPORT_PROTOCOL = 'PROTOCOL/IMPORT_PROTOCOL';
 const IMPORT_PROTOCOL_FAILED = Symbol('PROTOCOL/IMPORT_PROTOCOL_FAILED');
 const LOAD_PROTOCOL = 'LOAD_PROTOCOL';
-const LOAD_FACTORY_PROTOCOL = 'LOAD_FACTORY_PROTOCOL';
 const LOAD_PROTOCOL_FAILED = Symbol('LOAD_PROTOCOL_FAILED');
 const SET_PROTOCOL = 'SET_PROTOCOL';
 
@@ -38,22 +52,16 @@ export default function reducer(state = initialState, action = {}) {
         isLoaded: true,
         isLoading: false,
       };
-    case SET_SESSION:
-      if (action.protocolType) {
-        return {
-          ...state,
-          isLoaded: false,
-          isLoading: false,
-          type: action.protocolType,
-        };
-      }
-      return state;
     case END_SESSION:
       return initialState;
     case DOWNLOAD_PROTOCOL:
     case IMPORT_PROTOCOL:
+      return {
+        ...state,
+        isLoaded: false,
+        isLoading: true,
+      };
     case LOAD_PROTOCOL:
-    case LOAD_FACTORY_PROTOCOL:
       return {
         ...state,
         isLoaded: false,
@@ -73,57 +81,31 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
-function setProtocol(path, protocol) {
-  return {
-    type: SET_PROTOCOL,
-    path,
-    protocol,
-  };
-}
-
-// TODO: Simplify.
-// A "name" (in protocol.json) uniquely identifies a protocol.
-// The remoteId is a URL-safe version (digest) of this used by Servers.
-// This is different than the other identifier for a protocol: the filepath (aka path, aka id).
-// It's passed through the action chain just so it can be set on a session, which is
-// created before protocol is loaded/parsed.
-// i.e., Session export needs the protocol's remoteId (or protocol name).
-
-function downloadProtocolAction(uri, remoteId) {
+function downloadProtocolAction(uri) {
   return {
     type: DOWNLOAD_PROTOCOL,
-    protocolType: 'download',
-    remoteId,
     uri,
   };
 }
 
-function importProtocolAction(path, remoteId) {
+function importProtocolAction(path) {
   return {
     type: IMPORT_PROTOCOL,
-    protocolType: 'download',
-    remoteId,
     path,
   };
 }
 
-function loadProtocolAction(path, id, remoteId) {
-  let sessionId = id;
-  if (!id) {
-    sessionId = uuidv4();
-  }
+function loadProtocolAction(path) {
   return {
     type: LOAD_PROTOCOL,
     protocolType: 'download',
-    remoteId,
     path,
-    sessionId,
   };
 }
 
 function loadFactoryProtocolAction(path) {
   return {
-    type: LOAD_FACTORY_PROTOCOL,
+    type: LOAD_PROTOCOL,
     protocolType: 'factory',
     path,
   };
@@ -150,12 +132,21 @@ function downloadProtocolFailed(error) {
   };
 }
 
+function setProtocol(path, protocol, isFactoryProtocol) {
+  return {
+    type: SET_PROTOCOL,
+    path,
+    protocol,
+    isFactoryProtocol,
+  };
+}
+
 const downloadProtocolEpic = action$ =>
   action$.ofType(DOWNLOAD_PROTOCOL)
     .switchMap(action =>
       Observable
         .fromPromise(downloadProtocol(action.uri))
-        .map(protocolPath => importProtocolAction(protocolPath, action.remoteId))
+        .map(protocolPath => importProtocolAction(protocolPath))
         .catch(error => Observable.of(downloadProtocolFailed(error))),
     );
 
@@ -164,25 +155,27 @@ const importProtocolEpic = action$ =>
     .switchMap(action =>
       Observable
         .fromPromise(importProtocol(action.path))
-        .map(protocolFile => loadProtocolAction(protocolFile, null, action.remoteId))
+        .map(protocolFile => loadProtocolAction(protocolFile, null))
         .catch(error => Observable.of(importProtocolFailed(error))),
     );
 
 const loadProtocolEpic = action$ =>
-  action$.ofType(LOAD_PROTOCOL) // Filter for load protocol action
+  action$
+    .filter(action => action.type === LOAD_PROTOCOL && action.protocolType !== 'factory')
     .switchMap(action => // Favour subsequent load actions over earlier ones
       Observable
         .fromPromise(loadProtocol(action.path)) // Get protocol
-        .map(response => setProtocol(action.path, response)) // Parse and save
+        .map(response => setProtocol(action.path, response, false)) // Parse and save
         .catch(error => Observable.of(loadProtocolFailed(error))), //  ...or throw an error
     );
 
 const loadFactoryProtocolEpic = action$ =>
-  action$.ofType(LOAD_FACTORY_PROTOCOL) // Filter for load protocol action
+  action$
+    .filter(action => action.type === LOAD_PROTOCOL && action.protocolType === 'factory')
     .switchMap(action => // Favour subsequent load actions over earlier ones
       Observable
         .fromPromise(loadFactoryProtocol(action.path)) // Get protocol
-        .map(response => setProtocol(action.path, response)) // Parse and save
+        .map(response => setProtocol(action.path, response, true)) // Parse and save
         .catch(error => Observable.of(loadProtocolFailed(error))), //  ...or throw an error
     );
 
@@ -204,7 +197,6 @@ const actionTypes = {
   DOWNLOAD_PROTOCOL_FAILED,
   LOAD_PROTOCOL,
   LOAD_PROTOCOL_FAILED,
-  LOAD_FACTORY_PROTOCOL,
   SET_PROTOCOL,
 };
 

--- a/src/ducks/modules/protocols.js
+++ b/src/ducks/modules/protocols.js
@@ -1,73 +1,56 @@
 import { actionTypes as ProtocolActionTypes } from './protocol';
 
-const LOAD_PROTOCOL = ProtocolActionTypes.LOAD_PROTOCOL;
+/**
+ * `protocols` maintains some cached data and metadata about the protocol files available on disk.
+ *
+ * For downloaded protocols, `name` is the unique ID.
+ *
+ * As a side effect for SET_PROTOCOL (from `./protocol`), which provides the parsed protocol JSON,
+ * the store is updated.
+ */
 
-const ADD_PROTOCOL = 'ADD_PROTOCOL';
+const SET_PROTOCOL = ProtocolActionTypes.SET_PROTOCOL;
 
 const initialState = [
   {
-    name: 'Education Protocol',
-    version: '4.0.0',
-    description: 'This is the education protocol.',
-    type: 'factory',
+    name: 'Teaching Protocol',
+    description: 'version 4.0.0',
     path: 'education.netcanvas',
+    isFactoryProtocol: true,
   },
   {
     name: 'Development Protocol',
-    version: '4.0.0',
-    description: 'This is the development protocol.',
-    type: 'factory',
+    description: 'version 4.0.0',
     path: 'development.netcanvas',
+    isFactoryProtocol: true,
   },
 ];
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
-    case LOAD_PROTOCOL: {
-      // Downloaded protocols always have unique paths, so check remote ID as well.
-      const matchesCurrentAction = protocol => protocol.type === action.protocolType &&
-        (protocol.path === action.path ||
-          (protocol.remoteId && protocol.remoteId === action.remoteId));
+    case SET_PROTOCOL: {
+      // TODO: Protocol should be validated before import; this check shouldn't be needed
+      if (!action.protocol.name) { return state; }
 
-      if (state.some(matchesCurrentAction)) {
+      const exists = action.isFactoryProtocol ||
+        state.some(protocol => protocol.name === action.protocol.name);
+
+      // FIXME: should update description if that changes (for non-factory).
+      // FIXME: should update path if that changes (for non-factory).
+      if (exists) {
         return state;
       }
+
       return [
         ...state,
         {
-          name: action.path,
+          name: action.protocol.name,
+          description: action.protocol.description,
           path: action.path,
-          type: action.protocolType,
-          remoteId: action.remoteId,
         },
       ];
     }
-    case ADD_PROTOCOL:
-      return [
-        ...state,
-        action.protocol,
-      ];
     default:
       return state;
   }
 }
-
-function addProtocol(protocol) {
-  return {
-    type: ADD_PROTOCOL,
-    protocol,
-  };
-}
-
-const actionCreators = {
-  addProtocol,
-};
-
-const actionTypes = {
-  ADD_PROTOCOL,
-};
-
-export {
-  actionCreators,
-  actionTypes,
-};

--- a/src/ducks/modules/protocols.js
+++ b/src/ducks/modules/protocols.js
@@ -32,22 +32,26 @@ export default function reducer(state = initialState, action = {}) {
       // TODO: Protocol should be validated before import; this check shouldn't be needed
       if (!action.protocol.name) { return state; }
 
-      const exists = action.isFactoryProtocol ||
-        state.some(protocol => protocol.name === action.protocol.name);
+      // Do not allow updates to factory protocols
+      if (action.isFactoryProtocol) { return state; }
 
-      // FIXME: should update description if that changes (for non-factory).
-      // FIXME: should update path if that changes (for non-factory).
-      if (exists) {
-        return state;
+      const newProtocol = {
+        name: action.protocol.name,
+        description: action.protocol.description,
+        path: action.path,
+      };
+
+      const existingIndex = state.findIndex(protocol => protocol.name === newProtocol.name);
+
+      if (existingIndex > -1) {
+        const updatedState = [...state];
+        updatedState.splice(existingIndex, 1, newProtocol);
+        return updatedState;
       }
 
       return [
         ...state,
-        {
-          name: action.protocol.name,
-          description: action.protocol.description,
-          path: action.path,
-        },
+        newProtocol,
       ];
     }
     default:

--- a/src/ducks/modules/session.js
+++ b/src/ducks/modules/session.js
@@ -4,7 +4,6 @@ const ADD_SESSION = SessionsActionTypes.ADD_SESSION;
 
 const SET_SESSION = 'SET_SESSION';
 const END_SESSION = 'END_SESSION';
-const LOAD_PROTOCOL = 'LOAD_PROTOCOL';
 
 const initialState = 'CREATE_NEW';
 
@@ -12,7 +11,6 @@ export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case SET_SESSION:
     case ADD_SESSION:
-    case LOAD_PROTOCOL:
       return action.sessionId;
     case END_SESSION:
       return initialState;
@@ -21,6 +19,9 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
+/**
+ * setSession can be used to resume an interview (e.g. from GUI, or URL on load)
+ */
 function setSession(id, protocolType) {
   return {
     type: SET_SESSION,

--- a/src/selectors/__tests__/protocols.test.js
+++ b/src/selectors/__tests__/protocols.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import { protocolsByPath } from '../protocols';
+
+const mockProtocols = [
+  {
+    name: 'a',
+    path: 'aa-aa-aa',
+  },
+  {
+    name: 'b',
+    path: 'bb-bb-bb',
+  },
+];
+
+const mockState = { protocols: mockProtocols };
+
+describe('protocols selectors', () => {
+  describe('protocolsByPath', () => {
+    it('returns an object, keyed by path', () => {
+      expect(protocolsByPath(mockState)['aa-aa-aa']).toEqual(mockProtocols[0]);
+    });
+  });
+});

--- a/src/selectors/__tests__/skip-logic.test.js
+++ b/src/selectors/__tests__/skip-logic.test.js
@@ -4,8 +4,6 @@ import { getNextIndex, isStageSkipped } from '../skip-logic';
 
 import { stages as getStages } from '../session';
 
-jest.mock('../session');
-
 const mockState = {
   session: 'a',
   sessions: {
@@ -14,7 +12,7 @@ const mockState = {
         edges: [
           { id: 1, type: 'friend', to: 1, from: 2 },
         ],
-        edgo: {},
+        ego: {},
         nodes: [
           { id: 1, type: 'person', name: 'soAndSo' },
           { id: 2, type: 'person', name: 'whoDunnit' },
@@ -176,10 +174,6 @@ const mockState = {
 };
 
 describe('skip-logic selector', () => {
-  beforeAll(() => {
-    getStages.mockImplementation(() => mockState.protocol.stages);
-  });
-
   describe('getNextIndex()', () => {
     it('returns the index if valid', () => {
       const index = getNextIndex(1)(mockState);
@@ -187,7 +181,8 @@ describe('skip-logic selector', () => {
     });
 
     it('rotates the index if out of bounds', () => {
-      const index = getNextIndex(7)(mockState);
+      const stageCount = getStages(mockState).length;
+      const index = getNextIndex(stageCount)(mockState);
       expect(index).toEqual(0);
     });
   });

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 import { findKey, filter, has, reject } from 'lodash';
 import { createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
+import { getCurrentSession } from './session';
 
 // Selectors that are generic between interfaces
 
@@ -21,7 +22,6 @@ const propStageId = (_, props) => props.stage.id;
 const propPromptId = (_, props) => props.prompt.id;
 
 // State selectors
-export const getCurrentSession = state => state.sessions[state.session];
 
 // MemoedSelectors
 export const getNetwork = createDeepEqualSelector(

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -1,6 +1,13 @@
 /* eslint-disable import/prefer-default-export */
+import crypto from 'crypto';
 
 import { createDeepEqualSelector } from './utils';
+
+/**
+ * The remote protocol ID on any instance of Server is the hex-encoded sha256 of its [unique] name.
+ * Server will need to know this ID when we export/import session data.
+ */
+const nameDigest = name => name && crypto.createHash('sha256').update(name).digest('hex');
 
 export const protocolRegistry = createDeepEqualSelector(
   state => state.protocol && state.protocol.variableRegistry,
@@ -15,6 +22,11 @@ export const protocolForms = createDeepEqualSelector(
 export const getExternalData = createDeepEqualSelector(
   state => state.protocol.externalData,
   protocolData => protocolData,
+);
+
+export const getRemoteProtocolId = createDeepEqualSelector(
+  state => state.protocol && state.protocol.type !== 'factory' && state.protocol.name,
+  remoteName => nameDigest(remoteName) || null,
 );
 
 export const makeGetNodeColor = () => createDeepEqualSelector(

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 import crypto from 'crypto';
 
 import { createDeepEqualSelector } from './utils';

--- a/src/selectors/protocols.js
+++ b/src/selectors/protocols.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+import { createDeepEqualSelector } from './utils';
+
+const protocolReducer = (obj, protocol) => {
+  obj[protocol.path] = protocol; // eslint-disable-line no-param-reassign
+  return obj;
+};
+
+// @return {Object} protocol info, keyed by ID/path
+export const protocolsByPath = createDeepEqualSelector(
+  state => state.protocols.reduce(protocolReducer, {}),
+  protocolData => protocolData,
+);

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -14,6 +14,7 @@ const DefaultFinishStage = {
 const protocol = state => state.protocol;
 const withFinishStage = stages => (stages.length ? [...stages, DefaultFinishStage] : []);
 
+export const getCurrentSession = state => state.sessions[state.session];
 export const anySessionIsActive = state => state.session && state.session !== initialState;
 export const settingsMenuIsOpen = state => state.menu.settingsMenuIsOpen;
 export const stageMenuIsOpen = state => state.menu.stageMenuIsOpen;

--- a/src/utils/__tests__/matchSessionPath.test.js
+++ b/src/utils/__tests__/matchSessionPath.test.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+import { matchSessionPath, protocolIdFromSessionPath } from '../matchSessionPath';
+
+describe('session path helpers', () => {
+  const protocolId = 'protocol2';
+  const example = `/session/session1/factory/${protocolId}/0`;
+
+  describe('matchSessionPath', () => {
+    it('returns an object with matched params', () => {
+      const match = matchSessionPath(example);
+      expect(match).toHaveProperty('params');
+      expect(match.params.protocolType).toEqual('factory');
+    });
+  });
+
+  describe('protocolIdFromSessionPath', () => {
+    it('matches protocol ID (path)', () => {
+      expect(protocolIdFromSessionPath(example)).toEqual(protocolId);
+    });
+  });
+});

--- a/src/utils/matchSessionPath.js
+++ b/src/utils/matchSessionPath.js
@@ -1,0 +1,23 @@
+import { matchPath } from 'react-router-dom';
+
+const ProtocolIdKey = 'protocolId';
+
+const SessionPath = `/session/:sessionId/:protocolType/:${ProtocolIdKey}/:stageIndex`;
+
+const matchSessionPath = pathname => matchPath(pathname, { path: SessionPath });
+
+/**
+ * Get a string (ID; sometimes called 'path') which can be used to uniquely identify a protocol
+ * in state.protocols.
+ * @param {string} pathname full URL path to a session; e.g. '/session/sess1/download/protocol2/0'
+ * @return {string} the protocol's "path" (base directory name), e.g. 'protocol2'
+ */
+const protocolIdFromSessionPath = (pathname) => {
+  const pathInfo = matchSessionPath(pathname);
+  return pathInfo && pathInfo.params[ProtocolIdKey];
+};
+
+export {
+  matchSessionPath,
+  protocolIdFromSessionPath,
+};


### PR DESCRIPTION
Resolves #545. Resolves #558.

This updates redux actions (with some minor changes to state shape) to better support protocol exporting and simplify some of the import/load/set flows with sessions. This builds on the FinishSession interface branch (a merge should wait on #559), but the two can be reviewed in parallel.

This also adds support for loading devtools extensions in electron (as redux-devtools was very useful for this effort), but installation left as a manual exercise (see Readme).

### Notes on changes
- Removes some of the differences between `loadFactoryProtocol` and `loadProtocol`
  + In particular, both now make use of `addSession()`
  + ...and session IDs are no longer generated by protocol actions
  + This reduces some of the coupling, but interfaces must call addSession in both cases now. (Unwanted side-effects from programming error should be solved by #570.)
- Removes the `remoteId` that was passed through actions (to provide initial support for export). Remote IDs are now calculated locally as they are not server-specific.

### Manual testing

We don't have much integration testing yet, and there's still integration between sessions and protocols. I've gone through combinations of {protocolType} + {loadAction|exportAction}:

- Factory protocols vs Downloaded (Server- and URL-sourced) protocols
- Loading
  - existing sessions
    - via app reload
    - via 'resume interview'
  - new Sessions
    - via protocol cards (startup screen)
    - via download flows
- Exporting (or not) as expected