### PR TITLE
Fix/node positioning false

### DIFF
--- a/src/containers/NodeBucket.js
+++ b/src/containers/NodeBucket.js
@@ -12,21 +12,24 @@ const EnhancedNode = DragSource(Node);
 
 class NodeBucket extends PureComponent {
   static propTypes = {
+    allowPositioning: PropTypes.bool,
     getLabel: PropTypes.func.isRequired,
     node: PropTypes.object,
   };
 
   static defaultProps = {
+    allowPositioning: true,
     node: null,
   };
 
   render() {
     const {
+      allowPositioning,
       getLabel,
       node,
     } = this.props;
 
-    if (!node) { return null; }
+    if (!allowPositioning || !node) { return null; }
 
     return (
       <div className="node-bucket">

--- a/src/containers/__tests__/NodeBucket.test.js
+++ b/src/containers/__tests__/NodeBucket.test.js
@@ -37,6 +37,6 @@ describe('<NodeBucket />', () => {
   it('does not display bucket when positioning is disabled', () => {
     const component = shallow(<NodeBucket {...mockProps} allowPositioning={false} />);
 
-    expect(component).toMatchSnapshot();
+    expect(component.children()).toHaveLength(0);
   });
 });

--- a/src/containers/__tests__/NodeBucket.test.js
+++ b/src/containers/__tests__/NodeBucket.test.js
@@ -12,7 +12,6 @@ const sociogramOptionsDefault = {
   canHighlight: false,
   highlightAttributes: {},
   allowSelect: false,
-  allowPositioning: false,
   selectMode: '',
   sortOrderBy: [],
   concentricCircles: 0,
@@ -31,6 +30,12 @@ const mockProps = {
 describe('<NodeBucket />', () => {
   it('renders ok', () => {
     const component = shallow(<NodeBucket {...mockProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('does not display bucket when positioning is disabled', () => {
+    const component = shallow(<NodeBucket {...mockProps} allowPositioning={false} />);
 
     expect(component).toMatchSnapshot();
   });

--- a/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
@@ -1,11 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<NodeBucket /> renders ok 1`] = `
+exports[`<NodeBucket /> does not display bucket when positioning is disabled 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <NodeBucket
     allowPositioning={false}
+    allowSelect={false}
+    canCreateEdge={false}
+    canHighlight={false}
+    concentricCircles={0}
+    createEdge="bar"
+    displayEdges={Array []}
+    getLabel={[Function]}
+    highlightAttributes={Object {}}
+    layout="foo"
+    layoutVariable="foo"
+    node={
+      Object {
+        "label": "some label",
+      }
+    }
+    selectMode=""
+    skewedTowardCenter={false}
+    sort={Object {}}
+    sortOrderBy={Array []}
+    updateNode={[Function]}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): null,
+  Symbol(enzyme.__nodes__): Array [
+    null,
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`<NodeBucket /> renders ok 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <NodeBucket
+    allowPositioning={true}
     allowSelect={false}
     canCreateEdge={false}
     canHighlight={false}

--- a/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/NodeBucket.test.js.snap
@@ -1,53 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<NodeBucket /> does not display bucket when positioning is disabled 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <NodeBucket
-    allowPositioning={false}
-    allowSelect={false}
-    canCreateEdge={false}
-    canHighlight={false}
-    concentricCircles={0}
-    createEdge="bar"
-    displayEdges={Array []}
-    getLabel={[Function]}
-    highlightAttributes={Object {}}
-    layout="foo"
-    layoutVariable="foo"
-    node={
-      Object {
-        "label": "some label",
-      }
-    }
-    selectMode=""
-    skewedTowardCenter={false}
-    sort={Object {}}
-    sortOrderBy={Array []}
-    updateNode={[Function]}
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): null,
-  Symbol(enzyme.__nodes__): Array [
-    null,
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
 exports[`<NodeBucket /> renders ok 1`] = `
 ShallowWrapper {
   "length": 1,


### PR DESCRIPTION
Fixes #591. This fixes the sociogram's NodeBucket to only display if `allowPositioning` is `true`. To test, set `allowPositioning` to false in a sociogram prompt's `layout`. The NodeBucket should not display.