### PR TITLE
https clients for NC Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,12 @@ yarn.lock
 build.json
 
 *.zip
-*.pbxproj
+plugins/**/*.pbxproj
 Icon^M^M
 
 .devserver
 config.xml.original
+
+# Xcode (Cordova plugin)
+xcuserdata/
+IDEWorkspaceChecks.plist

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ React Scripts
 
 This project currently requires version `8.11.1` of node, and version `5.8.0` of npm. These are the only supported versions for this project.
 
-** NOTE: ** npm 5.8.0 is not installed by default with node 8.11.1. You will need to use `npm install -g npm` to do this. Test which version of npm you are using by typing `npm --version`.
+** NOTE: ** npm 5.8.0 is not installed by default with node 8.11.1. You will need to use `npm install -g npm@5.8.0` to do this. Test which version of npm you are using by typing `npm --version`.
 
 As a convenience, the repository contains a `.node-version` file that enables convinient use of a node environment manager.
 

--- a/config.xml
+++ b/config.xml
@@ -68,4 +68,5 @@
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
     <engine name="android" spec="^7.1.0" />
     <engine name="ios" spec="^4.5.4" />
+    <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -66,7 +66,7 @@
     <plugin name="cordova-plugin-x-socialsharing" spec="^5.2.1" />
     <plugin name="cordova-plugin-zeroconf" spec="^1.3.3" />
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
+    <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
     <engine name="android" spec="^7.1.0" />
     <engine name="ios" spec="^4.5.4" />
-    <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
 </widget>

--- a/cordova-plugin-network-canvas-client/README.md
+++ b/cordova-plugin-network-canvas-client/README.md
@@ -1,0 +1,3 @@
+# Network Canvas Client
+
+An API client for an instance of [Network Canvas](https://github.com/codaco/Network-Canvas) communicating with paired instances of [Server](https://github.com/codaco/Server).

--- a/cordova-plugin-network-canvas-client/package.json
+++ b/cordova-plugin-network-canvas-client/package.json
@@ -14,5 +14,10 @@
     "canvas"
   ],
   "author": "codaco",
-  "license": "GPL-3.0-or-later"
+  "license": "GPL-3.0-or-later",
+  "engines": {
+    "cordovaDependencies": {
+        "0.0.1": { "cordova-plugin-file": "^5.0.0"}
+    }
+  }
 }

--- a/cordova-plugin-network-canvas-client/package.json
+++ b/cordova-plugin-network-canvas-client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cordova-plugin-network-canvas-client",
+  "version": "0.0.1",
+  "description": "Cordova Plugin for Network Canvas API clients",
+  "keywords": [
+    "social",
+    "network",
+    "sna",
+    "visualization",
+    "research",
+    "public",
+    "health",
+    "network",
+    "canvas"
+  ],
+  "author": "codaco",
+  "license": "GPL-3.0-or-later"
+}

--- a/cordova-plugin-network-canvas-client/plugin.xml
+++ b/cordova-plugin-network-canvas-client/plugin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        id="cordova-plugin-network-canvas-client" version="0.0.1">
+    <name>Network Canvas Client</name>
+    <description>Cordova Plugin for Network Canvas API clients</description>
+    <license>GPL-3.0-or-later</license>
+    <keywords>social network,sna,visualization,research,public health,network canvas</keywords>
+    <js-module src="www/client.js" name="client">
+        <clobbers target="cordova.plugins.NetworkCanvasClient" />
+    </js-module>
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="NetworkCanvasClient">
+                <param name="ios-package" value="NetworkCanvasClient"/>
+            </feature>
+        </config-file>
+        <header-file src="src/ios/NetworkCanvasClient.h" />
+        <source-file src="src/ios/NetworkCanvasClient.m" />
+    </platform>
+    <platform name="android">
+        <config-file target="config.xml" parent="/*">
+            <feature name="NetworkCanvasClient">
+                <param name="android-package" value="org.codaco.networkCanvas.plugin.NetworkCanvasClient"/>
+            </feature>
+        </config-file>
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.INTERNET" />
+        </config-file>
+        <source-file src="src/android/NetworkCanvasClient.java" target-dir="src/org/codaco/networkCanvas/plugin" />
+    </platform>
+</plugin>

--- a/cordova-plugin-network-canvas-client/plugin.xml
+++ b/cordova-plugin-network-canvas-client/plugin.xml
@@ -5,6 +5,7 @@
     <description>Cordova Plugin for Network Canvas API clients</description>
     <license>GPL-3.0-or-later</license>
     <keywords>social network,sna,visualization,research,public health,network canvas</keywords>
+    <dependency id="cordova-plugin-file" version="^5.0.0" />
     <js-module src="www/client.js" name="client">
         <clobbers target="cordova.plugins.NetworkCanvasClient" />
     </js-module>

--- a/cordova-plugin-network-canvas-client/src/android/NetworkCanvasClient.java
+++ b/cordova-plugin-network-canvas-client/src/android/NetworkCanvasClient.java
@@ -1,0 +1,216 @@
+package org.codaco.networkCanvas.plugin;
+
+import android.util.Base64;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManagerFactory;
+
+public class NetworkCanvasClient extends CordovaPlugin {
+    private Charset UTF_8 = Charset.forName("UTF-8");
+
+    private KeyStore keyStore = null;
+
+    HostnameVerifier localhostVerifier = new HostnameVerifier() {
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            HostnameVerifier verifier = HttpsURLConnection.getDefaultHostnameVerifier();
+            return verifier.verify("127.0.0.1", session);
+        }
+    };
+
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        switch (action) {
+            case "send":
+                String deviceId = args.getString(0);
+                String url = args.getString(1);
+                String method = args.getString(2);
+                String body = null;
+                if (args.length() > 3) {
+                    body = args.getString(3);
+                    System.out.println("BODY LENGTH" + body.length());
+                }
+                this.send(deviceId, url, method, body, callbackContext);
+                return true;
+            case "acceptCertificate":
+                String cert = args.getString(0);
+                this.acceptCertificate(cert, callbackContext);
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     Supply a public Server certificate to be considered trusted.
+     Async.
+
+     Arguments to the cordova command:
+     1. {string} The PEM-formatted certificate
+
+     // Adapted from https://developer.android.com/training/articles/security-ssl#java
+     // Apache-2.0: https://developer.android.com/license
+     */
+    private void acceptCertificate(String cert, CallbackContext callbackContext) {
+        System.out.println(cert);
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            InputStream inputStream = new ByteArrayInputStream(cert.getBytes(UTF_8));
+            Certificate certificate = factory.generateCertificate(inputStream);
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+
+            keyStore.load(null, null);
+            // TODO: accept alias from client?
+            keyStore.setCertificateEntry("CustomServerCert", certificate);
+            this.keyStore = keyStore;
+            callbackContext.success();
+
+        } catch (CertificateException e) {
+            e.printStackTrace();
+        } catch (KeyStoreException e) {
+            e.printStackTrace();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private String inputStreamAsString(InputStream stream) throws IOException {
+        int bufSize = 1024;
+        char[] buffer = new char[bufSize];
+        InputStreamReader streamReader = new InputStreamReader(stream, UTF_8);
+        BufferedReader bufferedReader = new BufferedReader(streamReader, bufSize);
+        StringWriter writer = new StringWriter();
+        int charsRead = 0;
+        while (-1 != (charsRead = bufferedReader.read(buffer))) {
+            writer.write(buffer, 0, charsRead);
+        }
+        return writer.toString();
+    }
+
+    private JSONObject inputStreamAsJSONObject(InputStream stream) {
+        String string = null;
+        JSONObject obj = null;
+        try {
+            string = inputStreamAsString(stream);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return jsonError("Error reading Server response");
+        }
+        try {
+            obj = new JSONObject(string);
+        } catch (JSONException e) {
+            e.printStackTrace();
+            return jsonError("Error parsing Server response");
+        }
+        return obj;
+    }
+
+    /**
+     *
+     * @param deviceId
+     * @param toUrl
+     * @param method
+     * @param body
+     * @param callbackContext
+     *
+     * Adapted from https://developer.android.com/training/articles/security-ssl#java
+     * Apache-2.0: https://developer.android.com/license
+     */
+    private void send(String deviceId, String toUrl, String method, String body, CallbackContext callbackContext) {
+        try {
+            String algo = TrustManagerFactory.getDefaultAlgorithm();
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(algo);
+            trustManagerFactory.init(keyStore);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+
+
+            URL url = new URL(toUrl);
+
+            HttpsURLConnection urlConnection = (HttpsURLConnection)url.openConnection();
+            urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+            urlConnection.setHostnameVerifier(localhostVerifier);
+
+            urlConnection.setRequestProperty("Content-Type", "application/json");
+            urlConnection.setRequestMethod(method);
+
+            // Basic Auth
+            String creds = deviceId + ":";
+            String auth = Base64.encodeToString(creds.getBytes(UTF_8), Base64.DEFAULT);
+            urlConnection.setRequestProperty("Authorization", "Basic " + auth);
+
+            if (body != null) {
+                urlConnection.setDoOutput(true);
+                OutputStream out = urlConnection.getOutputStream();
+                out.write(body.getBytes(UTF_8));
+                out.close();
+            }
+
+            int code = urlConnection.getResponseCode();
+
+//            InputStream in = urlConnection.getInputStream();
+            if (code >= HttpsURLConnection.HTTP_BAD_REQUEST) {
+                JSONObject resp = inputStreamAsJSONObject(urlConnection.getErrorStream());
+                callbackContext.error(resp);
+            } else {
+                JSONObject resp = inputStreamAsJSONObject(urlConnection.getInputStream());
+                callbackContext.success(resp);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // Fatal. No device support for default algo.
+            e.printStackTrace();
+            callbackContext.error(jsonError("SSL not supported on this device."));
+        } catch (IOException | KeyStoreException | KeyManagementException e) {
+            e.printStackTrace();
+            callbackContext.error(jsonError(e));
+        }
+    }
+
+    /**
+     * @param message User-friendly error message
+     * @return JSON matching Server API format
+     */
+    private JSONObject jsonError(String message) {
+        JSONObject err = new JSONObject();
+        try {
+            err.put("status", "error");
+            err.put("message", message);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return err;
+    }
+
+    private JSONObject jsonError(Exception exception){
+        return jsonError(exception.getMessage());
+    }
+}

--- a/cordova-plugin-network-canvas-client/src/android/NetworkCanvasClient.java
+++ b/cordova-plugin-network-canvas-client/src/android/NetworkCanvasClient.java
@@ -1,20 +1,32 @@
 package org.codaco.networkCanvas.plugin;
 
+import android.net.Uri;
 import android.util.Base64;
 
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaResourceApi;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.LOG;
+import org.apache.cordova.PluginManager;
+import org.apache.cordova.file.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -29,22 +41,34 @@ import java.security.cert.CertificateFactory;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 
 public class NetworkCanvasClient extends CordovaPlugin {
-    private Charset UTF_8 = Charset.forName("UTF-8");
+    private final String LogTag = "NetworkCanvas:ClientPlugin";
+    private final Charset UTF_8 = Charset.forName("UTF-8");
+    private final int BufferSize = 1024;
 
-    private KeyStore keyStore = null;
+    private KeyStore keyStore;
+    private FileUtils cdvFilePlugin;
+    private CordovaResourceApi cdvResourceApi;
 
     class ApiRequest implements Runnable {
         private final String deviceId;
         private final URL url;
         private final String method;
-        private final String body;
         private final CallbackContext callbackContext;
+        private Uri downloadDestination;
+        private String body;
 
-        public ApiRequest(String deviceId, URL url, String method, String body, CallbackContext callbackContext) {
+        ApiRequest(String deviceId, URL url, Uri downloadDestination, CallbackContext callbackContext) {
+            this.deviceId = deviceId;
+            this.url = url;
+            this.downloadDestination = downloadDestination;
+            this.method = "GET";
+            this.callbackContext = callbackContext;
+        }
+
+        ApiRequest(String deviceId, URL url, String method, String body, CallbackContext callbackContext) {
             this.deviceId = deviceId;
             this.url = url;
             this.method = method;
@@ -58,6 +82,9 @@ public class NetworkCanvasClient extends CordovaPlugin {
          */
         @Override
         public void run() {
+            HttpsURLConnection urlConnection = null;
+            InputStream respInputStream = null;
+            InputStream respErrorStream = null;
             try {
                 String algo = TrustManagerFactory.getDefaultAlgorithm();
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(algo);
@@ -66,7 +93,7 @@ public class NetworkCanvasClient extends CordovaPlugin {
                 SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
 
-                HttpsURLConnection urlConnection = (HttpsURLConnection)url.openConnection();
+                urlConnection = (HttpsURLConnection)url.openConnection();
                 urlConnection.setSSLSocketFactory(sslContext.getSocketFactory());
                 urlConnection.setHostnameVerifier(localhostVerifier);
 
@@ -87,38 +114,61 @@ public class NetworkCanvasClient extends CordovaPlugin {
 
                 int code = urlConnection.getResponseCode();
                 if (code >= HttpsURLConnection.HTTP_BAD_REQUEST) {
-                    JSONObject resp = inputStreamAsJSONObject(urlConnection.getErrorStream());
+                    respErrorStream = urlConnection.getErrorStream();
+                    JSONObject resp = inputStreamToJSONObject(respErrorStream);
+                    respErrorStream.close();
                     callbackContext.error(resp);
+                } else if (downloadDestination != null) {
+                    // Save Server response to file and respond with file info
+                    respInputStream = urlConnection.getInputStream();
+                    inputStreamToFile(respInputStream, downloadDestination);
+                    File savedFile = cdvResourceApi.mapUriToFile(downloadDestination);
+                    JSONObject fileInfo = cdvFilePlugin.getEntryForFile(savedFile);
+                    respInputStream.close();
+                    callbackContext.success(fileInfo);
                 } else {
-                    JSONObject resp = inputStreamAsJSONObject(urlConnection.getInputStream());
+                    // Respond directly with data
+                    respInputStream = urlConnection.getInputStream();
+                    JSONObject resp = inputStreamToJSONObject(respInputStream);
+                    respInputStream.close();
                     callbackContext.success(resp);
                 }
             } catch (NoSuchAlgorithmException e) {
                 // Fatal. No device support for default algo.
                 e.printStackTrace();
                 callbackContext.error(jsonError("SSL not supported on this device."));
-            } catch (IOException | KeyStoreException | KeyManagementException e) {
+            } catch (IOException | JSONException | KeyStoreException | KeyManagementException e) {
                 e.printStackTrace();
                 callbackContext.error(jsonError(e));
+            } finally {
+                if (urlConnection != null) {
+                    urlConnection.disconnect();
+                }
             }
+
         }
     }
 
-    HostnameVerifier localhostVerifier = new HostnameVerifier() {
-        @Override
-        public boolean verify(String hostname, SSLSession session) {
-            HostnameVerifier verifier = HttpsURLConnection.getDefaultHostnameVerifier();
-            return verifier.verify("127.0.0.1", session);
-        }
+    private HostnameVerifier localhostVerifier = (hostname, session) -> {
+        HostnameVerifier verifier = HttpsURLConnection.getDefaultHostnameVerifier();
+        return verifier.verify("127.0.0.1", session);
     };
 
     @Override
-    public void onReset() {
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        cdvResourceApi = webView.getResourceApi();
+        cdvFilePlugin = getCdvFilePlugin(webView);
     }
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         switch (action) {
+            case "acceptCertificate":
+                String cert = args.getString(0);
+                this.acceptCertificate(cert, callbackContext);
+                return true;
+            case "download":
             case "send":
                 String deviceId = args.getString(0);
                 URL url = null;
@@ -129,17 +179,24 @@ public class NetworkCanvasClient extends CordovaPlugin {
                     callbackContext.error(jsonError("Invalid URL"));
                     return true;
                 }
-                String method = args.getString(2);
+
+                ApiRequest req = null;
+                String method = null;
                 String body = null;
-                if (args.length() > 3) {
-                    body = args.getString(3);
+                if (action.equals("download")) {
+                    String destination = args.getString(2);
+                    Uri cordovaUri = Uri.parse(destination);
+                    Uri nativeUri = cdvResourceApi.remapUri(cordovaUri);
+                    req = new ApiRequest(deviceId, url, nativeUri, callbackContext);
+                } else {
+                    method = args.getString(2);
+                    if (args.length() > 3) {
+                        body = args.getString(3);
+                    }
+                    req = new ApiRequest(deviceId, url, method, body, callbackContext);
                 }
-                ApiRequest req = new ApiRequest(deviceId, url, method, body, callbackContext);
+
                 cordova.getThreadPool().execute(req);
-                return true;
-            case "acceptCertificate":
-                String cert = args.getString(0);
-                this.acceptCertificate(cert, callbackContext);
                 return true;
         }
         return false;
@@ -162,38 +219,53 @@ public class NetworkCanvasClient extends CordovaPlugin {
             InputStream inputStream = new ByteArrayInputStream(cert.getBytes(UTF_8));
             Certificate certificate = factory.generateCertificate(inputStream);
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-
             keyStore.load(null, null);
-            // TODO: accept alias from client?
-            keyStore.setCertificateEntry("CustomServerCert", certificate);
+            keyStore.setCertificateEntry("NetworkCanvasServerCert", certificate);
             this.keyStore = keyStore;
             callbackContext.success();
-
-        } catch (CertificateException e) {
+        } catch (CertificateException | KeyStoreException | NoSuchAlgorithmException | IOException e) {
             e.printStackTrace();
-        } catch (KeyStoreException e) {
-            e.printStackTrace();
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+            callbackContext.error(e.getLocalizedMessage());
         }
     }
 
+    //region response formatting
     private String inputStreamAsString(InputStream stream) throws IOException {
-        int bufSize = 1024;
-        char[] buffer = new char[bufSize];
-        InputStreamReader streamReader = new InputStreamReader(stream, UTF_8);
-        BufferedReader bufferedReader = new BufferedReader(streamReader, bufSize);
-        StringWriter writer = new StringWriter();
-        int charsRead = 0;
-        while (-1 != (charsRead = bufferedReader.read(buffer))) {
-            writer.write(buffer, 0, charsRead);
+        char[] buffer = new char[BufferSize];
+        try (
+            InputStreamReader streamReader = new InputStreamReader(stream, UTF_8);
+            BufferedReader bufferedReader = new BufferedReader(streamReader, BufferSize);
+            StringWriter writer = new StringWriter();
+        ) {
+            int charsRead = 0;
+            while (-1 != (charsRead = bufferedReader.read(buffer))) {
+                writer.write(buffer, 0, charsRead);
+            }
+            return writer.toString();
         }
-        return writer.toString();
     }
 
-    private JSONObject inputStreamAsJSONObject(InputStream stream) {
+    private void ensureParentDir(Uri uri) {
+        File file = new File(uri.getPath());
+        File parentDir = file.getParentFile();
+        if (parentDir != null) {
+            parentDir.mkdirs();
+        }
+    }
+
+    private void inputStreamToFile(InputStream inputStream, Uri destination) throws IOException {
+        ensureParentDir(destination);
+        byte[] buf = new byte[BufferSize];
+        try (FileOutputStream outputStream = new FileOutputStream(destination.getPath())) {
+            int bytesRead = 0;
+            while (-1 != (bytesRead = inputStream.read(buf))) {
+                outputStream.write(buf, 0, bytesRead);
+            }
+            outputStream.flush();
+        }
+    }
+
+    private JSONObject inputStreamToJSONObject(InputStream stream) {
         String string = null;
         JSONObject obj = null;
         try {
@@ -228,5 +300,32 @@ public class NetworkCanvasClient extends CordovaPlugin {
 
     private JSONObject jsonError(Exception exception){
         return jsonError(exception.getMessage());
+    }
+    //endregion
+
+    private FileUtils getCdvFilePlugin(CordovaWebView webView) {
+        PluginManager pluginManager = null;
+        try {
+            Method method = webView.getClass().getMethod("getPluginManager");
+            pluginManager = (PluginManager) method.invoke(webView);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            // try getField
+        }
+
+        if (pluginManager == null) {
+            try {
+                Field field = webView.getClass().getField("pluginManager");
+                pluginManager = (PluginManager)field.get(webView);
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                // Log warning below
+            }
+        }
+
+        if (pluginManager != null) {
+            return (FileUtils) pluginManager.getPlugin("File");
+        }
+
+        LOG.w(LogTag, "Could not get FilePlugin; download interface will not be available");
+        return null;
     }
 }

--- a/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
+++ b/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
@@ -1,0 +1,34 @@
+//
+//  NetworkCanvasClient.h
+//  NetworkCanvas
+//
+//  Created by Bryan Fox on 8/13/18.
+//  Copyright © 2018 Codaco. All rights reserved.
+//
+
+#import <Cordova/CDV.h>
+
+@interface NetworkCanvasClient : CDVPlugin <NSURLSessionDelegate, NSURLSessionTaskDelegate>
+
+/**
+ Supply a public Server certificate to be considered trusted.
+ Async.
+
+ Arguments to the cordova command:
+ 1. {string} The PEM-formatted certificate
+ */
+- (void)acceptCertificate:(CDVInvokedUrlCommand*)command;
+
+/**
+ Send a request to a Server and receive the response.
+ Async.
+
+ Arguments to the cordova command:
+ 1. {string} deviceId, used for auth
+ 2. {string} URL
+ 3. {string} HTTP method
+ 4. {string} (optional) POST body
+ */
+- (void)send:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
+++ b/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
@@ -31,4 +31,15 @@
  */
 - (void)send:(CDVInvokedUrlCommand*)command;
 
+/**
+ Send a request to a Server and save the response data to the specifed local file URL.
+ Async.
+
+ Arguments to the cordova command:
+ 1. {string} deviceId, used for auth
+ 2. {string} sourceURL of data to download
+ 3. {string} targetURL local filesystem URL to save file
+ */
+- (void)download:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
+++ b/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.h
@@ -2,8 +2,7 @@
 //  NetworkCanvasClient.h
 //  NetworkCanvas
 //
-//  Created by Bryan Fox on 8/13/18.
-//  Copyright © 2018 Codaco. All rights reserved.
+//  See LICENSE file at project root or https://github.com/codaco/Network-Canvas/blob/master/LICENSE
 //
 
 #import <Cordova/CDV.h>

--- a/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.m
+++ b/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.m
@@ -1,0 +1,216 @@
+//
+//  NetworkCanvasClient.m
+//  NetworkCanvas
+//
+//  Created by Bryan Fox on 8/13/18.
+//  Copyright © 2018 Codaco. All rights reserved.
+//
+
+#import "NetworkCanvasClient.h"
+
+typedef void(^DataTaskCompletion)(NSData *data, NSURLResponse *response, NSError *error);
+
+@interface NetworkCanvasClient()
+    @property NSMutableDictionary *taskMetadata;
+    @property NSOperationQueue *operationQueue;
+    @property NSData *acceptableCert;
+@end
+
+@implementation NetworkCanvasClient
+
+- (void)pluginInitialize
+{
+    self.operationQueue = [NSOperationQueue new];
+    self.taskMetadata = [NSMutableDictionary new];
+}
+
+#pragma mark - NSURLSessionTaskDelegate
+
+// Challenge for HTTP basic auth: provide the deviceID as the username
+// Only sent for HTTPS requests to protect confidentiality of ID.
+// TODO: Review. Possibly require IP, and not hostname? Else DNS is attack vector for revealing deviceId...
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
+{
+    NSURLProtectionSpace *protectionSpace = challenge.protectionSpace;
+    if (
+        [protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] &&
+        [protectionSpace.protocol isEqualToString:NSURLProtectionSpaceHTTPS]
+        ) {
+        NSDictionary *meta = [self.taskMetadata objectForKey:task.taskDescription];
+        NSString *deviceId = [meta objectForKey:@"deviceId"];
+        NSURLCredential *cred = [NSURLCredential credentialWithUser:deviceId
+                                                           password:@""
+                                                        persistence:NSURLCredentialPersistenceForSession];
+        completionHandler(NSURLSessionAuthChallengeUseCredential, cred);
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
+}
+
+#pragma mark - NSURLSessionDelegate
+
+// Server certificate challenge
+- (void)URLSession:(NSURLSession *)session
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
+{
+    if (![challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+        return;
+    }
+
+    NSLog(@"ProtectHost %@", challenge.protectionSpace.host);
+
+    SecTrustRef trust = challenge.protectionSpace.serverTrust;
+
+    // 1. Update trust policy to require loopback addr (even if another IP/name
+    //    is used to address the Server.
+    //    Server certs [must] include 127.0.0.1 as CN or in SAN.
+    SecPolicyRef localhostPolicy = SecPolicyCreateSSL(true, CFSTR("127.0.0.1"));
+    SecTrustSetPolicies(trust, localhostPolicy);
+    CFRelease(localhostPolicy);
+
+    // 2. Add OOB trusted cert to chain
+    CFDataRef cert = (__bridge CFDataRef)self.acceptableCert;
+    SecCertificateRef pretrustedCert = SecCertificateCreateWithData(kCFAllocatorDefault,
+                                                                    cert);
+    if (pretrustedCert) {
+        SecCertificateRef preTrustedCerts[1];
+        preTrustedCerts[0] = pretrustedCert;
+        CFArrayRef certs = CFArrayCreate(kCFAllocatorDefault,
+                                         (const void **)preTrustedCerts, 1,
+                                         &kCFTypeArrayCallBacks);
+        SecTrustSetAnchorCertificates(trust, certs);
+        CFRelease(certs);
+        CFRelease(pretrustedCert);
+    } else {
+        NSLog(@"WARN Couldn't create trusted cert ref (probably invalid format)");
+    }
+
+    // 3. Evaluate the trust policy
+    SecTrustResultType evaluationResult = kSecTrustResultInvalid;
+
+    if (SecTrustEvaluate(trust, &evaluationResult) != errSecSuccess) {
+        NSLog(@"WARN Cert could not be evaluated");
+    }
+
+    switch (evaluationResult) {
+        case kSecTrustResultUnspecified: // OS trusts this certificate
+            completionHandler(NSURLSessionAuthChallengeUseCredential,
+                              [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+            break;
+        default:
+            NSLog(@"Invalid cert");
+            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, NULL);
+    }
+}
+
+#pragma mark - Cordova Interface
+
+- (void)acceptCertificate:(CDVInvokedUrlCommand*)command
+{
+    NSString *fullCert = [command.arguments objectAtIndex:0];
+
+    // TODO: more robust
+    // Strip first line & last 2 lines (e.g. "-----END CERTIFICATE-----\n\n")
+    NSArray *arr = [fullCert componentsSeparatedByString:@"\n"];
+    NSString *certificate = [[arr subarrayWithRange:NSMakeRange(1, arr.count - 3)] componentsJoinedByString:@"\n"];
+
+    self.acceptableCert = [[NSData alloc] initWithBase64EncodedString:certificate
+                                                              options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                      messageAsString:@"OK"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+};
+
+- (void)send:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult *pluginResult = nil;
+    NSString *deviceId = [command.arguments objectAtIndex:0];
+    NSString *urlStr = [command.arguments objectAtIndex:1];
+    NSString *method = [command.arguments objectAtIndex:2];
+
+    NSString *body = nil;
+    if (command.arguments.count > 3) {
+        body = [command.arguments objectAtIndex:3];
+    }
+
+    if (deviceId && urlStr) {
+        NSURL *url = [NSURL URLWithString:urlStr];
+        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+        req.HTTPMethod = method;
+        [req setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+        if (body) {
+            [req setHTTPBody:[body dataUsingEncoding:NSUTF8StringEncoding]];
+        }
+        [self fulfillRequestWithDeviceId: deviceId
+                                 request:req
+                              callbackId:command.callbackId];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                     messageAsDictionary:[self errorDictWithMessage:@"Arg required"]];
+        [self.commandDelegate sendPluginResult:pluginResult
+                                    callbackId:command.callbackId];
+    }
+}
+
+- (void)onReset
+{
+    [self.operationQueue cancelAllOperations];
+    [self.taskMetadata removeAllObjects];
+}
+
+#pragma mark - private
+
+// Error object matching server format
+- (NSDictionary *)errorDictWithMessage:(NSString *)message
+{
+    return @{
+             @"status": @"error",
+             @"message": message,
+            };
+}
+
+- (void)fulfillRequestWithDeviceId:(NSString *)deviceId request:(NSURLRequest *)req callbackId:(NSString *)callbackId
+{
+    NSDictionary *meta = @{
+                           @"deviceId": deviceId,
+                           };
+    [self.taskMetadata setObject:meta forKey:callbackId];
+
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:self.operationQueue];
+
+    DataTaskCompletion completionHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        CDVPluginResult *pluginResult = nil;
+
+        if (error) {
+            NSLog(@"Network Error: %@", error);
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                         messageAsDictionary:[self errorDictWithMessage:error.localizedDescription]];
+        } else {
+            NSString *resp = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            CDVCommandStatus cdvStatus = (httpResponse.statusCode >= 400) ? CDVCommandStatus_ERROR : CDVCommandStatus_OK;
+            pluginResult = [CDVPluginResult resultWithStatus:cdvStatus messageAsString:resp];
+        }
+
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+        [self.taskMetadata removeObjectForKey:callbackId];
+    };
+
+    NSURLSessionTask *reqTask = [session dataTaskWithRequest:req completionHandler:completionHandler];
+    [reqTask setTaskDescription:callbackId];
+
+    // TODO: Cancel token support. (Send a cancellation ID, but keep result open for normal resolution.)
+//    CDVPluginResult *cancelToken = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:callbackId];
+//    // API accepts NSNumber, but is converted to bool internally
+//    cancelToken.keepCallback = @1;
+//    [self.commandDelegate sendPluginResult:cancelToken callbackId:callbackId];
+    [reqTask resume];
+}
+
+@end

--- a/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.m
+++ b/cordova-plugin-network-canvas-client/src/ios/NetworkCanvasClient.m
@@ -5,8 +5,7 @@
 //  This plugin requires the Cordova File Plugin:
 //  https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-file/
 //
-//  Created by Bryan Fox on 8/13/18.
-//  Copyright © 2018 Codaco. All rights reserved.
+//  See LICENSE file at project root or https://github.com/codaco/Network-Canvas/blob/master/LICENSE
 //
 
 #import "NetworkCanvasClient.h"

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin.xcworkspace/contents.xcworkspacedata
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:NetworkCanvasClientPlugin/NetworkCanvasClientPlugin.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../../../platforms/ios/CordovaLib/CordovaLib.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin.xcodeproj/project.pbxproj
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin.xcodeproj/project.pbxproj
@@ -1,0 +1,467 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0F9C891E212DFCF3005324ED /* NetworkCanvasClientPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F9C8914212DFCF2005324ED /* NetworkCanvasClientPlugin.framework */; };
+		0F9C8923212DFCF3005324ED /* NetworkCanvasClientPluginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F9C8922212DFCF3005324ED /* NetworkCanvasClientPluginTests.m */; };
+		0F9C8934212DFD73005324ED /* NetworkCanvasClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F9C8932212DFD73005324ED /* NetworkCanvasClient.m */; };
+		0F9C8937212DFFCC005324ED /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F9C8936212DFFCC005324ED /* libCordova.a */; };
+		0F9C893B212E0026005324ED /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F9C893A212E0026005324ED /* libCordova.a */; };
+		0F9C893D212E1CBE005324ED /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0F9C893C212E1CBE005324ED /* Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0F9C891F212DFCF3005324ED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0F9C890B212DFCF2005324ED /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0F9C8913212DFCF2005324ED;
+			remoteInfo = NetworkCanvasClientPlugin;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0F9C8914212DFCF2005324ED /* NetworkCanvasClientPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkCanvasClientPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F9C891D212DFCF3005324ED /* NetworkCanvasClientPluginTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NetworkCanvasClientPluginTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F9C8922212DFCF3005324ED /* NetworkCanvasClientPluginTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NetworkCanvasClientPluginTests.m; sourceTree = "<group>"; };
+		0F9C8924212DFCF3005324ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0F9C8932212DFD73005324ED /* NetworkCanvasClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NetworkCanvasClient.m; path = ../../../src/ios/NetworkCanvasClient.m; sourceTree = "<group>"; };
+		0F9C8933212DFD73005324ED /* NetworkCanvasClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NetworkCanvasClient.h; path = ../../../src/ios/NetworkCanvasClient.h; sourceTree = "<group>"; };
+		0F9C8936212DFFCC005324ED /* libCordova.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCordova.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F9C8938212E0015005324ED /* Cordova.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Cordova.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F9C893A212E0026005324ED /* libCordova.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCordova.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F9C893C212E1CBE005324ED /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0F9C8910212DFCF2005324ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0F9C8937212DFFCC005324ED /* libCordova.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0F9C891A212DFCF3005324ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0F9C893B212E0026005324ED /* libCordova.a in Frameworks */,
+				0F9C891E212DFCF3005324ED /* NetworkCanvasClientPlugin.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0F9C890A212DFCF2005324ED = {
+			isa = PBXGroup;
+			children = (
+				0F9C8933212DFD73005324ED /* NetworkCanvasClient.h */,
+				0F9C8932212DFD73005324ED /* NetworkCanvasClient.m */,
+				0F9C8916212DFCF2005324ED /* NetworkCanvasClientPlugin */,
+				0F9C8921212DFCF3005324ED /* NetworkCanvasClientPluginTests */,
+				0F9C8915212DFCF2005324ED /* Products */,
+				0F9C8935212DFFCC005324ED /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0F9C8915212DFCF2005324ED /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0F9C8914212DFCF2005324ED /* NetworkCanvasClientPlugin.framework */,
+				0F9C891D212DFCF3005324ED /* NetworkCanvasClientPluginTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0F9C8916212DFCF2005324ED /* NetworkCanvasClientPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				0F9C893C212E1CBE005324ED /* Info.plist */,
+			);
+			path = NetworkCanvasClientPlugin;
+			sourceTree = "<group>";
+		};
+		0F9C8921212DFCF3005324ED /* NetworkCanvasClientPluginTests */ = {
+			isa = PBXGroup;
+			children = (
+				0F9C8922212DFCF3005324ED /* NetworkCanvasClientPluginTests.m */,
+				0F9C8924212DFCF3005324ED /* Info.plist */,
+			);
+			path = NetworkCanvasClientPluginTests;
+			sourceTree = "<group>";
+		};
+		0F9C8935212DFFCC005324ED /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0F9C893A212E0026005324ED /* libCordova.a */,
+				0F9C8938212E0015005324ED /* Cordova.framework */,
+				0F9C8936212DFFCC005324ED /* libCordova.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0F9C8911212DFCF2005324ED /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0F9C8913212DFCF2005324ED /* NetworkCanvasClientPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0F9C8928212DFCF3005324ED /* Build configuration list for PBXNativeTarget "NetworkCanvasClientPlugin" */;
+			buildPhases = (
+				0F9C890F212DFCF2005324ED /* Sources */,
+				0F9C8910212DFCF2005324ED /* Frameworks */,
+				0F9C8911212DFCF2005324ED /* Headers */,
+				0F9C8912212DFCF2005324ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NetworkCanvasClientPlugin;
+			productName = NetworkCanvasClientPlugin;
+			productReference = 0F9C8914212DFCF2005324ED /* NetworkCanvasClientPlugin.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		0F9C891C212DFCF3005324ED /* NetworkCanvasClientPluginTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0F9C892B212DFCF3005324ED /* Build configuration list for PBXNativeTarget "NetworkCanvasClientPluginTests" */;
+			buildPhases = (
+				0F9C8919212DFCF3005324ED /* Sources */,
+				0F9C891A212DFCF3005324ED /* Frameworks */,
+				0F9C891B212DFCF3005324ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0F9C8920212DFCF3005324ED /* PBXTargetDependency */,
+			);
+			name = NetworkCanvasClientPluginTests;
+			productName = NetworkCanvasClientPluginTests;
+			productReference = 0F9C891D212DFCF3005324ED /* NetworkCanvasClientPluginTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0F9C890B212DFCF2005324ED /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = Codaco;
+				TargetAttributes = {
+					0F9C8913212DFCF2005324ED = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+					0F9C891C212DFCF3005324ED = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+				};
+			};
+			buildConfigurationList = 0F9C890E212DFCF2005324ED /* Build configuration list for PBXProject "NetworkCanvasClientPlugin" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 0F9C890A212DFCF2005324ED;
+			productRefGroup = 0F9C8915212DFCF2005324ED /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0F9C8913212DFCF2005324ED /* NetworkCanvasClientPlugin */,
+				0F9C891C212DFCF3005324ED /* NetworkCanvasClientPluginTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0F9C8912212DFCF2005324ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0F9C893D212E1CBE005324ED /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0F9C891B212DFCF3005324ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0F9C890F212DFCF2005324ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0F9C8919212DFCF3005324ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0F9C8923212DFCF3005324ED /* NetworkCanvasClientPluginTests.m in Sources */,
+				0F9C8934212DFD73005324ED /* NetworkCanvasClient.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0F9C8920212DFCF3005324ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0F9C8913212DFCF2005324ED /* NetworkCanvasClientPlugin */;
+			targetProxy = 0F9C891F212DFCF3005324ED /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0F9C8926212DFCF3005324ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0F9C8927212DFCF3005324ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0F9C8929212DFCF3005324ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkCanvasClientPlugin/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.codaco.NetworkCanvasClientPlugin;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0F9C892A212DFCF3005324ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = NetworkCanvasClientPlugin/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.codaco.NetworkCanvasClientPlugin;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		0F9C892C212DFCF3005324ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = NetworkCanvasClientPluginTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.codaco.NetworkCanvasClientPluginTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0F9C892D212DFCF3005324ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = NetworkCanvasClientPluginTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.codaco.NetworkCanvasClientPluginTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0F9C890E212DFCF2005324ED /* Build configuration list for PBXProject "NetworkCanvasClientPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0F9C8926212DFCF3005324ED /* Debug */,
+				0F9C8927212DFCF3005324ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0F9C8928212DFCF3005324ED /* Build configuration list for PBXNativeTarget "NetworkCanvasClientPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0F9C8929212DFCF3005324ED /* Debug */,
+				0F9C892A212DFCF3005324ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0F9C892B212DFCF3005324ED /* Build configuration list for PBXNativeTarget "NetworkCanvasClientPluginTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0F9C892C212DFCF3005324ED /* Debug */,
+				0F9C892D212DFCF3005324ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0F9C890B212DFCF2005324ED /* Project object */;
+}

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin.xcodeproj/project.pbxproj
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		0F9C8937212DFFCC005324ED /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F9C8936212DFFCC005324ED /* libCordova.a */; };
 		0F9C893B212E0026005324ED /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F9C893A212E0026005324ED /* libCordova.a */; };
 		0F9C893D212E1CBE005324ED /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0F9C893C212E1CBE005324ED /* Info.plist */; };
+		0FA5ED6F212F99AC0031A040 /* CDVFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5ED6E212F99AC0031A040 /* CDVFile.h */; };
+		0FA5ED75212F9A100031A040 /* CDVLocalFilesystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5ED74212F9A100031A040 /* CDVLocalFilesystem.h */; };
+		0FA5ED77212F9A3F0031A040 /* CDVFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5ED70212F99E70031A040 /* CDVFile.m */; };
+		0FA5ED78212F9A500031A040 /* CDVLocalFilesystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5ED71212F99E70031A040 /* CDVLocalFilesystem.m */; };
+		0FA5ED7A212F9A660031A040 /* CDVAssetLibraryFilesystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5ED79212F9A660031A040 /* CDVAssetLibraryFilesystem.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +41,11 @@
 		0F9C8938212E0015005324ED /* Cordova.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Cordova.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F9C893A212E0026005324ED /* libCordova.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCordova.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F9C893C212E1CBE005324ED /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0FA5ED6E212F99AC0031A040 /* CDVFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDVFile.h; path = "../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file/CDVFile.h"; sourceTree = "<group>"; };
+		0FA5ED70212F99E70031A040 /* CDVFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CDVFile.m; path = "../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file/CDVFile.m"; sourceTree = "<group>"; };
+		0FA5ED71212F99E70031A040 /* CDVLocalFilesystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CDVLocalFilesystem.m; path = "../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file/CDVLocalFilesystem.m"; sourceTree = "<group>"; };
+		0FA5ED74212F9A100031A040 /* CDVLocalFilesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDVLocalFilesystem.h; path = "../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file/CDVLocalFilesystem.h"; sourceTree = "<group>"; };
+		0FA5ED79212F9A660031A040 /* CDVAssetLibraryFilesystem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CDVAssetLibraryFilesystem.m; path = "../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file/CDVAssetLibraryFilesystem.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +72,11 @@
 		0F9C890A212DFCF2005324ED = {
 			isa = PBXGroup;
 			children = (
+				0FA5ED79212F9A660031A040 /* CDVAssetLibraryFilesystem.m */,
+				0FA5ED74212F9A100031A040 /* CDVLocalFilesystem.h */,
+				0FA5ED70212F99E70031A040 /* CDVFile.m */,
+				0FA5ED71212F99E70031A040 /* CDVLocalFilesystem.m */,
+				0FA5ED6E212F99AC0031A040 /* CDVFile.h */,
 				0F9C8933212DFD73005324ED /* NetworkCanvasClient.h */,
 				0F9C8932212DFD73005324ED /* NetworkCanvasClient.m */,
 				0F9C8916212DFCF2005324ED /* NetworkCanvasClientPlugin */,
@@ -114,6 +129,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0FA5ED75212F9A100031A040 /* CDVLocalFilesystem.h in Headers */,
+				0FA5ED6F212F99AC0031A040 /* CDVFile.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,6 +238,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0FA5ED7A212F9A660031A040 /* CDVAssetLibraryFilesystem.m in Sources */,
+				0FA5ED78212F9A500031A040 /* CDVLocalFilesystem.m in Sources */,
+				0FA5ED77212F9A3F0031A040 /* CDVFile.m in Sources */,
 				0F9C8923212DFCF3005324ED /* NetworkCanvasClientPluginTests.m in Sources */,
 				0F9C8934212DFD73005324ED /* NetworkCanvasClient.m in Sources */,
 			);
@@ -289,6 +309,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_ROOT)/../../../../../platforms/ios/CordovaLib/Classes/Public";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -344,6 +365,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_ROOT)/../../../../../platforms/ios/CordovaLib/Classes/Public";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
@@ -362,6 +384,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_ROOT)/../../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file",
+					"$(PROJECT_ROOT)/../../../../../platforms/ios/CordovaLib/Classes/Public",
+				);
 				INFOPLIST_FILE = NetworkCanvasClientPlugin/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -385,6 +411,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_ROOT)/../../../../../platforms/ios/NetworkCanvas/Plugins/cordova-plugin-file",
+					"$(PROJECT_ROOT)/../../../../../platforms/ios/CordovaLib/Classes/Public",
+				);
 				INFOPLIST_FILE = NetworkCanvasClientPlugin/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin/Info.plist
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPlugin/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/Info.plist
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/NetworkCanvasClientPluginTests.m
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/NetworkCanvasClientPluginTests.m
@@ -1,0 +1,54 @@
+//
+//  NetworkCanvasClientPluginTests.m
+//  NetworkCanvasClientPluginTests
+//
+//  Created by Bryan Fox on 8/22/18.
+//  Copyright © 2018 Codaco. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NetworkCanvasClient.h"
+
+
+@interface NetworkCanvasClientPluginTests : XCTestCase
+@property NetworkCanvasClient *client;
+@end
+
+@implementation NetworkCanvasClientPluginTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.client = [NetworkCanvasClient new];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma - helpers
+
+- (CDVInvokedUrlCommand *)commandWithArgs:(NSArray *)args {
+    NSArray *cdvArgs = @[@"callbackId", @"ClassName", @"methodName", args];
+    return [CDVInvokedUrlCommand commandFromJson:cdvArgs];
+}
+
+#pragma - tests
+
+- (void)testAcceptDoesNotThrowWhenMissingCert {
+    CDVInvokedUrlCommand *cmd = [self commandWithArgs:@[]];
+    XCTAssertNoThrow([self.client acceptCertificate:cmd]);
+}
+
+- (void)testAcceptDoesNotThrowWithInvalidCert {
+    CDVInvokedUrlCommand *cmd = [self commandWithArgs:@[@"mock-cert"]];
+    XCTAssertNoThrow([self.client acceptCertificate:cmd]);
+}
+
+- (void)testSendDoesNotThrowWhenMissingArgs {
+    CDVInvokedUrlCommand *cmd = [self commandWithArgs:@[]];
+    XCTAssertNoThrow([self.client send:cmd]);
+}
+
+@end

--- a/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/NetworkCanvasClientPluginTests.m
+++ b/cordova-plugin-network-canvas-client/test/ios/NetworkCanvasClientPlugin/NetworkCanvasClientPluginTests/NetworkCanvasClientPluginTests.m
@@ -2,8 +2,7 @@
 //  NetworkCanvasClientPluginTests.m
 //  NetworkCanvasClientPluginTests
 //
-//  Created by Bryan Fox on 8/22/18.
-//  Copyright © 2018 Codaco. All rights reserved.
+//  See LICENSE file at project root or https://github.com/codaco/Network-Canvas/blob/master/LICENSE
 //
 
 #import <XCTest/XCTest.h>

--- a/cordova-plugin-network-canvas-client/www/client.js
+++ b/cordova-plugin-network-canvas-client/www/client.js
@@ -1,0 +1,72 @@
+const exec = require('cordova/exec'); // eslint-disable-line import/no-unresolved
+
+const ServiceName = 'NetworkCanvasClient';
+
+const Actions = {
+  acceptCertificate: 'acceptCertificate',
+  send: 'send',
+};
+
+const respObject = (resp) => {
+  let data;
+  // TODO: can ever be Error type? (not clear from cordova docs)
+  if (typeof resp === 'string') {
+    data = JSON.parse(resp);
+  } else {
+    data = resp;
+  }
+  // Add data key to match axios interface
+  return { data };
+};
+
+// Match axios interface: errors have an additional response prop
+const respError = (resp) => {
+  const response = respObject(resp);
+  const err = new Error(response.message);
+  err.response = response;
+  return err;
+};
+
+class NetworkCanvasClient {
+  constructor(deviceId, serverCertData, baseURL) {
+    this.deviceId = deviceId;
+    this.serverCert = serverCertData;
+    this.baseURL = baseURL;
+  }
+
+  buildUrl(path) {
+    // TODO: robustness; use existing helpers?
+    return `${this.baseURL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+  }
+
+  acceptCertificate(cert = this.serverCert) {
+    return new Promise((resolve, reject) => {
+      const sendArgs = [cert];
+      exec(resolve, reject, ServiceName, Actions.acceptCertificate, sendArgs);
+    });
+  }
+
+  get(path) {
+    return this.send(path);
+  }
+
+  post(path, data) {
+    return this.send(path, 'POST', data);
+  }
+
+  send(path, method = 'GET', data = null) {
+    return new Promise((resolve, reject) => {
+      const sendArgs = [this.deviceId, this.buildUrl(path), method];
+      if (data) { sendArgs.push(JSON.stringify(data)); }
+
+      return exec(
+        resp => resolve(respObject(resp)),
+        resp => reject(respError(resp)),
+        ServiceName,
+        Actions.send,
+        sendArgs);
+    });
+  }
+}
+
+module.exports = NetworkCanvasClient;

--- a/cordova-plugin-network-canvas-client/www/client.js
+++ b/cordova-plugin-network-canvas-client/www/client.js
@@ -9,7 +9,6 @@ const Actions = {
 
 const respObject = (resp) => {
   let data;
-  // TODO: can ever be Error type? (not clear from cordova docs)
   if (typeof resp === 'string') {
     data = JSON.parse(resp);
   } else {
@@ -35,14 +34,24 @@ class NetworkCanvasClient {
   }
 
   buildUrl(path) {
-    // TODO: robustness; use existing helpers?
     return `${this.baseURL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
   }
 
+  /**
+   * @param  {string} cert PEM-formatted cert
+   * @return {Promise} Resolves with undefined if accepted.
+   *                   Rejects with error otherwise.
+   */
   acceptCertificate(cert = this.serverCert) {
     return new Promise((resolve, reject) => {
       const sendArgs = [cert];
-      exec(resolve, reject, ServiceName, Actions.acceptCertificate, sendArgs);
+      exec(
+        resolve,
+        resp => reject(respError(resp)),
+        ServiceName,
+        Actions.acceptCertificate,
+        sendArgs,
+      );
     });
   }
 
@@ -54,6 +63,14 @@ class NetworkCanvasClient {
     return this.send(path, 'POST', data);
   }
 
+  /**
+   * @async
+   * @param  {string} path
+   * @param  {string} method='GET'
+   * @param  {Object} data serializable as JSON
+   * @return {Promise} Resolves with the response object.
+   *                   Rejects with an error object if any error occurs.
+   */
   send(path, method = 'GET', data = null) {
     return new Promise((resolve, reject) => {
       const sendArgs = [this.deviceId, this.buildUrl(path), method];

--- a/cordova-plugin-network-canvas-client/www/client.js
+++ b/cordova-plugin-network-canvas-client/www/client.js
@@ -39,8 +39,9 @@ class NetworkCanvasClient {
     this.baseURL = baseURL;
   }
 
+  // @throws
   buildUrl(path) {
-    return `${this.baseURL.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+    return new URL(path, this.baseURL).href;
   }
 
   /**
@@ -91,9 +92,9 @@ class NetworkCanvasClient {
     });
   }
 
-  download(url, destination) {
-    const sendArgs = [this.deviceId, url, destination];
+  download(path, destination) {
     return new Promise((resolve, reject) => {
+      const sendArgs = [this.deviceId, this.buildUrl(path), destination];
       exec(resolve, reject, ServiceName, Actions.download, sendArgs);
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3911,6 +3911,9 @@
             "resolved": "https://registry.npmjs.org/cordova-plugin-file-transfer/-/cordova-plugin-file-transfer-1.7.1.tgz",
             "integrity": "sha1-p12L4uvDu5sjxbG70ZkhTsJnWGs="
         },
+        "cordova-plugin-network-canvas-client": {
+            "version": "file:cordova-plugin-network-canvas-client"
+        },
         "cordova-plugin-whitelist": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
         "cordova-plugin-device": "^2.0.2",
         "cordova-plugin-file": "^5.0.0",
         "cordova-plugin-file-transfer": "^1.7.1",
-        "cordova-plugin-network-canvas-client": "file:cordova-plugin-network-canvas-client",
+        "cordova-plugin-network-canvas-client": "./cordova-plugin-network-canvas-client",
         "cordova-plugin-whitelist": "^1.3.3",
         "cordova-plugin-wkwebview-engine": "^1.1.4",
         "cordova-plugin-x-socialsharing": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
         "cordova-plugin-device": "^2.0.2",
         "cordova-plugin-file": "^5.0.0",
         "cordova-plugin-file-transfer": "^1.7.1",
+        "cordova-plugin-network-canvas-client": "file:cordova-plugin-network-canvas-client",
         "cordova-plugin-whitelist": "^1.3.3",
         "cordova-plugin-wkwebview-engine": "^1.1.4",
         "cordova-plugin-x-socialsharing": "^5.2.1",
@@ -227,7 +228,8 @@
             "cordova-plugin-file-transfer": {},
             "cordova-plugin-whitelist": {},
             "cordova-plugin-zeroconf": {},
-            "cordova-plugin-device": {}
+            "cordova-plugin-device": {},
+            "cordova-plugin-network-canvas-client": {}
         }
     }
 }

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -8,6 +8,8 @@ const log = require('electron-log');
 const registerAssetsProtocol = require('./components/assetsProtocol').registerAssetsProtocol;
 require('./components/updater');
 
+const { commonName } = require('../src/utils/shared-api/sslConfig.js');
+
 const isMacOS = () => os.platform() === 'darwin';
 
 const titlebarParameters = isMacOS() ? { titleBarStyle: 'hidden', frame: false } : {};
@@ -183,8 +185,9 @@ ipcMain.on('add-cert', (evt, cert) => {
 
 app.on('certificate-error', (event, webContents, requestedUrl, error, certificate, callback) => {
   const protocolMatch = requestedUrl.startsWith('https:');
+  const nameMatch = certificate.subject.commonName === commonName;
   const rawCert = normalizeEol(certificate.data);
-  if (protocolMatch && pretrustedCertificates.has(rawCert)) {
+  if (nameMatch && protocolMatch && pretrustedCertificates.has(rawCert)) {
     event.preventDefault();
     callback(true);
   } else {

--- a/public/electron-starter.js
+++ b/public/electron-starter.js
@@ -1,4 +1,5 @@
-const { app, BrowserWindow, dialog, Menu, shell } = require('electron');
+const logger = require('electron-log');
+const { app, BrowserWindow, dialog, Menu, shell, ipcMain } = require('electron');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -168,6 +169,31 @@ app.on('ready', () => {
   createMenu();
   createWindow();
   loadDevToolsExtensions();
+});
+
+const normalizeEol = str => str.replace(/\r\n|\r|\n/g, '\r\n');
+
+// App must only add a certificate known to be from a trusted, paired Server.
+// Cert will be considered when making https calls; see the 'certificate-error' handler.
+const pretrustedCertificates = new Set();
+ipcMain.on('add-cert', (evt, cert) => {
+  pretrustedCertificates.add(normalizeEol(cert));
+  evt.sender.send('add-cert-complete');
+});
+
+app.on('certificate-error', (event, webContents, requestedUrl, error, certificate, callback) => {
+  const protocolMatch = requestedUrl.startsWith('https:');
+  const rawCert = normalizeEol(certificate.data);
+  if (protocolMatch && pretrustedCertificates.has(rawCert)) {
+    event.preventDefault();
+    callback(true);
+  } else {
+    logger.warn('Unexpected certificate error', requestedUrl);
+    logger.error(error);
+    // Calling `callback(false)` will cancel the request and prevent the error
+    // from being given to XHR. With axios, this results in a silent failure.
+    // Instead, allow the error to occur by not calling back.
+  }
 });
 
 // Quit when all windows are closed.

--- a/src/components/ErrorMessage.js
+++ b/src/components/ErrorMessage.js
@@ -51,7 +51,10 @@ const ErrorMessage = ({
 
 ErrorMessage.propTypes = {
   acknowledged: PropTypes.bool,
-  error: PropTypes.instanceOf(Error),
+  error: PropTypes.oneOfType([
+    PropTypes.instanceOf(Error),
+    PropTypes.shape({ friendlyMessage: PropTypes.string }),
+  ]),
   acknowledgeError: PropTypes.func.isRequired,
 };
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,76 +1,8 @@
-/* globals cordova */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { Icon } from '../ui/components';
 import { MenuItem, Scroller } from './';
-
-import { isCordova } from '../utils/Environment';
-
-import ApiClient from '../utils/ApiClient';
-
-// const b64EncodeUnicode = str => btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-//   (match, p1) => String.fromCharCode(`0x${p1}`),
-// ));
-
-const serverAddr = '192.168.1.4';
-
-const testPlugin = () => {
-  const pairingServiceUrl = `https://${serverAddr}:51002`;
-  // TODO: this is available from redux: servers.paired[].deviceId
-  const deviceId = '5b1ac0e7-c896-405f-bab0-8b778ab1b6eb';
-  // TODO: from redux
-  const endpointUrl = '/protocols';
-  // TODO: this is available from redux: servers.paired[].publicCert
-  const cert = `-----BEGIN CERTIFICATE-----
-MIIDBjCCAe6gAwIBAgIJb4Mq75vZ4WcqMA0GCSqGSIb3DQEBCwUAMCUxIzAhBgNV
-BAMTGk5ldHdvcmsgQ2FudmFzIChsb2NhbGhvc3QpMB4XDTE4MDgwNjE1NTQzMFoX
-DTI4MDgwMzE1NTQzMFowJTEjMCEGA1UEAxMaTmV0d29yayBDYW52YXMgKGxvY2Fs
-aG9zdCkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCCLNWb6Fpu+Ggs
-5sixcLB5c5nIBSj/OBjaSTps8h5JNOll2AZWQ1WDWNDIRwej8/uh6K20WWO3nvK2
-9w/EodnH09+tBWHkFy/pGBAZCtJi6hzG9ED9FlcBMetfa8azh39fdvqDneKxc6fc
-ppanYqThb6WVxm0Ghk5rnFKjEaVBpkGaxcbfFXJGZqmb5pSPH7eSv0A4wqBN92nY
-K3Qvr2sbf1iB7OKwTcsN0H0NSPn2NDG6TIGgu3meEf+gfbWwKFuuP6FZQIDM4I4N
-6r9ZIyoOvbgTutmOgFU9lXET8biH3W/1mZ9TJZgQT6NRCNLMWGOGIPlswpmv0xRg
-X+/TV/yzAgMBAAGjOTA3MAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MBoGA1Ud
-EQQTMBGCCWxvY2FsaG9zdIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAJqI9TKX5
-4SGjCmpLtttPeVYDjkXwx24v/JmaXoT6cl7Q65AYsVdRQbw8rl36qNkLbRi0Uc5C
-suTPxrhXBfKQ6GgxaINaPnk7jBKjM84BOjFD1jPMh9pio7rfE7VCvvy7ODZwqWFV
-KwtjoL1ya83a25CeZScTZbvOnJ+O3Pisbiy2mscv9zcgppRYJJf+oJnt1PbhN/P+
-9DrG/wIxSUYQy7vmdN61mfVylvahL2hZqPkwVzJwS+n4i+pPRoNP57ErcvnimvCm
-B2cJveDofiZPxFlJfSQGG/LCQAH/NVreP7y6s6kayQXy9zVO7S0fHxnkiIO5o+zh
-40wpQ+77K/jLdw==
------END CERTIFICATE-----
-`;
-
-  if (!isCordova()) {
-    console.log('Electron test');
-    const apiClient = new ApiClient({
-      name: 'mb18.local',
-      host: 'mb18.local.',
-      port: 51001,
-      addresses: [serverAddr],
-      pairingServiceUrl,
-      secureUrl: pairingServiceUrl.replace('51001', '51002').replace('http:', 'https:'),
-      sslCertificate: cert,
-      deviceId,
-      deviceSecret: 'fe8f7b86c1749ce5471f4764c0c2e05846cc4539fb439dc07c5658e494e720b2',
-    });
-    apiClient
-      .addTrustedCert()
-      .then(() => apiClient.getProtocols())
-      .then(protocols => console.log('Protocols', protocols))
-      .catch(console.error);
-    return;
-  }
-
-  const client = new cordova.plugins.NetworkCanvasClient(deviceId, cert, pairingServiceUrl);
-  client.acceptCertificate(cert)
-    .then(res => console.log('acceptCertificate response', res))
-    .then(() => client.send(endpointUrl))
-    .then(res => console.log('server response', res))
-    .catch(err => console.error('promise chain err', err));
-};
 
 const closeEvents = [
   'click',
@@ -157,12 +89,6 @@ class MenuFactory extends Component {
         menuType={item.menuType}
       />),
     );
-
-    menuItems.unshift(<MenuItem
-      key={'test-plugin'}
-      onClick={() => testPlugin()}
-      label="API Send test"
-    />);
 
     return (
       <div className="menu" ref={(node) => { this.domNode = node; }}>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -45,7 +45,7 @@ B2cJveDofiZPxFlJfSQGG/LCQAH/NVreP7y6s6kayQXy9zVO7S0fHxnkiIO5o+zh
 
   if (!isCordova()) {
     console.log('Electron test');
-    const apiClient = new ApiClient(apiUrl, {
+    const apiClient = new ApiClient({
       name: 'mb18.local',
       host: 'mb18.local.',
       port: 51001,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,8 +1,76 @@
+/* globals cordova */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { Icon } from '../ui/components';
 import { MenuItem, Scroller } from './';
+
+import { isCordova } from '../utils/Environment';
+
+import ApiClient from '../utils/ApiClient';
+
+// const b64EncodeUnicode = str => btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
+//   (match, p1) => String.fromCharCode(`0x${p1}`),
+// ));
+
+const serverAddr = '192.168.1.4';
+
+const testPlugin = () => {
+  const apiUrl = `https://${serverAddr}:51002`;
+  // TODO: this is available from redux: servers.paired[].deviceId
+  const deviceId = '5b1ac0e7-c896-405f-bab0-8b778ab1b6eb';
+  // TODO: from redux
+  const endpointUrl = '/protocols';
+  // TODO: this is available from redux: servers.paired[].publicCert
+  const cert = `-----BEGIN CERTIFICATE-----
+MIIDBjCCAe6gAwIBAgIJb4Mq75vZ4WcqMA0GCSqGSIb3DQEBCwUAMCUxIzAhBgNV
+BAMTGk5ldHdvcmsgQ2FudmFzIChsb2NhbGhvc3QpMB4XDTE4MDgwNjE1NTQzMFoX
+DTI4MDgwMzE1NTQzMFowJTEjMCEGA1UEAxMaTmV0d29yayBDYW52YXMgKGxvY2Fs
+aG9zdCkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCCLNWb6Fpu+Ggs
+5sixcLB5c5nIBSj/OBjaSTps8h5JNOll2AZWQ1WDWNDIRwej8/uh6K20WWO3nvK2
+9w/EodnH09+tBWHkFy/pGBAZCtJi6hzG9ED9FlcBMetfa8azh39fdvqDneKxc6fc
+ppanYqThb6WVxm0Ghk5rnFKjEaVBpkGaxcbfFXJGZqmb5pSPH7eSv0A4wqBN92nY
+K3Qvr2sbf1iB7OKwTcsN0H0NSPn2NDG6TIGgu3meEf+gfbWwKFuuP6FZQIDM4I4N
+6r9ZIyoOvbgTutmOgFU9lXET8biH3W/1mZ9TJZgQT6NRCNLMWGOGIPlswpmv0xRg
+X+/TV/yzAgMBAAGjOTA3MAwGA1UdEwQFMAMBAf8wCwYDVR0PBAQDAgL0MBoGA1Ud
+EQQTMBGCCWxvY2FsaG9zdIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAJqI9TKX5
+4SGjCmpLtttPeVYDjkXwx24v/JmaXoT6cl7Q65AYsVdRQbw8rl36qNkLbRi0Uc5C
+suTPxrhXBfKQ6GgxaINaPnk7jBKjM84BOjFD1jPMh9pio7rfE7VCvvy7ODZwqWFV
+KwtjoL1ya83a25CeZScTZbvOnJ+O3Pisbiy2mscv9zcgppRYJJf+oJnt1PbhN/P+
+9DrG/wIxSUYQy7vmdN61mfVylvahL2hZqPkwVzJwS+n4i+pPRoNP57ErcvnimvCm
+B2cJveDofiZPxFlJfSQGG/LCQAH/NVreP7y6s6kayQXy9zVO7S0fHxnkiIO5o+zh
+40wpQ+77K/jLdw==
+-----END CERTIFICATE-----
+`;
+
+  if (!isCordova()) {
+    console.log('Electron test');
+    const apiClient = new ApiClient(apiUrl, {
+      name: 'mb18.local',
+      host: 'mb18.local.',
+      port: 51001,
+      addresses: [serverAddr],
+      apiUrl,
+      secureUrl: apiUrl.replace('51001', '51002').replace('http:', 'https:'),
+      serverCert: cert,
+      deviceId,
+      deviceSecret: 'fe8f7b86c1749ce5471f4764c0c2e05846cc4539fb439dc07c5658e494e720b2',
+    });
+    apiClient
+      .addTrustedCert()
+      .then(() => apiClient.getProtocols())
+      .then(protocols => console.log('Protocols', protocols))
+      .catch(console.error);
+    return;
+  }
+
+  const client = new cordova.plugins.NetworkCanvasClient(deviceId, cert, apiUrl);
+  client.acceptCertificate(cert)
+    .then(res => console.log('acceptCertificate response', res))
+    .then(() => client.send(endpointUrl))
+    .then(res => console.log('server response', res))
+    .catch(err => console.error('promise chain err', err));
+};
 
 const closeEvents = [
   'click',
@@ -89,6 +157,12 @@ class MenuFactory extends Component {
         menuType={item.menuType}
       />),
     );
+
+    menuItems.unshift(<MenuItem
+      key={'test-plugin'}
+      onClick={() => testPlugin()}
+      label="API Send test"
+    />);
 
     return (
       <div className="menu" ref={(node) => { this.domNode = node; }}>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -16,7 +16,7 @@ import ApiClient from '../utils/ApiClient';
 const serverAddr = '192.168.1.4';
 
 const testPlugin = () => {
-  const apiUrl = `https://${serverAddr}:51002`;
+  const pairingServiceUrl = `https://${serverAddr}:51002`;
   // TODO: this is available from redux: servers.paired[].deviceId
   const deviceId = '5b1ac0e7-c896-405f-bab0-8b778ab1b6eb';
   // TODO: from redux
@@ -50,9 +50,9 @@ B2cJveDofiZPxFlJfSQGG/LCQAH/NVreP7y6s6kayQXy9zVO7S0fHxnkiIO5o+zh
       host: 'mb18.local.',
       port: 51001,
       addresses: [serverAddr],
-      apiUrl,
-      secureUrl: apiUrl.replace('51001', '51002').replace('http:', 'https:'),
-      serverCert: cert,
+      pairingServiceUrl,
+      secureUrl: pairingServiceUrl.replace('51001', '51002').replace('http:', 'https:'),
+      sslCertificate: cert,
       deviceId,
       deviceSecret: 'fe8f7b86c1749ce5471f4764c0c2e05846cc4539fb439dc07c5658e494e720b2',
     });
@@ -64,7 +64,7 @@ B2cJveDofiZPxFlJfSQGG/LCQAH/NVreP7y6s6kayQXy9zVO7S0fHxnkiIO5o+zh
     return;
   }
 
-  const client = new cordova.plugins.NetworkCanvasClient(deviceId, cert, apiUrl);
+  const client = new cordova.plugins.NetworkCanvasClient(deviceId, cert, pairingServiceUrl);
   client.acceptCertificate(cert)
     .then(res => console.log('acceptCertificate response', res))
     .then(() => client.send(endpointUrl))

--- a/src/components/Setup/ServerAddressForm.js
+++ b/src/components/Setup/ServerAddressForm.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import { addApiUrlToService, pairingApiProtocol, isValidAddress, isValidPort, maxPort, minPort } from '../../utils/serverAddressing';
+import { addPairingUrlToService, pairingApiProtocol, isValidAddress, isValidPort, maxPort, minPort } from '../../utils/serverAddressing';
 import { Button, Icon } from '../../ui/components';
 
 class ServerAddressForm extends PureComponent {
@@ -16,11 +16,11 @@ class ServerAddressForm extends PureComponent {
 
   onSubmit = (evt) => {
     evt.preventDefault();
-    const server = addApiUrlToService({
+    const server = addPairingUrlToService({
       addresses: [this.state.address],
       port: this.state.port,
     });
-    if (server.apiUrl) {
+    if (server.pairingServiceUrl) {
       this.props.selectServer(server);
     } else {
       this.setState({

--- a/src/components/Setup/ServerAddressForm.js
+++ b/src/components/Setup/ServerAddressForm.js
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types';
 import { addPairingUrlToService, pairingApiProtocol, isValidAddress, isValidPort, maxPort, minPort } from '../../utils/serverAddressing';
 import { Button, Icon } from '../../ui/components';
 
+/**
+ * @class Renders a form for user to manually enter Server connection info.
+ */
 class ServerAddressForm extends PureComponent {
   constructor(props) {
     super(props);

--- a/src/components/Setup/ServerAddressForm.js
+++ b/src/components/Setup/ServerAddressForm.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import { addApiUrlToService, apiProtocol, isValidAddress, isValidPort, maxPort, minPort } from '../../utils/serverAddressing';
+import { addApiUrlToService, pairingApiProtocol, isValidAddress, isValidPort, maxPort, minPort } from '../../utils/serverAddressing';
 import { Button, Icon } from '../../ui/components';
 
 class ServerAddressForm extends PureComponent {
@@ -78,7 +78,7 @@ class ServerAddressForm extends PureComponent {
         </p>
         <fieldset className="server-address-form__fields">
           <div className="server-address-form__field">
-            <p className="server-address-form__text">{apiProtocol}://</p>
+            <p className="server-address-form__text">{pairingApiProtocol}://</p>
           </div>
           <div className="server-address-form__field">
             <input

--- a/src/components/Setup/ServerPairingForm.js
+++ b/src/components/Setup/ServerPairingForm.js
@@ -5,6 +5,9 @@ import PairingCodeInput from './PairingCodeInput';
 import { Button, Spinner } from '../../ui/components';
 import { PairingCodeLength } from '../../utils/shared-api/pairingCodeConfig';
 
+/**
+ * @class Renders a form for user to enter the out-of-band pairing code presented by Server.
+ */
 class ServerPairingForm extends Component {
   constructor(props) {
     super(props);

--- a/src/components/Setup/ServerSetup.js
+++ b/src/components/Setup/ServerSetup.js
@@ -24,7 +24,7 @@ ServerSetup.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
   server: PropTypes.shape({
     addresses: PropTypes.array.isRequired,
-    apiUrl: PropTypes.string.isRequired,
+    pairingServiceUrl: PropTypes.string.isRequired,
     host: PropTypes.string,
   }).isRequired,
 };

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -20,7 +20,7 @@ const ExportSection = ({ defaultServer, children }) => (
       <h2>Data Export</h2>
       <p>
         Export this interview to {defaultServer.name} <br />
-        <small>{defaultServer.apiUrl}</small>
+        <small>{defaultServer.secureServiceUrl}</small>
       </p>
     </div>
     <div>
@@ -62,9 +62,9 @@ class FinishSession extends Component {
     return <p>This session is not exportable: it is not associated with any Server.</p>;
   }
 
-  get serverApiUrl() {
+  get exportUrl() {
     const { defaultServer } = this.props;
-    return defaultServer && defaultServer.apiUrl;
+    return defaultServer && defaultServer.secureServiceUrl;
   }
 
   get currentSessionBelongsToProtocol() {
@@ -72,7 +72,7 @@ class FinishSession extends Component {
   }
 
   get currentSessionisExportable() {
-    return this.currentSessionBelongsToProtocol && this.serverApiUrl;
+    return this.currentSessionBelongsToProtocol && this.exportUrl;
   }
 
   export(currentSession) {

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -13,6 +13,7 @@ import { actionCreators as modalActions } from '../../ducks/modules/modals';
 import { getNetwork } from '../../selectors/interface';
 import { getCurrentSession } from '../../selectors/session';
 import { protocolRegistry, getRemoteProtocolId } from '../../selectors/protocol';
+import { getPairedServer } from '../../selectors/servers';
 
 const ExportSection = ({ defaultServer, children }) => (
   <div className="finish-session-interface__section finish-session-interface__section--export">
@@ -170,7 +171,7 @@ function mapStateToProps(state) {
     currentSession: getCurrentSession(state),
     remoteProtocolId: getRemoteProtocolId(state),
     sessionId: state.session,
-    defaultServer: state.servers && state.servers.paired[0],
+    defaultServer: getPairedServer(state),
     variableRegistry: protocolRegistry(state),
   };
 }

--- a/src/containers/Interfaces/FinishSession.js
+++ b/src/containers/Interfaces/FinishSession.js
@@ -78,9 +78,7 @@ class FinishSession extends Component {
   export(currentSession) {
     const { remoteProtocolId, sessionId } = this.props;
     const sessionData = currentSession.network;
-    if (this.serverApiUrl) {
-      this.props.exportSession(this.serverApiUrl, remoteProtocolId, sessionId, sessionData);
-    }
+    this.props.exportSession(remoteProtocolId, sessionId, sessionData);
   }
 
   downloadData = (additionalInformation) => {

--- a/src/containers/Interfaces/__tests__/FinishSession.test.js
+++ b/src/containers/Interfaces/__tests__/FinishSession.test.js
@@ -16,7 +16,7 @@ describe('the Finish Interface', () => {
   beforeEach(() => {
     mockProps = {
       currentSession: {},
-      defaultServer: { apiUrl: 'x.x.x.x' },
+      defaultServer: { secureServiceUrl: 'x.x.x.x' },
       remoteProtocolId: 'mockProtocolId',
     };
   });

--- a/src/containers/Setup/ProtocolImport.js
+++ b/src/containers/Setup/ProtocolImport.js
@@ -105,22 +105,41 @@ class ProtocolImport extends PureComponent {
         </React.Fragment>
       );
     }
-    return { buttonContent, mainContent: content };
+
+    let headerContent;
+    if (showUrlForm) {
+      headerContent = (
+        <React.Fragment>
+          <h1>Fetch a protocol from another location</h1>
+          <p>
+            To import a protocol not on Server, enter its URL below.
+          </p>
+        </React.Fragment>
+      );
+    } else {
+      headerContent = (
+        <React.Fragment>
+          <h1>Fetch a protocol from Server</h1>
+          <p>
+            To use this feature, open Server on a computer connected to the same network as
+            this device.
+          </p>
+          <p>For information about using this feature, see our documentation.</p>
+        </React.Fragment>
+      );
+    }
+
+    return { buttonContent, headerContent, mainContent: content };
   }
 
   render() {
-    const { mainContent, buttonContent } = this.contentAreas();
+    const { headerContent, mainContent, buttonContent } = this.contentAreas();
     return (
       <div className="protocol-import">
         <Link to="/" className="protocol-import__close">
           <Icon name="close" />
         </Link>
-        <h1>Fetch a protocol from Server</h1>
-        <p>
-          To use this feature, open Server on a computer connected to the same network as
-          this device.
-        </p>
-        <p>For information about using this feature, see our documentation.</p>
+        { headerContent }
         <div className="protocol-import__content">
           {mainContent}
         </div>

--- a/src/containers/Setup/ProtocolImport.js
+++ b/src/containers/Setup/ProtocolImport.js
@@ -58,7 +58,7 @@ class ProtocolImport extends PureComponent {
     let buttonContent = null;
     if (pairedServer) {
       content = <ServerProtocols server={pairedServer} />;
-    } else if (selectedServer && selectedServer.apiUrl) {
+    } else if (selectedServer && selectedServer.pairingServiceUrl) {
       content = (
         <ServerPairing
           server={selectedServer}

--- a/src/containers/Setup/ServerList.js
+++ b/src/containers/Setup/ServerList.js
@@ -89,12 +89,14 @@ class ServerList extends Component {
       <div className="server-list__content">
         {
           this.state.servers.map((server) => {
-            // Review: Single server may have two apiUrls; should this be treated as two servers?
-            const isPaired = pairedServers.some(s => s.apiUrl === server.apiUrl);
+            // Review: Single server may have two pairingServiceUrls;
+            // should this be treated as two servers?
+            const isPaired = pairedServers.some(s => (
+              s.pairingServiceUrl === server.pairingServiceUrl));
             const onSelect = isPaired ? this.props.selectPairedServer : this.props.selectServer;
             return (
               <ServerCard
-                key={server.apiUrl}
+                key={server.pairingServiceUrl}
                 data={server}
                 selectServer={onSelect}
                 secondaryLabel={isPaired ? '(paired)' : ''}

--- a/src/containers/Setup/ServerPairing.js
+++ b/src/containers/Setup/ServerPairing.js
@@ -61,7 +61,8 @@ class ServerPairing extends Component {
     const { deviceName } = this.props;
     this.apiClient.confirmPairing(pairingCode, pairingRequestId, pairingRequestSalt, deviceName)
       .then((device) => {
-        this.props.addServer(this.props.server, device.id, device.secret);
+        const server = { ...this.props.server, secureUrl: device.secureUrl };
+        this.props.addServer(server, device.serverCert, device.id, device.secret);
         this.setState({
           ...emptyState,
           pairedDeviceId: device.id,

--- a/src/containers/Setup/ServerPairing.js
+++ b/src/containers/Setup/ServerPairing.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import ApiClient from '../../utils/ApiClient';
+import { addSecureApiUrlToServer } from '../../utils/serverAddressing';
 import { ServerSetup, ServerPairingForm } from '../../components/Setup';
 import { actionCreators } from '../../ducks/modules/servers';
 
@@ -60,9 +61,14 @@ class ServerPairing extends Component {
     const { pairingCode, pairingRequestId, pairingRequestSalt } = this.state;
     const { deviceName } = this.props;
     this.apiClient.confirmPairing(pairingCode, pairingRequestId, pairingRequestSalt, deviceName)
-      .then((device) => {
-        const server = { ...this.props.server, secureUrl: device.secureUrl };
-        this.props.addServer(server, device.serverCert, device.id, device.secret);
+      .then((pairingInfo) => {
+        const device = pairingInfo.device;
+        const server = addSecureApiUrlToServer({
+          ...this.props.server,
+          securePort: pairingInfo.securePort,
+          sslCertificate: pairingInfo.sslCertificate,
+        });
+        this.props.addServer(server, device.id, device.secret);
         this.setState({
           ...emptyState,
           pairedDeviceId: device.id,

--- a/src/containers/Setup/ServerPairing.js
+++ b/src/containers/Setup/ServerPairing.js
@@ -24,7 +24,7 @@ class ServerPairing extends Component {
   }
 
   componentDidMount() {
-    this.apiClient = new ApiClient(this.props.server.apiUrl);
+    this.apiClient = new ApiClient(this.props.server.pairingServiceUrl);
     this.requestPairingCode();
   }
 
@@ -116,7 +116,7 @@ ServerPairing.propTypes = {
   onError: PropTypes.func,
   pairingFailed: PropTypes.func.isRequired,
   server: PropTypes.shape({
-    apiUrl: PropTypes.string.isRequired,
+    pairingServiceUrl: PropTypes.string.isRequired,
     host: PropTypes.string,
   }).isRequired,
 };

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -77,7 +77,7 @@ ServerProtocols.propTypes = {
   protocolPath: PropTypes.string,
   protocolType: PropTypes.string.isRequired,
   server: PropTypes.shape({
-    apiUrl: PropTypes.string.isRequired,
+    pairingServiceUrl: PropTypes.string.isRequired,
   }).isRequired,
   sessionId: PropTypes.string.isRequired,
 };

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -10,6 +10,10 @@ import { actionCreators as sessionsActions } from '../../ducks/modules/sessions'
 import { ServerProtocolList, ServerSetup } from '../../components/Setup';
 import { getPairedServer } from '../../selectors/servers';
 
+/**
+ * @class
+ * Renders a list of protocols, from which a user can choose to download.
+ */
 class ServerProtocols extends Component {
   constructor(props) {
     super(props);
@@ -53,7 +57,8 @@ class ServerProtocols extends Component {
             protocols={protocols}
             selectProtocol={(p) => {
               addSession();
-              downloadProtocol(p.downloadUrl);
+              this.apiClient.addTrustedCert()
+                .then(() => downloadProtocol(p.downloadUrl, true));
             }}
           />
         }

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -58,7 +58,7 @@ class ServerProtocols extends Component {
             selectProtocol={(p) => {
               addSession();
               this.apiClient.addTrustedCert()
-                .then(() => downloadProtocol(p.downloadUrl, true));
+                .then(() => downloadProtocol(p.downloadPath, true));
             }}
           />
         }

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -30,7 +30,9 @@ class ServerProtocols extends Component {
   }
 
   fetchProtocolList = () => {
-    this.apiClient.getProtocols()
+    this.apiClient
+      .addTrustedCert()
+      .then(() => this.apiClient.getProtocols())
       .then(protocols => this.setState({ protocols }))
       .catch(err => this.handleApiError(err));
   }

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -8,7 +8,7 @@ import ApiClient from '../../utils/ApiClient';
 import { actionCreators as protocolActions } from '../../ducks/modules/protocol';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { ServerProtocolList, ServerSetup } from '../../components/Setup';
-import { getPairedServerFactory } from '../../selectors/servers';
+import { getPairedServer } from '../../selectors/servers';
 
 class ServerProtocols extends Component {
   constructor(props) {
@@ -17,9 +17,8 @@ class ServerProtocols extends Component {
   }
 
   componentDidMount() {
-    const { server, getPairedServer } = this.props;
-    const pairedServer = getPairedServer(server.apiUrl);
-    this.apiClient = new ApiClient(server.apiUrl, pairedServer);
+    const { pairedServer } = this.props;
+    this.apiClient = new ApiClient(pairedServer);
     this.fetchProtocolList();
   }
 
@@ -65,7 +64,6 @@ class ServerProtocols extends Component {
 
 ServerProtocols.defaultProps = {
   onError: () => {},
-  getPairedServer: () => {},
   protocolPath: '',
 };
 
@@ -75,7 +73,7 @@ ServerProtocols.propTypes = {
   downloadProtocolFailed: PropTypes.func.isRequired,
   isProtocolLoaded: PropTypes.bool.isRequired,
   onError: PropTypes.func,
-  getPairedServer: PropTypes.func,
+  pairedServer: PropTypes.object.isRequired,
   protocolPath: PropTypes.string,
   protocolType: PropTypes.string.isRequired,
   server: PropTypes.shape({
@@ -90,7 +88,7 @@ function mapStateToProps(state) {
     protocolPath: state.protocol.path,
     protocolType: state.protocol.type,
     sessionId: state.session,
-    getPairedServer: getPairedServerFactory(state),
+    pairedServer: getPairedServer(state),
   };
 }
 

--- a/src/containers/Setup/__tests__/ProtocolImport.test.js
+++ b/src/containers/Setup/__tests__/ProtocolImport.test.js
@@ -16,7 +16,7 @@ describe('<ProtocolImport>', () => {
   });
 
   it('displays a connected pairing component after a server is selected', () => {
-    component.setState({ selectedServer: { apiUrl: 'http://a.local:80' } });
+    component.setState({ selectedServer: { pairingServiceUrl: 'http://a.local:80' } });
     expect(component.find('Connect(ServerPairing)')).toHaveLength(1);
   });
 });

--- a/src/containers/Setup/__tests__/ServerPairing.test.js
+++ b/src/containers/Setup/__tests__/ServerPairing.test.js
@@ -8,7 +8,7 @@ describe('<ServerPairing>', () => {
   let component;
   const mockDownloadFn = jest.fn();
   const protocolType = '';
-  const mockServer = { apiUrl: '' };
+  const mockServer = { apiUrl: 'http://example.com:1234' };
 
   beforeEach(() => {
     component = shallow((

--- a/src/containers/Setup/__tests__/ServerPairing.test.js
+++ b/src/containers/Setup/__tests__/ServerPairing.test.js
@@ -8,7 +8,7 @@ describe('<ServerPairing>', () => {
   let component;
   const mockDownloadFn = jest.fn();
   const protocolType = '';
-  const mockServer = { apiUrl: 'http://example.com:1234' };
+  const mockServer = { pairingServiceUrl: 'http://example.com:1234' };
 
   beforeEach(() => {
     component = shallow((

--- a/src/containers/Setup/__tests__/SetupScreen.test.js
+++ b/src/containers/Setup/__tests__/SetupScreen.test.js
@@ -9,8 +9,6 @@ describe('<SetupScreen>', () => {
     const component = shallow((
       <SetupScreen
         setDeviceDescription={jest.fn()}
-        downloadProtocol={jest.fn()}
-        loadFactoryProtocol={jest.fn()}
         protocolType=""
         isProtocolLoaded={false}
       />
@@ -25,8 +23,6 @@ describe('<SetupScreen>', () => {
     const component = shallow((
       <SetupScreen
         setDeviceDescription={jest.fn()}
-        downloadProtocol={jest.fn()}
-        loadFactoryProtocol={jest.fn()}
         protocolType=""
         isProtocolLoaded={false}
       />

--- a/src/ducks/modules/externalData.js
+++ b/src/ducks/modules/externalData.js
@@ -7,6 +7,7 @@ const initialState = null;
 
 /**
  * @private
+ * @description
  * All external data nodes must be identified in the app with a primary key (== NodePK).
  *
  * For each object in an external data set's collection of nodes:

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -97,10 +97,11 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
-function downloadProtocolAction(uri) {
+function downloadProtocolAction(uri, forNCServer) {
   return {
     type: DOWNLOAD_PROTOCOL,
     uri,
+    forNCServer,
   };
 }
 
@@ -169,7 +170,7 @@ const downloadProtocolEpic = action$ =>
   action$.ofType(DOWNLOAD_PROTOCOL)
     .switchMap(action =>
       Observable
-        .fromPromise(downloadProtocol(action.uri))
+        .fromPromise(downloadProtocol(action.uri, action.forNCServer))
         .map(protocolPath => importProtocolAction(protocolPath))
         .catch(error => Observable.of(downloadProtocolFailed(error))),
     );

--- a/src/ducks/modules/protocol.js
+++ b/src/ducks/modules/protocol.js
@@ -4,6 +4,7 @@ import { omit } from 'lodash';
 
 import { actionTypes as SessionActionTypes } from './session';
 import { supportedWorkers } from '../../utils/WorkerAgent';
+import { getPairedServer } from '../../selectors/servers';
 import {
   loadProtocol,
   importProtocol,
@@ -166,14 +167,18 @@ function setWorkerContent(workerUrlMap = {}) {
   };
 }
 
-const downloadProtocolEpic = action$ =>
+const downloadProtocolEpic = (action$, store) =>
   action$.ofType(DOWNLOAD_PROTOCOL)
-    .switchMap(action =>
-      Observable
-        .fromPromise(downloadProtocol(action.uri, action.forNCServer))
+    .switchMap((action) => {
+      let pairedServer;
+      if (action.forNCServer) {
+        pairedServer = getPairedServer(store.getState());
+      }
+      return Observable
+        .fromPromise(downloadProtocol(action.uri, pairedServer))
         .map(protocolPath => importProtocolAction(protocolPath))
-        .catch(error => Observable.of(downloadProtocolFailed(error))),
-    );
+        .catch(error => Observable.of(downloadProtocolFailed(error)));
+    });
 
 const importProtocolEpic = action$ =>
   action$.ofType(IMPORT_PROTOCOL)

--- a/src/ducks/modules/servers.js
+++ b/src/ducks/modules/servers.js
@@ -11,7 +11,6 @@ export default function reducer(state = initialState, action = {}) {
       if (action.server) {
         const pairingInfo = {
           ...action.server,
-          serverCert: action.serverCert,
           deviceId: action.deviceId,
           deviceSecret: action.deviceSecret,
         };

--- a/src/ducks/modules/servers.js
+++ b/src/ducks/modules/servers.js
@@ -11,6 +11,7 @@ export default function reducer(state = initialState, action = {}) {
       if (action.server) {
         const pairingInfo = {
           ...action.server,
+          serverCert: action.serverCert,
           deviceId: action.deviceId,
           deviceSecret: action.deviceSecret,
         };
@@ -22,11 +23,12 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
-const addServer = (server, deviceId, deviceSecret) => ({
+const addServer = (server, serverCert, deviceId, deviceSecret) => ({
   type: ADD_SERVER,
   deviceId,
   deviceSecret,
   server,
+  serverCert,
 });
 
 const pairingFailed = error => ({

--- a/src/ducks/modules/servers.js
+++ b/src/ducks/modules/servers.js
@@ -23,12 +23,11 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
-const addServer = (server, serverCert, deviceId, deviceSecret) => ({
+const addServer = (server, deviceId, deviceSecret) => ({
   type: ADD_SERVER,
   deviceId,
   deviceSecret,
   server,
-  serverCert,
 });
 
 const pairingFailed = error => ({

--- a/src/selectors/__tests__/servers.test.js
+++ b/src/selectors/__tests__/servers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { getPairedServerFactory } from '../servers';
+import { getPairedServer } from '../servers';
 
 const apiUrl = 'http://0.0.0.0';
 const mockServer = { apiUrl };
@@ -11,17 +11,13 @@ const mockState = {
 };
 
 describe('server selectors', () => {
-  describe('getPairedServerFactory', () => {
-    it('returns a function', () => {
-      expect(getPairedServerFactory(mockState)).toBeInstanceOf(Function);
-    });
-
-    it('can get paired server by URL', () => {
-      expect(getPairedServerFactory(mockState)(apiUrl)).toEqual(mockServer);
+  describe('getPairedServer', () => {
+    it('can get the paired', () => {
+      expect(getPairedServer(mockState)).toEqual(mockServer);
     });
 
     it('returns null if not found', () => {
-      expect(getPairedServerFactory(mockState)('bad-url')).toEqual(null);
+      expect(getPairedServer({ servers: { paired: [] } })).toEqual(null);
     });
   });
 });

--- a/src/selectors/__tests__/servers.test.js
+++ b/src/selectors/__tests__/servers.test.js
@@ -1,8 +1,7 @@
 /* eslint-env jest */
 import { getPairedServer } from '../servers';
 
-const apiUrl = 'http://0.0.0.0';
-const mockServer = { apiUrl };
+const mockServer = { pairingServiceUrl: 'http://0.0.0.0' };
 
 const mockState = {
   servers: {

--- a/src/selectors/servers.js
+++ b/src/selectors/servers.js
@@ -1,15 +1,14 @@
-import { memoize } from 'lodash';
-
 import { createDeepEqualSelector } from './utils';
 
 const pairedServers = state => state.servers.paired;
 
 // Servers are considered equal if they use the same URL
-const getPairedServerFactory = createDeepEqualSelector(
+const getPairedServer = createDeepEqualSelector(
   pairedServers,
-  servers => memoize(apiUrl => servers.find(s => s.apiUrl === apiUrl) || null),
+  // TODO: shape will change to storing only a single server; pick first for now
+  servers => servers[0] || null,
 );
 
 export {
-  getPairedServerFactory, // eslint-disable-line import/prefer-default-export
+  getPairedServer, // eslint-disable-line import/prefer-default-export
 };

--- a/src/selectors/servers.js
+++ b/src/selectors/servers.js
@@ -5,8 +5,8 @@ const pairedServers = state => state.servers.paired;
 // Servers are considered equal if they use the same URL
 const getPairedServer = createDeepEqualSelector(
   pairedServers,
-  // TODO: shape will change to storing only a single server; pick first for now
-  servers => servers[0] || null,
+  // TODO: shape will change to storing only a single server; pick last for now
+  servers => servers[servers.length - 1] || null,
 );
 
 export {

--- a/src/styles/components/_protocol-card-list.scss
+++ b/src/styles/components/_protocol-card-list.scss
@@ -28,7 +28,7 @@
 
     &--single-protocol {
       // If there's only one protocol card, extend height to meet 'prefix' line
-      height: calc(100% - var(--card-height) / 2);
+      height: calc((5rem / 2) - #{$scroller-top-padding});
     }
   }
 

--- a/src/styles/containers/_protocol-import.scss
+++ b/src/styles/containers/_protocol-import.scss
@@ -1,7 +1,7 @@
 .protocol-import {
   position: relative;
   margin: 0 130px;
-  max-width: 48rem;
+  width: 48rem;
 
   &__close {
     position: absolute;

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -215,12 +215,12 @@ class ApiClient {
       .catch(err => handleError(err));
   }
 
-  downloadProtocol(url, destination) {
+  downloadProtocol(path, destination) {
     if (isCordova()) {
-      return this.httpsClient.download(url, destination).catch(handleError);
+      return this.httpsClient.download(path, destination).catch(handleError);
     } else if (isElectron()) {
       return this.httpsClient
-        .get(url, { ...this.authHeader, responseType: 'arraybuffer' })
+        .get(path, { ...this.authHeader, responseType: 'arraybuffer' })
         .then(resp => new Uint8Array(resp.data));
     }
     return Promise.reject(new Error('Downloads not supported on this platform'));

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -112,7 +112,7 @@ class ApiClient {
    */
   addTrustedCert() {
     if (isCordova()) {
-      return this.httpsClient.acceptCertificate();
+      return this.httpsClient.acceptCertificate().catch(handleError);
     } else if (isElectron()) {
       return new Promise((resolve, reject) => {
         if (!this.pairedServer || !this.pairedServer.sslCertificate) {

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -41,7 +41,7 @@ const handleError = (err) => {
 };
 
 /**
- * @class ApiClient
+ * @class
  *
  * Provides both a pairing client (http) and a secure client (https) once paired.
  *
@@ -102,6 +102,10 @@ class ApiClient {
   }
 
   /**
+   * @description Call this to add add the paired server's SSL certificate to the trust store.
+   * Calling this method without initializing the client with a paired server is an error.
+   *
+   * @method ApiClient#addTrustedCert
    * @async
    * @return {Promise} resolves if cert has been trusted;
    *                   rejects if there is no paired Server, or trust cannot be established

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -64,24 +64,24 @@ const handleError = (err) => {
  * All pending requests can be cancelled by calling cancelAll(). This will not reject the promised
  * response; rather, it will resolve with empty data.
  *
- * @param  {string|Object} apiUrlOrPairedServer Either a pairing API URL (http), or an
- *                                              already-paired Server
- * @param  {string} [apiUrlOrPairedServer.secureServiceUrl] HTTPS url for secure endpoints,
- *                                                          if a paired server is provied
+ * @param  {string|Object} pairingUrlOrPairedServer Either a pairing API URL (http), or an
+ *                                                  already-paired Server
+ * @param  {string} [pairingUrlOrPairedServer.secureServiceUrl] HTTPS url for secure endpoints,
+ *                                                              if a paired server is provied
  */
 class ApiClient {
   constructor(pairingUrlOrPairedServer) {
-    let apiUrl;
+    let pairingUrl;
     let pairedServer;
     if (isString(pairingUrlOrPairedServer)) {
-      apiUrl = pairingUrlOrPairedServer;
+      pairingUrl = pairingUrlOrPairedServer;
     } else if (pairingUrlOrPairedServer) {
       pairedServer = pairingUrlOrPairedServer;
     }
 
     this.cancelTokenSource = axios.CancelToken.source();
     this.pairedServer = pairedServer;
-    this.pairingServiceUrl = apiUrl || pairedServer.pairingServiceUrl;
+    this.pairingServiceUrl = pairingUrl || pairedServer.pairingServiceUrl;
     this.client = axios.create({
       baseURL: this.pairingServiceUrl.replace(/\/$/, ''),
       headers: defaultHeaders,

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -218,6 +218,10 @@ class ApiClient {
   downloadProtocol(url, destination) {
     if (isCordova()) {
       return this.httpsClient.download(url, destination).catch(handleError);
+    } else if (isElectron()) {
+      return this.httpsClient
+        .get(url, { ...this.authHeader, responseType: 'arraybuffer' })
+        .then(resp => new Uint8Array(resp.data));
     }
     return Promise.reject(new Error('Downloads not supported on this platform'));
   }

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -215,6 +215,13 @@ class ApiClient {
       .catch(err => handleError(err));
   }
 
+  downloadProtocol(url, destination) {
+    if (isCordova()) {
+      return this.httpsClient.download(url, destination).catch(handleError);
+    }
+    return Promise.reject(new Error('Downloads not supported on this platform'));
+  }
+
   /**
    * @async
    * @param {string} protocolId ID of the protocol this session belongs to

--- a/src/utils/__tests__/ApiClient.test.js
+++ b/src/utils/__tests__/ApiClient.test.js
@@ -9,7 +9,7 @@ jest.mock('axios');
 jest.mock('../shared-api/cipher');
 
 describe('ApiClient', () => {
-  const respData = { device: { id: '1' } };
+  const respData = { device: { id: '1' }, certificate: 'CERTIFICATE', securePort: 443 };
   const axiosResp = { data: { data: respData } };
 
   beforeAll(() => {
@@ -25,16 +25,25 @@ describe('ApiClient', () => {
   });
 
   describe('pairing confirmation', () => {
-    beforeEach(() => {
+    let pairingInfo;
+    beforeEach(async () => {
       // data payload is encrypted; mock it on cipher
       decrypt.mockReturnValue(JSON.stringify(respData));
+      const client = new ApiClient('');
+      pairingInfo = await client.confirmPairing();
     });
 
-    it('returns device ID and secret', async () => {
-      const client = new ApiClient('');
-      const device = await client.confirmPairing();
-      expect(device.id).toEqual(respData.device.id);
-      expect(device).toHaveProperty('secret');
+    it('returns device ID and secret', () => {
+      expect(pairingInfo.device.id).toEqual(respData.device.id);
+      expect(pairingInfo.device).toHaveProperty('secret');
+    });
+
+    it('returns an SSL cert for Server', () => {
+      expect(pairingInfo.sslCertificate).toEqual(respData.certificate);
+    });
+
+    it('returns the secure port for SSL', () => {
+      expect(pairingInfo.securePort).toEqual(respData.securePort);
     });
   });
 });

--- a/src/utils/__tests__/ApiClient.test.js
+++ b/src/utils/__tests__/ApiClient.test.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 import ApiClient from '../ApiClient';
 import { decrypt } from '../shared-api/cipher';
+import * as Environment from '../../utils/Environment';
 
 jest.mock('axios');
 jest.mock('../shared-api/cipher');
@@ -23,13 +24,20 @@ describe('ApiClient', () => {
   });
 
   beforeEach(() => {
+    Environment.isElectron = jest.fn().mockReturnValue(true);
     axios.post.mockClear();
     client = new ApiClient(url);
   });
 
   describe('constructor', () => {
-    it('accepts a pairingUrl', () => {
-      expect(client.pairingServiceUrl).toEqual(url);
+    it('creates a pairing client from a pairingUrl', () => {
+      expect(client.pairingClient).toBeDefined();
+      expect(client.httpsClient).not.toBeDefined();
+    });
+    it('creates an https client from a pairedServer', () => {
+      const pairedClient = new ApiClient({ secureServiceUrl: 'https://example.com:1234' });
+      expect(pairedClient.httpsClient).toBeDefined();
+      expect(pairedClient.pairingClient).not.toBeDefined();
     });
   });
 

--- a/src/utils/__tests__/ApiClient.test.js
+++ b/src/utils/__tests__/ApiClient.test.js
@@ -11,6 +11,8 @@ jest.mock('../shared-api/cipher');
 describe('ApiClient', () => {
   const respData = { device: { id: '1' }, certificate: 'CERTIFICATE', securePort: 443 };
   const axiosResp = { data: { data: respData } };
+  const url = 'http://example.com:123';
+  let client;
 
   beforeAll(() => {
     axios.post.mockResolvedValue(axiosResp);
@@ -22,6 +24,13 @@ describe('ApiClient', () => {
 
   beforeEach(() => {
     axios.post.mockClear();
+    client = new ApiClient(url);
+  });
+
+  describe('constructor', () => {
+    it('accepts a pairingUrl', () => {
+      expect(client.pairingServiceUrl).toEqual(url);
+    });
   });
 
   describe('pairing confirmation', () => {
@@ -29,7 +38,6 @@ describe('ApiClient', () => {
     beforeEach(async () => {
       // data payload is encrypted; mock it on cipher
       decrypt.mockReturnValue(JSON.stringify(respData));
-      const client = new ApiClient('');
       pairingInfo = await client.confirmPairing();
     });
 

--- a/src/utils/__tests__/serverAddressing.test.js
+++ b/src/utils/__tests__/serverAddressing.test.js
@@ -4,10 +4,10 @@ import * as util from '../serverAddressing';
 describe('the serverAddressing util', () => {
   it('augments a service with the API URL', () => {
     const mockService = { port: 123, addresses: ['127.0.0.1'] };
-    const augmented = util.addApiUrlToService(mockService);
+    const augmented = util.addPairingUrlToService(mockService);
     expect(augmented).toMatchObject(mockService);
-    expect(augmented).toHaveProperty('apiUrl');
-    expect(augmented.apiUrl).toMatch('127.0.0.1:123');
+    expect(augmented).toHaveProperty('pairingServiceUrl');
+    expect(augmented.pairingServiceUrl).toMatch('127.0.0.1:123');
   });
 
   describe('port validation', () => {

--- a/src/utils/serverAddressing.js
+++ b/src/utils/serverAddressing.js
@@ -9,6 +9,13 @@ const AllowIPv6 = false;
 const isLinkLocal = addr => /^(fe80::|169\.254)/.test(addr);
 const isIpv6 = addr => /^[a-zA-Z0-9]{1,4}:/.test(addr); // good enough for needs here
 
+const parseUrl = (url) => {
+  const a = document.createElement('a');
+  a.href = url;
+  const { protocol, username, password, hostname, port, pathname, hash, href } = a;
+  return { protocol, username, password, hostname, port, pathname, hash, href };
+};
+
 // Performs basic escaping & checks using native (anchor) parsing.
 const validApiUrl = (address, port) => {
   if (!address || isLinkLocal(address) || !port) {
@@ -34,9 +41,8 @@ const validApiUrl = (address, port) => {
       return null;
     }
   }
-  const a = document.createElement('a');
-  a.href = `${apiProtocol}://${normalizedAddress}:${portNum}`;
 
+  const a = parseUrl(`${apiProtocol}://${normalizedAddress}:${portNum}`);
   // Disallow URLs if parsed to contain certain fields
   if (a.pathname && a.pathname !== '/') { return null; }
   if (a.hash || a.username || a.password) { return null; }
@@ -92,4 +98,5 @@ export {
   isValidPort,
   maxPort,
   minPort,
+  parseUrl,
 };

--- a/src/utils/serverAddressing.js
+++ b/src/utils/serverAddressing.js
@@ -69,7 +69,6 @@ const isValidPort = port => !!validApiUrl('0.0.0.0', port);
  * @property {string} host
  * @property {string} port
  * @property {Array} addresses
- * @property {string} apiUrl
  */
 
 /**
@@ -78,15 +77,13 @@ const isValidPort = port => !!validApiUrl('0.0.0.0', port);
  * @param {Service} service discovered (via MDNS) or manually created server info
  * @memberOf serverAddressing
  */
-// TODO: fix name; remove apiUrl
-const addApiUrlToService = (service) => {
+const addPairingUrlToService = (service) => {
   const apiService = { ...service };
   let apiInfo = null;
   apiService.addresses.some((addr) => {
     apiInfo = validApiUrl(addr, service.port);
     return !!apiInfo;
   });
-  apiService.apiUrl = apiInfo.toString();
   apiService.pairingServiceUrl = apiInfo.toString();
   return apiService;
 };
@@ -114,7 +111,7 @@ const addSecureApiUrlToServer = (server, securePort = server.securePort) => {
 };
 
 export {
-  addApiUrlToService,
+  addPairingUrlToService,
   addSecureApiUrlToServer,
   pairingApiProtocol,
   isValidAddress,

--- a/src/utils/serverDiscoverer.js
+++ b/src/utils/serverDiscoverer.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'eventemitter3';
 
 import { isElectron, isCordova } from '../utils/Environment';
-import { addApiUrlToService } from './serverAddressing';
+import { addPairingUrlToService } from './serverAddressing';
 
 class ServerDiscoverer {
   constructor() {
@@ -107,9 +107,9 @@ class ServerDiscoverer {
    * Emits a {@link Server} object
    */
   emitAnnouncement(normalizedService) {
-    const service = addApiUrlToService(normalizedService);
-    if (!service.apiUrl) {
-      console.warn('No apiUrl found', service); // eslint-disable-line no-console
+    const service = addPairingUrlToService(normalizedService);
+    if (!service.pairingServiceUrl) {
+      console.warn('No pairing URL found', service); // eslint-disable-line no-console
       return;
     }
     this.events.emit('SERVER_ANNOUNCED', service);

--- a/src/utils/shared-api/sslConfig.js
+++ b/src/utils/shared-api/sslConfig.js
@@ -1,0 +1,3 @@
+module.exports = {
+  commonName: 'Network Canvas (localhost)',
+};


### PR DESCRIPTION
This adds new clients for communicating with https endpoints on a paired Server. Because we have no central infrastructure, Server uses a self-signed cert which must be trusted by a client during pairing. Once paired, https calls ensure that this certificate is used in trust evaluation; users should not see a self-signed warning. Clients do not blindly trust any https endpoint.

### TODO
- [x] Cordova: SSL cert evaluation on file downloads
- [x] Device auth on file downloads

### Testing

The shape of servers is redux has changed, and is not backward-compatible. To use this branch, you'll need to remove any existing paired servers (i.e., Reset Data).

Test against the [feature/support-https-clients](https://github.com/codaco/Server/tree/feature/support-https-clients) branch of Server. The only difference on this branch is that all API calls to a paired Server (get protocols list, get protocol file, & post session data) should use https transparently to the user.

Resolves #537. Resolves #538. Resolves #539. Resolves #540. (I think it will be easier to test & review all platforms at once.)
