### PR TITLE
When a node is removed, remove any connected edges

### DIFF
--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -99,6 +99,17 @@ describe('network reducer', () => {
     });
   });
 
+  it('removes any edges containing a removed node', () => {
+    const state = {
+      nodes: [{ [PK]: 1 }, { [PK]: 2 }, { [PK]: 3 }],
+      edges: [{ from: 1, to: 2 }, { from: 1, to: 3 }, { from: 2, to: 3 }],
+    };
+    const newState = reducer(state, { type: actionTypes.REMOVE_NODE, [PK]: 1 });
+    expect(newState.edges).not.toContainEqual(state.edges[0]);
+    expect(newState.edges).not.toContainEqual(state.edges[1]);
+    expect(newState.edges).toContainEqual(state.edges[2]);
+  });
+
   it('should handle UPDATE_NODE', () => {
     const newState = reducer(
       {

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -92,11 +92,14 @@ export default function reducer(state = initialState, action = {}) {
         nodes: getUpdatedNodes(state.nodes, action.node, action.full),
       };
     }
-    case REMOVE_NODE:
+    case REMOVE_NODE: {
+      const removeNodePK = action[NodePK];
       return {
         ...state,
-        nodes: reject(state.nodes, node => node[NodePK] === action[NodePK]),
+        nodes: reject(state.nodes, node => node[NodePK] === removeNodePK),
+        edges: reject(state.edges, edge => edge.from === removeNodePK || edge.to === removeNodePK),
       };
+    }
     case ADD_EDGE:
       if (edgeExists(state.edges, action.edge)) { return state; }
       return {


### PR DESCRIPTION
Fixes #437.

When a node is removed from the network, remove any edges that connected it.