### PR TITLE
Prevent unnecessary nodeList scrolling

### DIFF
--- a/src/styles/components/_card-list.scss
+++ b/src/styles/components/_card-list.scss
@@ -1,6 +1,6 @@
 .card-list {
   flex-wrap: wrap;
-  margin-bottom: 10em;
+  padding-bottom: 10em;
   display: grid;
   grid-template-columns: 1fr 1fr;
   @media screen and (min-width: 1200px) {

--- a/src/styles/components/_node-list.scss
+++ b/src/styles/components/_node-list.scss
@@ -7,7 +7,7 @@
   align-content: flex-start;
   min-height: 100%;
   width: 100%;
-  margin-bottom: var(--base-node-size);
+  padding-bottom: var(--base-node-size);
 
   &--hover,
   &--drag {


### PR DESCRIPTION
When nodeList only contains one or two items, do not scroll them out of view.

Card list doesn't have the same issue since it doesn't have a min-height, but I changed both for consistency.

Issue:
![scroll-away](https://user-images.githubusercontent.com/39674/42536355-d067c7c8-845f-11e8-93e0-df8497b7cb02.gif)
