### PR TITLE
Handle invalid input types to Radar

### DIFF
--- a/src/containers/ConcentricCircles/Radar.js
+++ b/src/containers/ConcentricCircles/Radar.js
@@ -27,15 +27,20 @@ const weightedAverage = (a, b, factor = 1) =>
   zipWith(a, b, (c, d) => ((c * factor) + d) / (1 + factor));
 
 const Radar = ({ n, skewed }) => {
+  const num = parseInt(n, 10);
+  if (isNaN(num) || !num) {
+    return null;
+  }
+
   const radii = skewed ?
-    weightedAverage(equalByArea(50, n), equalByIncrement(50, n), 3) :
-    equalByIncrement(50, n);
+    weightedAverage(equalByArea(50, num), equalByIncrement(50, num), 3) :
+    equalByIncrement(50, num);
 
   const colorRing = color(getCSSVariableAsString('--ring'));
   const colorBackground = color(getCSSVariableAsString('--background'));
 
   const ringFill = (ring) => {
-    const mix = (ring + 1) / n;
+    const mix = (ring + 1) / num;
     const colorMix = color(colorBackground).mix(colorRing, mix);
     const hexColorMix = colorMix.hex();
     return hexColorMix;

--- a/src/containers/ConcentricCircles/__tests__/Radar.test.js
+++ b/src/containers/ConcentricCircles/__tests__/Radar.test.js
@@ -14,7 +14,23 @@ const mockProps = {
 describe('<Radar />', () => {
   it('renders ok', () => {
     const component = shallow(<Radar {...mockProps} />);
-
     expect(component).toMatchSnapshot();
+  });
+
+  describe('circle background', () => {
+    it('is lenient with input type', () => {
+      const component = shallow(<Radar {...{ ...mockProps, n: '10' }} />);
+      expect(component.find('circle')).toHaveLength(10);
+    });
+
+    it('is hidden when n is 0', () => {
+      const component = shallow(<Radar {...{ ...mockProps, n: 0 }} />);
+      expect(component.find('circle')).toHaveLength(0);
+    });
+
+    it('is hidden when n is NaN', () => {
+      const component = shallow(<Radar {...{ ...mockProps, n: 'a' }} />);
+      expect(component.find('circle')).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
This fixes rendering of the concentric circles when input type isn't a number.

Coerce strings to numbers when possible, but check for validity.

If NaN, the propTypes warning should still be logged to indicate why the circles are missing.

Fixes #632 