### PR TITLE
Remove fallback form behavior from protocol

### DIFF
--- a/src/selectors/__tests__/forms.test.js
+++ b/src/selectors/__tests__/forms.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+
+import { makeRehydrateForm } from '../forms';
+
+describe('forms selector', () => {
+  describe('makeRehydrateForm', () => {
+    const state = {
+      protocol: {
+        forms: { person: {} },
+      },
+    };
+    let rehydrateForm;
+
+    beforeEach(() => {
+      rehydrateForm = makeRehydrateForm();
+    });
+
+    it('defaults to null', () => {
+      const props = { stage: {} };
+      expect(rehydrateForm(state, props)).toBe(null);
+    });
+
+    it('returns null when defined as null (from Architect)', () => {
+      const props = { stage: { person: null } };
+      expect(rehydrateForm(state, props)).toBe(null);
+    });
+
+    it('returns form if defined', () => {
+      const props = { stage: { form: 'person' } };
+      expect(rehydrateForm(state, props)).toEqual(state.protocol.forms.person);
+    });
+  });
+});

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import { makeGetNodeType } from './interface';
 import { protocolRegistry, protocolForms } from './protocol';
 
 // Prop selectors
@@ -7,14 +6,6 @@ import { protocolRegistry, protocolForms } from './protocol';
 const propFields = (_, props) => props.fields;
 const propStageForm = (_, props) => props.stage.form;
 const propForm = (_, { entity, type }) => ({ entity, type });
-
-// Use the node type (e.g. "person") as the fallback form name —
-// this should always be present and will be created by architect.
-const nodeFormKey = createSelector(
-  propStageForm,
-  makeGetNodeType(),
-  (stageForm, nodeType) => stageForm || nodeType,
-);
 
 // MemoedSelectors
 
@@ -43,6 +34,6 @@ export const makeRehydrateFields = () =>
 
 export const makeRehydrateForm = () =>
   createSelector(
-    [nodeFormKey, protocolForms],
-    (form, forms) => forms[form],
+    [propStageForm, protocolForms],
+    (form, forms) => forms[form] || null,
   );


### PR DESCRIPTION
Resolves #592.

This removes the feature that defaulted form to a form definition matching the node type. If the form prop is falsy, then no form should be displayed. (See https://github.com/codaco/Architect/issues/136). The Component prop is still optional, since `null` is treated as missing by PropTypes.

I've [updated the documentation](https://github.com/codaco/Network-Canvas/wiki/Name-Generator/_compare/6433ed7b9b012597e37a228f3a5ed1a9fc299ce8...a039a973b26847dd283b887ba2cd82ecb6320730) to match.