### PR TITLE
Better handling of syntax errors in user scripts

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -70,11 +70,9 @@ module.exports = function(proxy, allowedHost) {
     https: protocol === 'https',
     host: host,
     overlay: false,
-    historyApiFallback: {
-      // Paths with dots should still use the history fallback.
-      // See https://github.com/facebookincubator/create-react-app/issues/387.
-      disableDotRule: true,
-    },
+    // We don't make use of the History API, and want non-existent resources
+    // such as user scripts to return 404, not index.html.
+    historyApiFallback: false,
     public: allowedHost,
     proxy,
     setup(app) {

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,6 @@
       "
     />
     <meta name="viewport" content="viewport-fit=cover, initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/icons/netCanvas-icon.ico">
     <title>Network Canvas</title>
   </head>
   <body>


### PR DESCRIPTION
Fixes #627.

The reported bug is with Chrome development, but this would be a problem with syntax errors in a user script as well.

If there's any syntax error in a worker script, then all clients making use of that worker will be notified of the failure, and the worker agent will reject any future requests. In the case of node labeling, this allows the Node container to fall back to the built-in label function.

Additionally, to make development mimic production a little better, I've disabled `historyApiFallback` in the dev server, which is what causes it to return index.html instead of 404s. This was the immediate source of the problem in #627. (This also uncovered a reference to a missing favicon, so I deleted that.)

### Testing

1. Browser: `npm start` and view the education protocol in a browser. See that nodes are no longer blank.

2. Any client: add a syntax error to the development worker script, and start a session with it. See that node labels use the original function (no emoji are visible).
