### PR TITLE
Add basic error boundary for stages

### DIFF
--- a/src/components/StageErrorBoundary.js
+++ b/src/components/StageErrorBoundary.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class StageErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  componentDidCatch(error) {
+    this.setState({ error });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { error } = this.state;
+    if (error) {
+      return (
+        <div className="error-boundary">
+          <h1>This stage failed to load</h1>
+          <p>The following error occurred: <code>{error.message}</code></p>
+        </div>
+      );
+    }
+    return children;
+  }
+}
+
+StageErrorBoundary.defaultProps = {
+  children: null,
+};
+
+StageErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]),
+};
+
+export default StageErrorBoundary;

--- a/src/components/__tests__/StageErrorBoundary.test.js
+++ b/src/components/__tests__/StageErrorBoundary.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import StageErrorBoundary from '../StageErrorBoundary';
+
+describe('StageErrorBoundary', () => {
+  const text = 'No error Here';
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<StageErrorBoundary>{<div>{text}</div>}</StageErrorBoundary>);
+  });
+
+  it('renders children when no error', () => {
+    expect(wrapper.text()).toEqual(text);
+  });
+
+  it('renders an error', () => {
+    const errMsg = 'Mock error';
+    wrapper.setState({ error: new Error(errMsg) });
+    expect(wrapper.text()).toContain(errMsg);
+  });
+});

--- a/src/containers/Stage.js
+++ b/src/containers/Stage.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 
-import getInterface from '../containers/Interfaces';
+import getInterface from './Interfaces';
+import StageErrorBoundary from '../components/StageErrorBoundary';
 import { stages } from '../selectors/session';
 
 /**
@@ -36,9 +37,11 @@ class Stage extends Component {
           </button>
         </div>
         <div className="stage__interface">
-          { CurrentInterface &&
-            <CurrentInterface stage={config} />
-          }
+          <StageErrorBoundary>
+            { CurrentInterface &&
+              <CurrentInterface stage={config} />
+            }
+          </StageErrorBoundary>
         </div>
         <div className="stage__control">
           <button

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -9,6 +9,7 @@
 @import 'form';
 @import 'form-wizard';
 @import 'dialog';
+@import 'error-boundary';
 @import 'react-draggable';
 @import 'draggable-preview';
 @import 'pairing-code-input';

--- a/src/styles/components/_error-boundary.scss
+++ b/src/styles/components/_error-boundary.scss
@@ -1,0 +1,7 @@
+.error-boundary {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+}


### PR DESCRIPTION
In the face of errors caused by stage loading or interaction (which is commonly happening as we update the protocol format), this allows user to continue or restart, rather than having to quit app or reset all data.

I think we've discussed using boundaries in places, but I don't see an issue filed. Apologies if this isn't what others had in mind — but it's making development with all of my [now outdated] protocol files easier.