### PR TITLE
Remove dynamic state from scrollable

### DIFF
--- a/src/behaviours/scrollable.js
+++ b/src/behaviours/scrollable.js
@@ -1,52 +1,10 @@
 import React, { Component } from 'react';
-import classNames from 'classnames';
-import { throttle } from 'lodash';
-
-const maxFramesPerSecond = 10;
 
 const scrollable = WrappedComponent =>
   class Scrollable extends Component {
-    constructor() {
-      super();
-
-      this.state = { isScrolling: false };
-      this.updateScrollState = throttle(this.updateScrollState, 1000 / maxFramesPerSecond);
-    }
-
-    componentDidMount() {
-      if (this.el) {
-        this.el.addEventListener('scroll', this.updateScrollState);
-      }
-    }
-
-    componentWillUnmount() {
-      if (this.el) {
-        this.el.removeEventListener('scroll', this.updateScrollState);
-      }
-    }
-
-    updateScrollState = () => {
-      this.setState({
-        isScrolling: this.isScrolling(),
-      });
-    }
-
-    isScrolling = () => {
-      const scrollTop = this.scrollTop();
-      return scrollTop && scrollTop > 0;
-    }
-
-    scrollTop = (pixels = null) => {
-      if (!this.el) { return null; }
-      if (pixels !== null) { this.el.scrollTop = pixels; }
-      return this.el.scrollTop;
-    }
-
     render() {
-      const classes = classNames('scrollable', { 'scrollable--is-scrolling': this.state.isScrolling });
-
       return (
-        <div className={classes} ref={(el) => { this.el = el; }}>
+        <div className="scrollable">
           <WrappedComponent {...this.props} scrollTop={this.scrollTop} />
         </div>
       );

--- a/src/behaviours/scrollable.js
+++ b/src/behaviours/scrollable.js
@@ -1,14 +1,12 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-const scrollable = WrappedComponent =>
-  class Scrollable extends Component {
-    render() {
-      return (
-        <div className="scrollable">
-          <WrappedComponent {...this.props} scrollTop={this.scrollTop} />
-        </div>
-      );
-    }
-  };
+const scrollable = (WrappedComponent) => {
+  const Scrollable = props => (
+    <div className="scrollable">
+      <WrappedComponent {...props} />
+    </div>
+  );
+  return Scrollable;
+};
 
 export default scrollable;

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -94,7 +94,7 @@ class MenuFactory extends Component {
       <div className="menu" ref={(node) => { this.domNode = node; }}>
         {children}
         <div className={isOpen ? 'menu__wrap menu__content menu__wrap--open' : 'menu__wrap menu__content'}>
-          <Scroller>
+          <Scroller className="menu__scroller">
             <Icon name="close" size="40px" className="menu__cross" onClick={this.menuClick} />
             <header>
               <h1 className="menu__title">{title}</h1>

--- a/src/components/NodeList.js
+++ b/src/components/NodeList.js
@@ -59,8 +59,6 @@ class NodeList extends Component {
     }
 
     // Otherwise, transition out and in again
-    this.props.scrollTop(0);
-
     this.setState({ exit: true }, () => {
       this.setState(
         { nodes: [], stagger: true },
@@ -152,7 +150,6 @@ NodeList.propTypes = {
   willAccept: PropTypes.bool,
   meta: PropTypes.object,
   listId: PropTypes.string.isRequired,
-  scrollTop: PropTypes.func,
   sortOrder: PropTypes.array,
 };
 
@@ -169,7 +166,6 @@ NodeList.defaultProps = {
   willAccept: false,
   isDragging: false,
   meta: {},
-  scrollTop: () => {},
   sortOrder: [],
 };
 

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -57,8 +57,6 @@ class OrdinalBinBucket extends Component {
     }
 
     // Otherwise, transition out and in again
-    this.props.scrollTop(0);
-
     this.setState({ exit: true }, () => {
       this.setState(
         { nodes: [], stagger: true },
@@ -150,7 +148,6 @@ OrdinalBinBucket.propTypes = {
   willAccept: PropTypes.bool,
   meta: PropTypes.object,
   listId: PropTypes.string.isRequired,
-  scrollTop: PropTypes.func,
   sortOrder: PropTypes.array,
 };
 
@@ -166,7 +163,6 @@ OrdinalBinBucket.defaultProps = {
   willAccept: false,
   isDragging: false,
   meta: {},
-  scrollTop: () => {},
   sortOrder: [],
 };
 

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -69,12 +69,11 @@ ShallowWrapper {
         }
         onDeleteCard={null}
         onToggleCard={[Function]}
-        scrollTop={[Function]}
         selected={[Function]}
       />,
       "className": "scrollable",
     },
-    "ref": [Function],
+    "ref": null,
     "rendered": Object {
       "instance": null,
       "key": undefined,
@@ -105,7 +104,6 @@ ShallowWrapper {
         ],
         "onDeleteCard": null,
         "onToggleCard": [Function],
-        "scrollTop": [Function],
         "selected": [Function],
       },
       "ref": null,
@@ -148,12 +146,11 @@ ShallowWrapper {
           }
           onDeleteCard={null}
           onToggleCard={[Function]}
-          scrollTop={[Function]}
           selected={[Function]}
         />,
         "className": "scrollable",
       },
-      "ref": [Function],
+      "ref": null,
       "rendered": Object {
         "instance": null,
         "key": undefined,
@@ -184,7 +181,6 @@ ShallowWrapper {
           ],
           "onDeleteCard": null,
           "onToggleCard": [Function],
-          "scrollTop": [Function],
           "selected": [Function],
         },
         "ref": null,

--- a/src/components/__tests__/__snapshots__/ListSelect-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSelect-test.js.snap
@@ -108,7 +108,7 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "details": [Function],
           "label": [Function],
@@ -190,7 +190,7 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "details": [Function],
             "label": [Function],

--- a/src/components/__tests__/__snapshots__/Menu.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Menu.test.js.snap
@@ -48,7 +48,9 @@ ShallowWrapper {
         <div
           className="menu__wrap menu__content"
         >
-          <Scrollable>
+          <Scrollable
+            className="menu__scroller"
+          >
             <Icon
               className="menu__cross"
               color=""
@@ -113,7 +115,9 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <Scrollable>
+          "children": <Scrollable
+            className="menu__scroller"
+          >
             <Icon
               className="menu__cross"
               color=""
@@ -165,7 +169,7 @@ ShallowWrapper {
         "rendered": Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "children": Array [
               <Icon
@@ -214,6 +218,7 @@ ShallowWrapper {
                 />
               </nav>,
             ],
+            "className": "menu__scroller",
           },
           "ref": null,
           "rendered": Array [
@@ -385,7 +390,9 @@ ShallowWrapper {
           <div
             className="menu__wrap menu__content"
           >
-            <Scrollable>
+            <Scrollable
+              className="menu__scroller"
+            >
               <Icon
                 className="menu__cross"
                 color=""
@@ -450,7 +457,9 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <Scrollable>
+            "children": <Scrollable
+              className="menu__scroller"
+            >
               <Icon
                 className="menu__cross"
                 color=""
@@ -502,7 +511,7 @@ ShallowWrapper {
           "rendered": Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "class",
+            "nodeType": "function",
             "props": Object {
               "children": Array [
                 <Icon
@@ -551,6 +560,7 @@ ShallowWrapper {
                   />
                 </nav>,
               ],
+              "className": "menu__scroller",
             },
             "ref": null,
             "rendered": Array [

--- a/src/styles/components/_card-list.scss
+++ b/src/styles/components/_card-list.scss
@@ -1,6 +1,9 @@
 .card-list {
+  --card-margin: 1rem;
+
   flex-wrap: wrap;
   padding-bottom: 10em;
+  padding-top: calc(#{$scroller-top-padding} - var(--card-margin));
   display: grid;
   grid-template-columns: 1fr 1fr;
   @media screen and (min-width: 1200px) {
@@ -23,7 +26,6 @@
   &__delete-button {
     --button-size: 1rem;
     --button-padding: #{spacing(small)};
-    --card-margin: 1.5rem;
 
     cursor: pointer;
     position: absolute;

--- a/src/styles/components/_menu.scss
+++ b/src/styles/components/_menu.scss
@@ -6,6 +6,12 @@
 .menu {
   position: absolute;
 
+  &__scroller {
+    .menu__cross {
+      margin-top: $scroller-top-padding;
+    }
+  }
+
   &__wrap {
     // General sidebar styles
     height: 100%;

--- a/src/styles/components/_node-list.scss
+++ b/src/styles/components/_node-list.scss
@@ -1,3 +1,5 @@
+$node-inset: 14px;  // approximate scaled margin + 'outer-trim' of a node
+
 .node-list {
   @include gpu;
   display: flex;
@@ -8,6 +10,8 @@
   min-height: 100%;
   width: 100%;
   padding-bottom: var(--base-node-size);
+
+  padding-top: $scroller-top-padding - $node-inset;
 
   &--hover,
   &--drag {

--- a/src/styles/components/_node-list.scss
+++ b/src/styles/components/_node-list.scss
@@ -9,7 +9,7 @@ $node-inset: 14px;  // approximate scaled margin + 'outer-trim' of a node
   align-content: flex-start;
   min-height: 100%;
   width: 100%;
-  padding-bottom: var(--base-node-size);
+  padding-bottom: calc(var(--base-node-size) / 2);
 
   padding-top: $scroller-top-padding - $node-inset;
 

--- a/src/styles/components/_ordinal-bins.scss
+++ b/src/styles/components/_ordinal-bins.scss
@@ -4,6 +4,14 @@
   height: 100%;
   flex: 1;
 
+  .scrollable {
+    @include scroller-mask($scroller-top-padding-small);
+
+    .node-list {
+      padding-top: max(0, $scroller-top-padding-small - $node-inset);
+    }
+  }
+
   &--title {
     flex: 1;
     display: flex;

--- a/src/styles/components/_panel.scss
+++ b/src/styles/components/_panel.scss
@@ -37,10 +37,6 @@
     display: flex;
   }
 
-  .node-list {
-    padding-top: 20px;
-  }
-
   .node {
     font-size: calc(var(--base-node-size) * .66);
     filter: drop-shadow(0 3px 0 var(--drop-shadow-color));

--- a/src/styles/components/_protocol-card-list.scss
+++ b/src/styles/components/_protocol-card-list.scss
@@ -6,8 +6,10 @@
   display: flex;
   flex: auto;
   flex-direction: row;
+  margin-top: -1 * $scroller-top-padding;
 
   &__scroller {
+    padding-top: $scroller-top-padding;
     position: relative;
   }
 
@@ -20,7 +22,7 @@
 
   &__left-border {
     border-left: var(--border-width) solid var(--border-color);
-    height: calc(100% - var(--card-height));
+    height: calc(100% - var(--card-height) - #{$scroller-top-padding});
     margin: calc(.5 * var(--card-height)) 0;
     position: absolute;
 

--- a/src/styles/components/_scrollable.scss
+++ b/src/styles/components/_scrollable.scss
@@ -1,17 +1,16 @@
-@function fade-to($fade-to: palette('background'), $direction: 0deg) {
-  @return linear-gradient($direction, $fade-to 0%, transparentize($fade-to, 1) 100%);
+@mixin scroller-mask($top-height: $scroller-top-padding) {
+  $bottom-height: 50px;
+  $opaque: rgba(0, 0, 0, 1);
+  mask-image: linear-gradient(180deg, transparent, $opaque $top-height, $opaque calc(100% - #{$bottom-height}), transparent 100%);
 }
 
 .scrollable {
-  $gradient-height-top: 35px;
-  $gradient-height-bottom: 50px;
-  $opaque: rgba(0, 0, 0, 1);
-  // sass-lint:disable no-vendor-prefixes
+  @include scroller-mask;
   flex: 1;
   overflow-x: hidden;
   overflow-y: scroll;
+  // sass-lint:disable no-vendor-prefixes
   -webkit-overflow-scrolling: touch;
-  mask-image: linear-gradient(180deg, transparent, $opaque $gradient-height-top, $opaque calc(100% - #{$gradient-height-bottom}), transparent 100%);
 
   &::-webkit-scrollbar {
     display: none;

--- a/src/styles/components/_scrollable.scss
+++ b/src/styles/components/_scrollable.scss
@@ -3,18 +3,17 @@
 }
 
 .scrollable {
-  // sass-lint:disable no-color-literals no-vendor-prefixes no-transition-all
+  $gradient-height-top: 35px;
+  $gradient-height-bottom: 50px;
+  $opaque: rgba(0, 0, 0, 1);
+  // sass-lint:disable no-vendor-prefixes
   flex: 1;
   overflow-x: hidden;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
-  mask-image: linear-gradient(0deg, rgba(0, 0, 0, 0) 20px, rgba(0, 0, 0, 1) 75px, rgba(0, 0, 0, 1) 100%, rgba(0, 0, 0, 0) 100%);
+  mask-image: linear-gradient(180deg, transparent, $opaque $gradient-height-top, $opaque calc(100% - #{$gradient-height-bottom}), transparent 100%);
 
   &::-webkit-scrollbar {
     display: none;
-  }
-
-  &--is-scrolling {
-    mask-image: linear-gradient(0deg, rgba(0, 0, 0, 0) 20px, rgba(0, 0, 0, 1) 75px, rgba(0, 0, 0, 1) 80%, rgba(0, 0, 0, 0) 100%);
   }
 }

--- a/src/styles/containers/_interfaces.scss
+++ b/src/styles/containers/_interfaces.scss
@@ -1,7 +1,9 @@
 // Shared mixins for interfaces.
 
+$interface-prompt-flex-basis: 200px;
+
 @mixin interface-prompt {
-  flex: 0 0 200px;
+  flex: 0 0 $interface-prompt-flex-basis;
   @include breakpoint('full') {
     flex: 0 0 17vh;
   }

--- a/src/styles/containers/_name-generator-auto-complete-interface.scss
+++ b/src/styles/containers/_name-generator-auto-complete-interface.scss
@@ -36,7 +36,12 @@ $search-z-index: 1000;
   }
 
   &__nodes {
+    height: calc(100% - #{$interface-prompt-flex-basis});
     text-align: left;
+
+    .scrollable {
+      height: 100%;
+    }
 
     .node__label {
       line-height: 1; // tighter fit for longer text (e.g., venues)

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,5 +1,8 @@
 $font-path: '../ui/assets/fonts';
 
+$scroller-top-padding: 30px;
+$scroller-top-padding-small: 15px;
+
 @import '../ui/styles/all';
 @import 'utils/all';
 @import 'helpers/all';


### PR DESCRIPTION
This removes the dynamic visibility of the Scroller's top gradient mask. See discussion in #548.

In short, the scroller gradient mask is always visible, and scrollable clients ensure that they have enough top padding so that content isn't obscured when scrollTop is 0. This is managed through sass vars for now; if it seems burdensome, we can re-evaluate.

#### Other minor changes:
- fixed the scrolling behavior on NG Autocomplete
- reduced the bottom padding on `NodeList` so you can't scroll past all content in panels

#### Notes

I don't think `scrollTop` was needed. It was called by the NodeList, but I couldn't find a case where it would matter, since node props always appeared to change. If I'm wrong about this, please let me know; I have a local branch that had nearly restored support for it from the prototype.

There are two other differences that I didn't mention in #548.

- The scrolling mask is visible against the highlight background color when a `NodeList` is an active drop target.
- I had to adjust the close button on `Menu` (to move below the mask)

#### Testing

Here are the clients of scrollable/Scroller I tested:
- CardList
  - [x] Sessions
  - [x] NameGen
  - [x] Search results
- NodeList
  - [x] Panels (NG)
  - [x] Bins  
  - [x] Main Node list (NG)
  - [x] NameGeneratorAutoComplete
- [x] Menu (Scroller)
- [x] ServerProtocolList
