### PR TITLE
Fix graphml download for data using special_category

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -154,6 +154,12 @@
             "label": "Prompt id",
             "description": "Prompt id",
             "type": "text"
+          },
+          "special_category": {
+            "label": "Special category",
+            "description": "A special category",
+            "type": "ordinal",
+            "options": [46,56]
           }
         }
       },


### PR DESCRIPTION
Example: the form on the prompt titled "This is a prompt containing markdown".