### PR TITLE
do not override type for hidden input

### DIFF
--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -26,7 +26,7 @@ const fieldTypes = {
   RadioGroup,
   Text,
   Toggle,
-  hidden: props => <input type="hidden" {...props} />,
+  hidden: props => <input {...props} type="hidden" />,
 };
 
 export const getInputComponent = componentType =>


### PR DESCRIPTION
Fixes #606.

To verify, look at the new node form in the development protocol, in both mobile and regular view. The hidden "timeCreated" field should not be visible, but present in the dom.