### PR TITLE
Remove unsupported hidden inputs

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -963,11 +963,6 @@
         {
           "variable": "age",
           "component": "TextInput"
-        },
-        {
-          "variable": "timeCreated",
-          "component": "hidden",
-          "value": "return Date.now().toString();"
         }
       ]
     },
@@ -1025,11 +1020,6 @@
         {
           "variable": "age",
           "component": "TextInput"
-        },
-        {
-          "variable": "timeCreated",
-          "component": "hidden",
-          "value": "return Date.now().toString();"
         }
       ]
     }


### PR DESCRIPTION
This removes the hidden inputs from the development protocol, which are no longer [documented](https://github.com/codaco/Network-Canvas/wiki/Variable-Types) as supported, and render as text inputs instead.

<img width="723" alt="development" src="https://user-images.githubusercontent.com/39674/42533199-35502e5e-8457-11e8-9055-e01659640572.png">
