### PR TITLE
Make builds & CI faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,5 @@ install:
   - npm install
 jobs:
   include:
-    - stage: prebuild
-      script: npm run test
-    - script: npm run lint
-    - script: npm run sass-lint
-    - stage: build
-      script: npm run build
+    - stage: test
+      script: npm run lint && npm run sass-lint && npm run test && npm run build

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -157,14 +157,23 @@ module.exports = {
           {
             test: /\.(js|jsx)$/,
             include: paths.appSrc,
-            loader: require.resolve('babel-loader'),
-            options: {
-
-              // This is a feature of `babel-loader` for webpack (not Babel itself).
-              // It enables caching results in ./node_modules/.cache/babel-loader/
-              // directory for faster rebuilds.
-              cacheDirectory: true,
-            },
+            use: [
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  poolTimeout: Infinity,
+                },
+              },
+              {
+                loader: require.resolve('babel-loader'),
+                options: {
+                  // This is a feature of `babel-loader` for webpack (not Babel itself).
+                  // It enables caching results in ./node_modules/.cache/babel-loader/
+                  // directory for faster rebuilds.
+                  cacheDirectory: true,
+                },
+              },
+            ],
           },
           {
             test: /\.woff2?$|\.woff$/,
@@ -178,6 +187,12 @@ module.exports = {
           {
             test: /\.scss$/,
             use: [
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  poolTimeout: Infinity,
+                },
+              },
               require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -143,10 +143,15 @@ module.exports = {
           {
             test: /\.(js|jsx)$/,
             include: paths.appSrc,
-            loader: require.resolve('babel-loader'),
-            options: {
-              compact: false,
-            },
+            use: [
+              require.resolve('thread-loader'),
+              {
+                loader: require.resolve('babel-loader'),
+                options: {
+                  compact: false,
+                },
+              },
+            ],
           },
           {
             test: /\.woff2?$|\.woff$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,8 +1955,7 @@
         "big.js": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-            "dev": true
+            "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
         },
         "binary": {
             "version": "0.3.0",
@@ -5580,8 +5579,7 @@
         "emojis-list": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-            "dev": true
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -11452,8 +11450,7 @@
         "json5": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         },
         "jsonfile": {
             "version": "2.4.0",
@@ -11717,14 +11714,12 @@
         "loader-runner": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-            "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
-            "dev": true
+            "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
         },
         "loader-utils": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-            "dev": true,
             "requires": {
                 "big.js": "3.2.0",
                 "emojis-list": "2.1.0",
@@ -20118,6 +20113,31 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
+        },
+        "thread-loader": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-1.2.0.tgz",
+            "integrity": "sha512-acJ0rvUk53+ly9cqYWNOpPqOgCkNpmHLPDGduNm4hDQWF7EDKEJXAopG9iEWsPPcml09wePkq3NF+ZUqnO6tbg==",
+            "requires": {
+                "async": "2.6.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+                    "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+                    "requires": {
+                        "lodash": "4.17.10"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+                }
+            }
         },
         "throat": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
         "cordova-plugin-x-socialsharing": "^5.2.1",
         "cordova-plugin-zeroconf": "^1.3.3",
         "object-hash": "^1.3.0",
-        "react-id-swiper": "^1.6.4"
+        "react-id-swiper": "^1.6.4",
+        "thread-loader": "^1.2.0"
     },
     "homepage": ".",
     "main": "www/electron-starter.js",


### PR DESCRIPTION
- Combines Travis jobs: We don't have the benefit of parallelism, and jobs are dominated by
boot & install overhead. (Contrast the `chore/travis-stages` run time [with others](https://travis-ci.org/codaco/Network-Canvas/builds).)
- Use [thread-loader](https://webpack.js.org/loaders/thread-loader/) for some loaders. This is used in more recent versions of create-react-app, and adopted in Server & Architect. On my machine, this speeds up dev & prod builds by 20-25%. I haven't seen any issues with it yet.