### PR TITLE
add missing values

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -154,6 +154,11 @@
             "label": "Prompt id",
             "description": "Prompt id",
             "type": "text"
+          },
+          "special_category": {
+            "label": "Special Category",
+            "description": "Special Category",
+            "type": "categorical"
           }
         }
       },

--- a/public/protocols/education.netcanvas/protocol.json
+++ b/public/protocols/education.netcanvas/protocol.json
@@ -24,7 +24,7 @@
             "label": "Contact frequency ordinal variable.",
             "description": "Contact frequency ordinal variable",
             "type": "ordinal",
-            "values": [
+            "options": [
               {
                 "label": "Last 24 hours",
                 "value": 4
@@ -161,33 +161,6 @@
             "label": "Type",
             "description": "Type",
             "type": "text"
-          },
-          "contactFreq": {
-            "label": "contactFreq",
-            "description": "Contact frequency.",
-            "type": "ordinal",
-            "values": [
-              {
-                "label": "Last 24 hours",
-                "value": 4
-              },
-              {
-                "label": "Last week",
-                "value": 3
-              },
-              {
-                "label": "Last six months",
-                "value": 2
-              },
-              {
-                "label": "Last two years",
-                "value": 1
-              },
-              {
-                "label": "Over two years ago",
-                "value": -1
-              }
-            ]
           }
         }
       },


### PR DESCRIPTION
This is a small change to change "values" to "options" for the education protocol. Without "options", the Ordinal Bin for the education protocol was not loading. Development protocol was working, so I assumed "options" was the correct word here.

This also adds a missing variable type for "special_category" to the development protocol, so graphml will download correctly.