### PR TITLE
Styling for the autocomplete list

### DIFF
--- a/src/components/Transition/Search.js
+++ b/src/components/Transition/Search.js
@@ -51,6 +51,13 @@ class Search extends Component {
       },
     };
 
+    // Search may be positioned by parent; animate horizontal centering
+    const rightCollapsed = getCssProp(elStyle, '--right-collapsed');
+    const rightExpanded = getCssProp(elStyle, '--right-offset');
+    if (rightCollapsed && rightExpanded) {
+      wrapperAnimation.right = [rightCollapsed, rightExpanded];
+    }
+
     const contentAnimation = {
       opacity: [0, 1],
     };
@@ -83,6 +90,14 @@ class Search extends Component {
       maxHeight: [el.getBoundingClientRect().height, collapsedSize],
       width: collapsedSize,
     };
+
+    // Search may be positioned by parent; animate horizontal centering
+    const rightCollapsed = getCssProp(elStyle, '--right-collapsed');
+    const rightExpanded = getCssProp(elStyle, '--right-offset');
+    if (rightCollapsed && rightExpanded) {
+      inverseWrapperAnimation.right = [rightExpanded, rightCollapsed];
+    }
+
 
     const inverseContentAnimation = {
       opacity: 0,

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -16,7 +16,6 @@ $results-height: calc(100vh - 350px);
   max-height: 100vh;
   position: absolute;
   transform-origin: right bottom;
-  width: 100%;
 
   &__header {
     padding: 2rem 0;

--- a/src/styles/containers/_name-generator-auto-complete-interface.scss
+++ b/src/styles/containers/_name-generator-auto-complete-interface.scss
@@ -1,5 +1,5 @@
 $search-icon-offset-x: 0;
-$search-icon-offset-y: 35px;
+$search-icon-offset-y: 1.8rem; // match stage menu button
 $search-z-index: 1000;
 
 .name-generator-auto-complete-interface {
@@ -15,14 +15,18 @@ $search-z-index: 1000;
   }
 
   &__search {
+    --right-collapsed: 50px; // align with 'core' of button
+    --right-offset: 180px; // margin equal to left menu width
+
     // Position collapsed search element around the 'core' of the icon
     bottom: $search-icon-offset-y;
-    right: $search-icon-offset-x;
+    right: var(--right-offset);
+    width: calc(100% - 2 * var(--right-offset));
     z-index: $search-z-index;
   }
 
   &__search-button {
-    bottom: $search-icon-offset-y - 8px;
+    bottom: calc(#{$search-icon-offset-y} - 8px);
     cursor: pointer;
     position: absolute;
     right: $search-icon-offset-x + 27px;


### PR DESCRIPTION
This updates Autocomplete styling to work with new menu. It adds a transition to the `right` property so that the search UI is centered within the interface.