### PR TITLE
Fix form wizard finish layout

### DIFF
--- a/src/styles/components/_form-wizard.scss
+++ b/src/styles/components/_form-wizard.scss
@@ -27,20 +27,18 @@
 
   &__previous,
   .form__button-container {
+    display: flex;
     max-width: 25%;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
   }
 
+  // On last step, contains both "Finished" and "Add another"
   .form__button-container {
+    align-items: flex-end;
+    flex-direction: column-reverse;
     right: 0;
-
-    .button, // "Finish"
-    .form__next-button {
-      position: absolute;
-      right: 0;
-    }
 
     .button {
       border-bottom-right-radius: 0;


### PR DESCRIPTION
Fixes #603.

I introduced this bug with #565; I hadn't tested a form that included "add another", which is part of the button container. This re-introduces flex layout to that container to prevent "Finish" from obscuring "Add Another".

The layout changes to the form itself remain, so I think the perceived animation jitter addressed by the earlier PR should remain OK.