### PR TITLE
Remove chalk dependency in production

### DIFF
--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -4,7 +4,6 @@ const os = require('os');
 const path = require('path');
 const url = require('url');
 const log = require('electron-log');
-const chalk = require('chalk');
 const registerAssetsProtocol = require('./components/assetsProtocol').registerAssetsProtocol;
 require('./components/updater');
 
@@ -153,7 +152,8 @@ function loadDevToolsExtensions() {
   try {
     extensions.split(';').forEach(filepath => BrowserWindow.addDevToolsExtension(filepath));
   } catch (err) {
-    /* eslint-disable no-console */
+    /* eslint-disable no-console, global-require */
+    const chalk = require('chalk');
     console.warn(err);
     console.warn(chalk.yellow('A Chrome dev tools extension failed to load. If the extension has upgraded, update your NC_DEVTOOLS_EXENSION_PATH:'));
     console.warn(chalk.yellow(process.env.NC_DEVTOOLS_EXENSION_PATH));


### PR DESCRIPTION
Chalk is not included in production dependencies; require only in development.