### PR TITLE
initialize checkbox value

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -207,6 +207,11 @@
             "description": "Human readable description",
             "type": "boolean"
           },
+          "checkboxVariable": {
+            "label": "A Checkbox",
+            "description": "Human readable description",
+            "type": "boolean"
+          },
           "ordinalVariable": {
             "label": "Ordinal Variable",
             "description": "Human readable description",
@@ -1015,6 +1020,10 @@
           "variable": "ordinalVariable",
           "component": "RadioGroup",
           "label": "How much do you like likert scales?"
+        },
+        {
+          "variable": "checkboxVariable",
+          "component": "Checkbox"
         },
         {
           "variable": "categoricalVariable",


### PR DESCRIPTION
Fixes #634. To verify, check and uncheck the checkbox on the development protocol's "NG Inputs" screen. It should be able to reopen the form and have the correct value for the checkbox.