### PR TITLE
Re-order dev protocol

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1042,57 +1042,6 @@
   },
   "stages": [
     {
-      "id": "welcome",
-      "label": "Welcome",
-      "type": "Information",
-      "title": "Title for the screen",
-      "items": [
-        {
-          "type": "text",
-          "content":
-            "Some arbitrary text content that can _contain_ **formatting**."
-        },
-        {
-          "type": "audio",
-          "content": "click_the_thing.mp3",
-          "description": "Click by clicking the thing"
-        },
-        { "type": "image", "content": "rubberduck.jpg" }
-      ]
-    },
-    {
-      "id": "info-sound",
-      "label": "InfoSound",
-      "type": "Information",
-      "title": "This interface has a video with sound",
-      "items": [
-        {
-          "type": "text",
-          "content":
-            "The video below has sound and is set to loop."
-        },
-        {
-          "type": "video",
-          "content": "withSound.mp4",
-          "description": "Click by clicking the thing",
-          "loop": true
-        }
-      ]
-    },
-    {
-      "id": "markdown",
-      "label": "Markdown",
-      "type": "Information",
-      "title": "Testing markdown",
-      "items": [
-        {
-          "type": "text",
-          "content":
-            "# h1 Heading 8-)\n## h2 Heading\n### h3 Heading\n#### h4 Heading\n##### h5 Heading\n###### h6 Heading\n\n\n## Horizontal Rules\n\n___\n\n---\n\n***\n\n\n## Emphasis\n\n**This is bold text**\n\n__This is bold text__\n\n*This is italic text* \n\n_This is italic text_ \n# Emoji \n:blush: :heartpulse: :wave:"
-        }
-      ]
-    },
-    {
       "id": "namegen1",
       "type": "NameGenerator",
       "label": "NG Closeness",
@@ -1526,6 +1475,57 @@
             "entity": "node",
             "type": "venue"
           }
+        }
+      ]
+    },
+    {
+      "id": "rubberduck",
+      "label": "Audio test",
+      "type": "Information",
+      "title": "Title for the screen",
+      "items": [
+        {
+          "type": "text",
+          "content":
+            "Some arbitrary text content that can _contain_ **formatting**."
+        },
+        {
+          "type": "audio",
+          "content": "click_the_thing.mp3",
+          "description": "Click by clicking the thing"
+        },
+        { "type": "image", "content": "rubberduck.jpg" }
+      ]
+    },
+    {
+      "id": "info-sound",
+      "label": "InfoSound",
+      "type": "Information",
+      "title": "This interface has a video with sound",
+      "items": [
+        {
+          "type": "text",
+          "content":
+            "The video below has sound and is set to loop."
+        },
+        {
+          "type": "video",
+          "content": "withSound.mp4",
+          "description": "Click by clicking the thing",
+          "loop": true
+        }
+      ]
+    },
+    {
+      "id": "markdown",
+      "label": "Markdown",
+      "type": "Information",
+      "title": "Testing markdown",
+      "items": [
+        {
+          "type": "text",
+          "content":
+            "# h1 Heading 8-)\n## h2 Heading\n### h3 Heading\n#### h4 Heading\n##### h5 Heading\n###### h6 Heading\n\n\n## Horizontal Rules\n\n___\n\n---\n\n***\n\n\n## Emphasis\n\n**This is bold text**\n\n__This is bold text__\n\n*This is italic text* \n\n_This is italic text_ \n# Emoji \n:blush: :heartpulse: :wave:"
         }
       ]
     },


### PR DESCRIPTION
This moves the initial static screens to the end of the interview. I spend a lot of time clicking past them or opening the stage menu to be able to work on other frequently-changing screens. (I've added "click the thing" to my music library in case I miss hearing it all the time.)

