### PR TITLE
Fix CSP for server pairing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="utf-8">
     <!-- default-src contains `blob:` as worker-src fallback for Android <= 8.0 -->
+    <!-- connect-src includes '*' to allow pairing with arbitrary Servers -->
     <meta http-equiv="Content-Security-Policy" content="
       default-src gap://ready file://* blob:;
-      connect-src 'self' data: http://localhost:* https://localhost:* ws://localhost:*;
+      connect-src data: *;
       img-src asset: 'self' android-webview-video-poster: data: cdvfile: file:;
       media-src 'self' asset: cdvfile: file: data:;
       style-src 'self' 'unsafe-inline';


### PR DESCRIPTION
This reverts an overly-aggressive CSP (connect-src) change I made in #613. The intent there was to prevent workers from making arbitrary network requests; worker scripts inherit the CSP of the app.

Of course, the app needs that flexibility in order to pair with arbitrary Servers, so I'm reverting for now. I'd like to investigate a way to keep that limitation on workers in the future; the CSP needs a review & update in general, so I'll open a separate issue for that.