### PR TITLE
Make node form optional

### DIFF
--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -161,12 +161,13 @@ class NameGenerator extends Component {
 
 NameGenerator.defaultProps = {
   activePromptAttributes: {},
+  form: null,
 };
 
 NameGenerator.propTypes = {
   activePromptAttributes: PropTypes.object,
   addNodes: PropTypes.func.isRequired,
-  form: PropTypes.object.isRequired,
+  form: PropTypes.object,
   getLabel: PropTypes.func.isRequired,
   newNodeAttributes: PropTypes.object.isRequired,
   nodesForPrompt: PropTypes.array.isRequired,
@@ -207,3 +208,7 @@ export default compose(
   withPrompt,
   connect(makeMapStateToProps, mapDispatchToProps),
 )(NameGenerator);
+
+export {
+  NameGenerator as UnconnectedNameGenerator,
+};

--- a/src/containers/Interfaces/__tests__/NameGenerator.test.js
+++ b/src/containers/Interfaces/__tests__/NameGenerator.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { UnconnectedNameGenerator as NameGenerator } from '../NameGenerator';
+
+const requiredProps = {
+  addNodes: jest.fn(),
+  getLabel: jest.fn(),
+  newNodeAttributes: {},
+  nodesForPrompt: [],
+  openModal: jest.fn(),
+  prompt: {},
+  promptBackward: jest.fn(),
+  promptForward: jest.fn(),
+  stage: {},
+  updateNode: jest.fn(),
+};
+
+describe('NameGenerator', () => {
+  it('does not require a form prop', () => {
+    const elem = shallow(<NameGenerator {...requiredProps} />);
+    expect(elem.find('Connect(NodeForm)')).toHaveLength(0);
+  });
+
+  it('renders a node form if provided in props', () => {
+    const props = { ...requiredProps, form: {} };
+    const elem = shallow(<NameGenerator {...props} />);
+    expect(elem.find('Connect(NodeForm)').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
A prompt may define no form and have no default.

See #592.