### PR TITLE
Fix standard protocol card styling

### DIFF
--- a/src/components/Setup/ProtocolCard.js
+++ b/src/components/Setup/ProtocolCard.js
@@ -17,7 +17,9 @@ const ProtocolCard = ({ protocol, selectProtocol, className, size }) => {
   const sized = baseClass => withBemModifier(baseClass, size);
   return (
     <div className={`${sized('protocol-card')} ${className}`} onClick={() => selectProtocol(protocol)}>
-      <Icon className="protocol-card__icon" name="add-a-screen" />
+      <div className="protocol-card__icon-wrapper">
+        <Icon className="protocol-card__icon" name="add-a-screen" />
+      </div>
       <div className="protocol-card__labels">
         <h2 className={sized('protocol-card__name')}>{protocol.name}</h2>
         <p className="protocol-card__description">{protocol.description}</p>

--- a/src/styles/components/_protocol-card.scss
+++ b/src/styles/components/_protocol-card.scss
@@ -1,4 +1,6 @@
-.protocol-card {
+$component: 'protocol-card';
+
+.#{$component} {
   align-items: center;
   background-color: var(--background);
   border-radius: 1rem;
@@ -7,6 +9,28 @@
   flex-direction: row;
   padding: spacing(large);
 
+  &__icon-wrapper {
+    flex: none;
+    height: 50px;
+    margin-right: 10px;
+    position: relative;
+    width: 50px;
+  }
+
+  &__icon {
+    // Override position & display of the 'add-a-screen' icon
+    // TODO: does this deserve its own svg?
+    left: -31px;
+    position: absolute;
+    top: -49px;
+
+    .cls-1,
+    .cls-2 {
+      display: none;
+    }
+  }
+
+  // Large variant displayed on the startup screen
   &--large {
     background-color: var(--light-background);
     flex-direction: column;
@@ -17,21 +41,10 @@
     text-align: center;
     width: 45vw;
     justify-content: center;
-  }
 
-  &__icon {
-    flex: none;
-
-    // Override position & display of the 'add-a-screen' icon.
-    // TODO: does this deserve its own svg?
-    margin: -50px -40px 0;
-
-    position: relative;
-    right: -15px;
-
-    .cls-1,
-    .cls-2 {
-      display: none;
+    .#{$component}__icon-wrapper {
+      margin-bottom: 40px;
+      margin-right: 0;
     }
   }
 


### PR DESCRIPTION
This fixes the positioning of the protocol card icon when used on the server protocol list.

before:
![card](https://user-images.githubusercontent.com/39674/42527083-af9f2924-8445-11e8-8e9d-f25a4d74b4f8.png)

after:
![after](https://user-images.githubusercontent.com/39674/42527127-d2d61a6a-8445-11e8-8e0e-8e6b11596ce5.png)

Styling on the startup screen (the 'large' variant) should remain the same within a couple of pixels.