### PR TITLE
Reduce node re-rendering calls in sorted lists

### DIFF
--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -43,7 +43,7 @@ class NodeList extends Component {
     if (this.refreshTimer) { clearTimeout(this.refreshTimer); }
 
     // Don't update if nodes are the same
-    if (isEqual(newProps.nodes, this.state.nodes)) {
+    if (isEqual(newProps.nodes, this.props.nodes)) {
       return;
     }
 

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -41,7 +41,7 @@ class OrdinalBinBucket extends Component {
 
   componentWillReceiveProps(newProps) {
     // Don't update if nodes are the same
-    if (isEqual(newProps.nodes, this.state.nodes)) {
+    if (isEqual(newProps.nodes, this.props.nodes)) {
       return;
     }
 

--- a/src/utils/__tests__/sortOrder.test.js
+++ b/src/utils/__tests__/sortOrder.test.js
@@ -92,15 +92,18 @@ describe('sortOrder', () => {
   it('treats "*" property as fifo ordering', () => {
     const sorter = sortOrder([{
       property: '*',
+      direction: 'asc',
+    }]);
+
+    expect(sorter(mockItems)).toMatchObject(mockItems);
+  });
+
+  it('treats "*" ("desc") as lifo ordering', () => {
+    const sorter = sortOrder([{
+      property: '*',
       direction: 'desc',
     }]);
 
-    expect(sorter(mockItems)).toMatchObject([
-      { name: 'dave' },
-      { name: 'eugine' },
-      { name: 'carolyn' },
-      { name: 'benjamin' },
-      { name: 'abigail' },
-    ]);
+    expect(sorter(mockItems)).toMatchObject([...mockItems].reverse());
   });
 });

--- a/src/utils/__tests__/sortOrder.test.js
+++ b/src/utils/__tests__/sortOrder.test.js
@@ -36,6 +36,11 @@ describe('sortOrder', () => {
     expect(sorter(mockItems)).toMatchObject(mockItems);
   });
 
+  it('it does not add any properties to items', () => {
+    const sorter = sortOrder();
+    expect(sorter(mockItems)[0]).toEqual(mockItems[0]);
+  });
+
   describe('order direction', () => {
     it('orders ascending with "asc"', () => {
       const sorter = sortOrder([{

--- a/src/utils/sortOrder.js
+++ b/src/utils/sortOrder.js
@@ -1,34 +1,47 @@
-import { orderBy } from 'lodash';
+import { omit, orderBy } from 'lodash';
 
 /* Maps a `createdIndex` index value to all items in an array */
 const withCreatedIndex = items => items.map((item, createdIndex) => ({ ...item, createdIndex }));
 
-/* property iteratee for the special case "*" property, which sorteds by `createdIndex` */
+/* all items without the 'createdIndex' prop */
+const withoutCreatedIndex = items => items.map(item => omit(item, 'createdIndex'));
+
+/* property iteratee for the special case "*" property, which sorts by `createdIndex` */
 const fifo = ({ createdIndex }) => createdIndex;
 
 /**
  * Returns a configured sorting function
- * @param {array} sortConfiguration - The title of the book.
- * @param {object} variableRegistry - an object containing variables for the node type as specified
+ * @param {Array} sortConfig - list of rules to sort by
+ * @param {Object} variableRegistry - an object containing variables for the node type as specified
  * at: `variableRegistry.node[nodeType]variables`
  * TODO: Use variable registry to respect variable type?
  */
-const sortOrder = (sortConfiguration = [], variableRegistry = {}) => { // eslint-disable-line
-  const iteratees = sortConfiguration.map(rule => rule.property)
-    .map(property => (property === '*' ? fifo : property));
+const sortOrder = (sortConfig = [], variableRegistry = {}) => { // eslint-disable-line
+  // '*' is a special prop to sort by the order in which nodes were added to the network
+  const isFifoLifo = rule => rule.property === '*';
 
-  const orders = sortConfiguration.map(rule => rule.direction);
+  // Lodash sort is stable; we can discard any fifo (*.asc) rules as no-ops.
+  const sortRules = sortConfig.filter(rule => !(isFifoLifo(rule) && rule.direction === 'asc'));
+  const orders = sortRules.map(rule => rule.direction);
+
+  // If sort involves LIFO ordering (*.desc), we need to add our own index
+  if (sortRules.some(isFifoLifo)) {
+    return items => orderBy(
+      withCreatedIndex(items),
+      sortRules.map(rule => (isFifoLifo(rule) ? fifo : rule.property)),
+      orders,
+    ).map(withoutCreatedIndex);
+  }
 
   /**
    * Returns a list of sorted items
    * @param {array} items - A list of items (nodes) to be sorted
    */
-  return items =>
-    orderBy(
-      withCreatedIndex(items),
-      iteratees,
-      orders,
-    );
+  return items => orderBy(
+    items,
+    sortRules.map(rule => rule.property),
+    orders,
+  );
 };
 
 export default sortOrder;


### PR DESCRIPTION
This PR includes a few optimizations for node rendering:

- returning equivalent node objects from the sorter (removing the internal `createdIndex` prop)
- some minor adjustments to the sorter to avoid two extra mappings when they're not needed (I believe lodash already uses indexes to implement a stable sort internally). It's not a big deal, but could matter with external data sets.
- Update the comparison check in NodeList (https://github.com/codaco/Network-Canvas/commit/350dd01683faa41b02718c150caa570203ee7204). When nodes were sorted, this check always returned false.
  + with the above change to keeping node props unchanged, this isn't as big a deal, but it still seems cleaner
- I also updated tests to clarify existing LIFO/FIFO behavior

I think these changes are still equivalent to what we want, but please review carefully!

Here are some behaviors on master I was trying to solve:

- during list scrolling, the list continually re-sorts, and all nodes re-render
- When there are multiple lists (e.g., with an ordinal bin), changing the props on one node (say, by moving bins) causes all nodes to re-render
  + this actually happens 3+ times, including on drag start and drag end.

To test, you can log calls to a Node's render(), and/or measure FPS on a heavily-populated list. The ordinal bins in the development protocol are a good place to start.
