### PR TITLE
Send token with API requests

### DIFF
--- a/src/containers/Setup/ServerPairing.js
+++ b/src/containers/Setup/ServerPairing.js
@@ -61,8 +61,7 @@ class ServerPairing extends Component {
     const { deviceName } = this.props;
     this.apiClient.confirmPairing(pairingCode, pairingRequestId, pairingRequestSalt, deviceName)
       .then((device) => {
-        // TODO: Here's the point we'd want to persist ID + secret above
-        this.props.addServer(this.props.server);
+        this.props.addServer(this.props.server, device.id, device.secret);
         this.setState({
           ...emptyState,
           pairedDeviceId: device.id,

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -16,7 +16,9 @@ class ServerProtocols extends Component {
   }
 
   componentDidMount() {
-    this.apiClient = new ApiClient(this.props.server.apiUrl);
+    const { server, pairedServers } = this.props;
+    const pairedServer = pairedServers && pairedServers.find(s => s.apiUrl === server.apiUrl);
+    this.apiClient = new ApiClient(server.apiUrl, pairedServer);
     this.fetchProtocolList();
   }
 
@@ -60,6 +62,7 @@ class ServerProtocols extends Component {
 
 ServerProtocols.defaultProps = {
   onError: () => {},
+  pairedServers: [],
   protocolPath: '',
 };
 
@@ -69,6 +72,7 @@ ServerProtocols.propTypes = {
   downloadProtocolFailed: PropTypes.func.isRequired,
   isProtocolLoaded: PropTypes.bool.isRequired,
   onError: PropTypes.func,
+  pairedServers: PropTypes.array,
   protocolPath: PropTypes.string,
   protocolType: PropTypes.string.isRequired,
   server: PropTypes.shape({
@@ -83,6 +87,7 @@ function mapStateToProps(state) {
     protocolPath: state.protocol.path,
     protocolType: state.protocol.type,
     sessionId: state.session,
+    pairedServers: state.servers.paired,
   };
 }
 

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -8,6 +8,7 @@ import ApiClient from '../../utils/ApiClient';
 import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { ServerProtocolList, ServerSetup } from '../../components/Setup';
+import { getPairedServerFactory } from '../../selectors/servers';
 
 class ServerProtocols extends Component {
   constructor(props) {
@@ -16,8 +17,8 @@ class ServerProtocols extends Component {
   }
 
   componentDidMount() {
-    const { server, pairedServers } = this.props;
-    const pairedServer = pairedServers && pairedServers.find(s => s.apiUrl === server.apiUrl);
+    const { server, getPairedServer } = this.props;
+    const pairedServer = getPairedServer(server.apiUrl);
     this.apiClient = new ApiClient(server.apiUrl, pairedServer);
     this.fetchProtocolList();
   }
@@ -62,7 +63,7 @@ class ServerProtocols extends Component {
 
 ServerProtocols.defaultProps = {
   onError: () => {},
-  pairedServers: [],
+  getPairedServer: () => {},
   protocolPath: '',
 };
 
@@ -72,7 +73,7 @@ ServerProtocols.propTypes = {
   downloadProtocolFailed: PropTypes.func.isRequired,
   isProtocolLoaded: PropTypes.bool.isRequired,
   onError: PropTypes.func,
-  pairedServers: PropTypes.array,
+  getPairedServer: PropTypes.func,
   protocolPath: PropTypes.string,
   protocolType: PropTypes.string.isRequired,
   server: PropTypes.shape({
@@ -87,7 +88,7 @@ function mapStateToProps(state) {
     protocolPath: state.protocol.path,
     protocolType: state.protocol.type,
     sessionId: state.session,
-    pairedServers: state.servers.paired,
+    getPairedServer: getPairedServerFactory(state),
   };
 }
 

--- a/src/ducks/modules/servers.js
+++ b/src/ducks/modules/servers.js
@@ -9,7 +9,12 @@ export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case ADD_SERVER:
       if (action.server) {
-        return { ...state, paired: [...state.paired, action.server] };
+        const pairingInfo = {
+          ...action.server,
+          deviceId: action.deviceId,
+          deviceSecret: action.deviceSecret,
+        };
+        return { ...state, paired: [...state.paired, pairingInfo] };
       }
       return state;
     default:
@@ -17,8 +22,10 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
-const addServer = server => ({
+const addServer = (server, deviceId, deviceSecret) => ({
   type: ADD_SERVER,
+  deviceId,
+  deviceSecret,
   server,
 });
 

--- a/src/selectors/__tests__/servers.test.js
+++ b/src/selectors/__tests__/servers.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+import { getPairedServerFactory } from '../servers';
+
+const apiUrl = 'http://0.0.0.0';
+const mockServer = { apiUrl };
+
+const mockState = {
+  servers: {
+    paired: [mockServer],
+  },
+};
+
+describe('server selectors', () => {
+  describe('getPairedServerFactory', () => {
+    it('returns a function', () => {
+      expect(getPairedServerFactory(mockState)).toBeInstanceOf(Function);
+    });
+
+    it('can get paired server by URL', () => {
+      expect(getPairedServerFactory(mockState)(apiUrl)).toEqual(mockServer);
+    });
+
+    it('returns null if not found', () => {
+      expect(getPairedServerFactory(mockState)('bad-url')).toEqual(null);
+    });
+  });
+});

--- a/src/selectors/servers.js
+++ b/src/selectors/servers.js
@@ -1,0 +1,15 @@
+import { memoize } from 'lodash';
+
+import { createDeepEqualSelector } from './utils';
+
+const pairedServers = state => state.servers.paired;
+
+// Servers are considered equal if they use the same URL
+const getPairedServerFactory = createDeepEqualSelector(
+  pairedServers,
+  servers => memoize(apiUrl => servers.find(s => s.apiUrl === apiUrl) || null),
+);
+
+export {
+  getPairedServerFactory, // eslint-disable-line import/prefer-default-export
+};

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -92,7 +92,7 @@ class ApiClient {
    * @param  {string} pairingRequestId from the requestPairing() response
    * @param  {string} pairingRequestSalt from the requestPairing() response
    * @async
-   * @return {Object} device
+   * @return {Object} device, decorated with the generated secret
    * @return {string} device.id
    * @throws {Error}
    */
@@ -123,7 +123,9 @@ class ApiClient {
         if (!decryptedData.device || !decryptedData.device.id) {
           throw new Error(UnexpectedResponseMessage);
         }
-        return decryptedData.device;
+        const device = decryptedData.device;
+        device.secret = secretHex;
+        return device;
       })
       .catch(handleError);
   }

--- a/src/utils/__tests__/ApiClient.test.js
+++ b/src/utils/__tests__/ApiClient.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+import axios from 'axios';
+
+import ApiClient from '../ApiClient';
+import { decrypt } from '../shared-api/cipher';
+
+jest.mock('axios');
+jest.mock('../shared-api/cipher');
+
+describe('ApiClient', () => {
+  const respData = { device: { id: '1' } };
+  const axiosResp = { data: { data: respData } };
+
+  beforeAll(() => {
+    axios.post.mockResolvedValue(axiosResp);
+    axios.CancelToken = {
+      source: jest.fn().mockReturnValue({ token: '' }),
+    };
+    axios.create.mockReturnValue(axios);
+  });
+
+  beforeEach(() => {
+    axios.post.mockClear();
+  });
+
+  describe('pairing confirmation', () => {
+    beforeEach(() => {
+      // data payload is encrypted; mock it on cipher
+      decrypt.mockReturnValue(JSON.stringify(respData));
+    });
+
+    it('returns device ID and secret', async () => {
+      const client = new ApiClient('');
+      const device = await client.confirmPairing();
+      expect(device.id).toEqual(respData.device.id);
+      expect(device).toHaveProperty('secret');
+    });
+  });
+});


### PR DESCRIPTION
Resolves #541. This stores device credentials (ID & Secret, associated with a server) once pairing is complete.

For subsequent API requests, the client sends a token (ID). This uses the username part of HTTP Basic Auth (at least for now); this is only for identification. We'll eventually be using another mechanism to authenticate, but this lays some of the groundwork.

Because of CORS headers, this requires server-side changes (or API calls will fail); see [feature/device-tokens](https://github.com/codaco/Server/compare/feature/device-tokens).