### PR TITLE
escape only closes menu

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -24,7 +24,7 @@ class MenuFactory extends Component {
     * adds listener for key events to close Menu
     */
   componentDidMount() {
-    window.onkeydown = this.listenForClose;
+    document.addEventListener('keydown', this.listenForClose, true);
   }
 
   componentDidUpdate() {
@@ -41,7 +41,7 @@ class MenuFactory extends Component {
     * removes listener for key events and click events to close Menu
     */
   componentWillUnmount() {
-    window.onkeydown = null;
+    document.removeEventListener('keydown', this.listenForClose);
     this.outsideClick.cancel();
   }
 
@@ -50,6 +50,7 @@ class MenuFactory extends Component {
 
     if (this.props.isOpen && (event.key === 'Escape' || event.keyCode === 27)) {
       this.props.toggleMenu();
+      e.stopPropagation();
     }
   }
 

--- a/src/containers/Interfaces/NameGeneratorAutoComplete.js
+++ b/src/containers/Interfaces/NameGeneratorAutoComplete.js
@@ -24,23 +24,9 @@ const getNodeIconName = makeGetNodeIconName();
   * @extends Component
   */
 class NameGeneratorAutoComplete extends Component {
-  componentDidMount() {
-    document.addEventListener('keydown', this.onKeyDown);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.onKeyDown);
-  }
-
   onSearchComplete(selectedResults) {
     this.props.addNodes(selectedResults, this.props.newNodeAttributes);
     this.props.closeSearch();
-  }
-
-  onKeyDown = (evt) => {
-    if (this.props.searchIsOpen && (evt.key === 'Escape' || evt.keyCode === 27)) {
-      this.props.closeSearch();
-    }
   }
 
   render() {


### PR DESCRIPTION
Resolves #466.

This removes the "esc" key listener from autocomplete and ensure that both session and stages menu respond to the "esc" key event.