### PR TITLE
Fix model data issues

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -6,7 +6,7 @@ import cx from 'classnames';
 import { scrollable, selectable } from '../behaviours';
 import { Card } from '.';
 import { Icon } from '../ui/components';
-import { nodePrimaryKeyProperty, getNodeAttributes } from '../ducks/modules/network';
+import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 
 const EnhancedCard = selectable(Card);
 
@@ -29,19 +29,17 @@ const CardList = (props) => {
 
   const classNames = cx('card-list', className);
 
-  const nodeAttributes = node => getNodeAttributes(node);
-
   return (
     <div className={classNames}>
       {
         nodes.map(node => (
           <span className="card-list__content" key={getKey(node)}>
             <EnhancedCard
-              label={label(nodeAttributes(node))}
+              label={label(node)}
               multiselect={multiselect}
               compact={compact}
               selected={selected(node)}
-              details={details(nodeAttributes(node))}
+              details={details(node)}
               onSelected={() => onToggleCard(node)}
             />
             {

--- a/src/components/ListSelect.js
+++ b/src/components/ListSelect.js
@@ -8,15 +8,14 @@ import sortOrder from '../utils/sortOrder';
 
 class ListSelect extends Component {
   static getDerivedStateFromProps(nextProps) {
-    const sorter = sortOrder(nextProps.initialSortOrder);
-    const sortedNodes = sorter(nextProps.nodes);
     return {
       activeSortOrder: {
         ...nextProps.initialSortOrder[0],
       },
-      nodes: sortedNodes,
+      nodes: nextProps.nodes,
     };
   }
+
   constructor(props) {
     super(props);
 

--- a/src/components/ListSelect.js
+++ b/src/components/ListSelect.js
@@ -7,15 +7,6 @@ import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 import sortOrder from '../utils/sortOrder';
 
 class ListSelect extends Component {
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      activeSortOrder: {
-        ...nextProps.initialSortOrder[0],
-      },
-      nodes: nextProps.nodes,
-    };
-  }
-
   constructor(props) {
     super(props);
 
@@ -24,7 +15,6 @@ class ListSelect extends Component {
         ...this.props.initialSortOrder[0], // For now, just respect the first default sort rule
       },
       filterValue: '',
-      nodes: this.props.nodes,
     };
   }
 
@@ -137,11 +127,12 @@ class ListSelect extends Component {
     const {
       details,
       label,
+      nodes,
       sortFields,
     } = this.props;
 
     const sorter = sortOrder([this.state.activeSortOrder]);
-    const nodes = sorter(this.state.nodes);
+    const sortedNodes = sorter(nodes);
 
     return (
       <div className="list-select">
@@ -161,7 +152,7 @@ class ListSelect extends Component {
         <CardList
           details={details}
           label={label}
-          nodes={this.getFilteredList(nodes)}
+          nodes={this.getFilteredList(sortedNodes)}
           onToggleCard={this.toggleCard}
           selected={this.isNodeSelected}
         />

--- a/src/components/ListSelect.js
+++ b/src/components/ListSelect.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Button } from '../ui/components';
 import { CardList } from '.';
-import { nodePrimaryKeyProperty, getNodeAttributes } from '../ducks/modules/network';
+import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 import sortOrder from '../utils/sortOrder';
 
 class ListSelect extends Component {
@@ -60,14 +60,11 @@ class ListSelect extends Component {
   getFilteredList = (list) => {
     const filteredList = list.filter(
       (node) => {
-        // Node data model attributes are stored in a specific named property
-        const nodeAttributes = getNodeAttributes(node);
-
         // Lowercase for comparison
-        const nodeLabel = this.props.label(nodeAttributes).toLowerCase();
+        const nodeLabel = this.props.label(node).toLowerCase();
         const filterValue = this.state.filterValue.toLowerCase();
 
-        const nodeDetails = this.props.details(nodeAttributes);
+        const nodeDetails = this.props.details(node);
 
         // Include in filtered list if:
         // - The label includes the filter value, OR
@@ -165,7 +162,7 @@ class ListSelect extends Component {
         <CardList
           details={details}
           label={label}
-          nodes={nodes}
+          nodes={this.getFilteredList(nodes)}
           onToggleCard={this.toggleCard}
           selected={this.isNodeSelected}
         />

--- a/src/components/ListSelect.js
+++ b/src/components/ListSelect.js
@@ -50,7 +50,7 @@ class ListSelect extends Component {
     const filteredList = list.filter(
       (node) => {
         // Lowercase for comparison
-        const nodeLabel = this.props.label(node).toLowerCase();
+        const nodeLabel = (this.props.label(node) || '').toLowerCase();
         const filterValue = this.state.filterValue.toLowerCase();
 
         const nodeDetails = this.props.details(node);

--- a/src/components/__tests__/ListSelect-test.js
+++ b/src/components/__tests__/ListSelect-test.js
@@ -7,9 +7,9 @@ import ListSelect from '../ListSelect';
 jest.mock('../../utils/CSSVariables');
 
 const nodes = [
-  { uid: 'a', name: 'a name', age: '22' },
-  { uid: 'b', name: 'b name', age: '88' },
-  { uid: 'c', name: 'c name', age: '33' },
+  { uid: 'a', attributes: { name: 'a name', age: '22' } },
+  { uid: 'b', attributes: { name: 'b name', age: '88' } },
+  { uid: 'c', attributes: { name: 'c name', age: '33' } },
 ];
 
 describe('ListSelect component', () => {

--- a/src/components/__tests__/__snapshots__/ListSelect-test.js.snap
+++ b/src/components/__tests__/__snapshots__/ListSelect-test.js.snap
@@ -18,18 +18,24 @@ ShallowWrapper {
     nodes={
       Array [
         Object {
-          "age": "22",
-          "name": "a name",
+          "attributes": Object {
+            "age": "22",
+            "name": "a name",
+          },
           "uid": "a",
         },
         Object {
-          "age": "88",
-          "name": "b name",
+          "attributes": Object {
+            "age": "88",
+            "name": "b name",
+          },
           "uid": "b",
         },
         Object {
-          "age": "33",
-          "name": "c name",
+          "attributes": Object {
+            "age": "33",
+            "name": "c name",
+          },
           "uid": "c",
         },
       ]
@@ -68,18 +74,24 @@ ShallowWrapper {
           nodes={
             Array [
               Object {
-                "age": "22",
-                "name": "a name",
+                "attributes": Object {
+                  "age": "22",
+                  "name": "a name",
+                },
                 "uid": "a",
               },
               Object {
-                "age": "88",
-                "name": "b name",
+                "attributes": Object {
+                  "age": "88",
+                  "name": "b name",
+                },
                 "uid": "b",
               },
               Object {
-                "age": "33",
-                "name": "c name",
+                "attributes": Object {
+                  "age": "33",
+                  "name": "c name",
+                },
                 "uid": "c",
               },
             ]
@@ -136,18 +148,24 @@ ShallowWrapper {
           "label": [Function],
           "nodes": Array [
             Object {
-              "age": "22",
-              "name": "a name",
+              "attributes": Object {
+                "age": "22",
+                "name": "a name",
+              },
               "uid": "a",
             },
             Object {
-              "age": "88",
-              "name": "b name",
+              "attributes": Object {
+                "age": "88",
+                "name": "b name",
+              },
               "uid": "b",
             },
             Object {
-              "age": "33",
-              "name": "c name",
+              "attributes": Object {
+                "age": "33",
+                "name": "c name",
+              },
               "uid": "c",
             },
           ],
@@ -184,18 +202,24 @@ ShallowWrapper {
             nodes={
               Array [
                 Object {
-                  "age": "22",
-                  "name": "a name",
+                  "attributes": Object {
+                    "age": "22",
+                    "name": "a name",
+                  },
                   "uid": "a",
                 },
                 Object {
-                  "age": "88",
-                  "name": "b name",
+                  "attributes": Object {
+                    "age": "88",
+                    "name": "b name",
+                  },
                   "uid": "b",
                 },
                 Object {
-                  "age": "33",
-                  "name": "c name",
+                  "attributes": Object {
+                    "age": "33",
+                    "name": "c name",
+                  },
                   "uid": "c",
                 },
               ]
@@ -252,18 +276,24 @@ ShallowWrapper {
             "label": [Function],
             "nodes": Array [
               Object {
-                "age": "22",
-                "name": "a name",
+                "attributes": Object {
+                  "age": "22",
+                  "name": "a name",
+                },
                 "uid": "a",
               },
               Object {
-                "age": "88",
-                "name": "b name",
+                "attributes": Object {
+                  "age": "88",
+                  "name": "b name",
+                },
                 "uid": "b",
               },
               Object {
-                "age": "33",
-                "name": "c name",
+                "attributes": Object {
+                  "age": "33",
+                  "name": "c name",
+                },
                 "uid": "c",
               },
             ],

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -11,7 +11,7 @@ import { makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper, NodePanels, NodeForm } from '../';
 import { NodeList, NodeBin } from '../../components/';
 import { makeRehydrateForm } from '../../selectors/forms';
-import { getNodeAttributes, nodeAttributesProperty, getNodeWithoutAttributes } from '../../ducks/modules/network';
+import { getNodeWithoutAttributes } from '../../ducks/modules/network';
 
 /**
   * Name Generator Interface
@@ -36,7 +36,7 @@ class NameGenerator extends Component {
    */
   onSubmitNewNode = (formData) => {
     if (formData) {
-      this.props.addNodes({ ...this.props.newNodeAttributes }, { ...formData });
+      this.props.addNodes({ attributes: { ...formData } }, this.props.newNodeAttributes);
     }
   }
 
@@ -71,10 +71,8 @@ class NameGenerator extends Component {
   onDrop = (item) => {
     const node = { ...item.meta };
     const nodeModelData = getNodeWithoutAttributes(node);
-    const nodeAttributeData = getNodeAttributes(node);
 
     const promptModelData = omit(this.props.newNodeAttributes);
-    const promptAttributeData = this.props.newNodeAttributes[nodeAttributesProperty];
 
     // Test if we are updating an existing network node, or adding it to the network
     if (has(node, 'promptId') || has(node, 'stageId')) {
@@ -83,10 +81,7 @@ class NameGenerator extends Component {
         { ...this.props.activePromptAttributes },
       );
     } else {
-      this.props.addNodes(
-        { ...merge(nodeModelData, promptModelData) },
-        { ...merge(nodeAttributeData, promptAttributeData) },
-      );
+      this.props.addNodes(node, this.props.newNodeAttributes);
     }
   }
 

--- a/src/containers/Interfaces/NameGeneratorAutoComplete.js
+++ b/src/containers/Interfaces/NameGeneratorAutoComplete.js
@@ -9,6 +9,7 @@ import withPrompt from '../../behaviours/withPrompt';
 import Search from '../../containers/Search';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { actionCreators as searchActions } from '../../ducks/modules/search';
+import { nodeAttributesProperty } from '../../ducks/modules/network';
 import { getNodeLabelFunction, makeGetNodeType, makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
 import { getCardDisplayLabel, getCardAdditionalProperties, makeGetNodeIconName, makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper } from '../';
@@ -58,6 +59,10 @@ class NameGeneratorAutoComplete extends Component {
 
     const ListId = 'AUTOCOMPLETE_NODE_LIST';
 
+    const searchOptions = { matchProperties: [], ...prompt.searchOptions };
+    searchOptions.matchProperties = searchOptions.matchProperties.map(prop => (
+      `${nodeAttributesProperty}.${prop}`));
+
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__prompt`}>
@@ -95,7 +100,7 @@ class NameGeneratorAutoComplete extends Component {
           nodeType={nodeType}
           onClick={closeSearch}
           onComplete={selectedResults => this.onSearchComplete(selectedResults)}
-          options={prompt.searchOptions}
+          options={searchOptions}
         />
 
         <div className="name-generator-auto-complete-interface__node-bin">

--- a/src/containers/Interfaces/NameGeneratorList.js
+++ b/src/containers/Interfaces/NameGeneratorList.js
@@ -79,6 +79,7 @@ class NameGeneratorList extends Component {
           />
         </div>
         <ListSelect
+          key={`select-${prompt.id}`}
           details={this.details}
           initialSortOrder={initialSortOrder}
           label={this.label}

--- a/src/containers/Interfaces/NameGeneratorList.js
+++ b/src/containers/Interfaces/NameGeneratorList.js
@@ -6,7 +6,7 @@ import { differenceBy } from 'lodash';
 
 import withPrompt from '../../behaviours/withPrompt';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
-import { nodePrimaryKeyProperty } from '../../ducks/modules/network';
+import { nodePrimaryKeyProperty, getNodeAttributes } from '../../ducks/modules/network';
 import { makeNetworkNodesForOtherPrompts, networkNodes } from '../../selectors/interface';
 import {
   getDataByPrompt,
@@ -44,10 +44,13 @@ class NameGeneratorList extends Component {
     this.props.removeNode(node[nodePrimaryKeyProperty]);
   }
 
-  label = node => node[this.props.labelKey];
+  label = node => getNodeAttributes(node)[this.props.labelKey];
 
-  details = node => this.props.visibleSupplementaryFields.map(
-    field => ({ [field.label]: node[field.variable] }));
+  details = (node) => {
+    const attrs = getNodeAttributes(node);
+    const fields = this.props.visibleSupplementaryFields;
+    return fields.map(field => ({ [field.label]: attrs[field.variable] }));
+  }
 
   render() {
     const {

--- a/src/containers/Search/Search.js
+++ b/src/containers/Search/Search.js
@@ -9,7 +9,7 @@ import SearchTransition from '../../components/Transition/Search';
 import SearchResults from './SearchResults';
 import AddCountButton from '../../components/AddCountButton';
 import { actionCreators as searchActions } from '../../ducks/modules/search';
-import { nodePrimaryKeyProperty } from '../../ducks/modules/network';
+import { getNodeAttributes, nodePrimaryKeyProperty } from '../../ducks/modules/network';
 import { makeGetFuse } from '../../selectors/search';
 
 /**
@@ -53,7 +53,10 @@ const InitialState = {
   *     `{label: '', variable: ''}` in each search set object.
   * @param props.options {object}
   * @param props.options.matchProperties {array} - one or more key names to search
-  *     in the dataset
+  *     in the dataset. Supports nested properties using dot notation.
+  *     Example:
+  *       data = [{ id: '', attribtues: { name: '' }}];
+  *       matchProperties = ['attributes.name'];
   * @param [props.options.fuzziness=0.5] {number} -
   *     How inexact search results may be, in the range [0,1].
   *     A value of zero requires an exact match. Large search sets may do better
@@ -157,17 +160,16 @@ class Search extends Component {
 
 
     // Result formatters:
-    const toDetail = (result, field) => ({ [field.label]: result[field.variable] });
-    const getLabel = result => result[primaryDisplayField];
-    const getSelected = result => this.state.selectedResults.indexOf(result) > -1;
-    const getDetails = result => additionalAttributes.map(attr => toDetail(result, attr));
+    const toDetail = (node, field) => ({ [field.label]: getNodeAttributes(node)[field.variable] });
+    const getLabel = node => getNodeAttributes(node)[primaryDisplayField];
+    const getSelected = node => this.state.selectedResults.indexOf(node) > -1;
+    const getDetails = node => additionalAttributes.map(attr => toDetail(node, attr));
 
     return (
       <SearchTransition
         className={searchClasses}
         in={!collapsed}
       >
-
         <form>
           <Icon name="close" size="40px" className="menu__cross search__close-button" onClick={evt => this.onClose(evt)} />
 
@@ -198,9 +200,7 @@ class Search extends Component {
             value={this.state.searchTerm}
             type="search"
           />
-
         </form>
-
       </SearchTransition>
     );
   }

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -73,12 +73,31 @@ describe('network reducer', () => {
       {
         type: actionTypes.ADD_NODES,
         nodes: [{ attributes: { name: 'foo' } }, { attributes: { name: 'bar' } }],
-        additionalAttributes: { stage: 1 },
+        additionalAttributes: { stageId: '2', attributes: { isFriend: true } },
       },
     );
 
-    expect(newState.nodes[0].attributes.stage).toEqual(1);
-    expect(newState.nodes[1].attributes.stage).toEqual(1);
+    expect(newState.nodes[0].stageId).toBe('2');
+    expect(newState.nodes[1].stageId).toBe('2');
+    expect(newState.nodes[0].attributes.isFriend).toBe(true);
+    expect(newState.nodes[1].attributes.isFriend).toBe(true);
+    expect(newState.nodes[0].attributes.name).toEqual('foo');
+    expect(newState.nodes[1].attributes.name).toEqual('bar');
+  });
+
+  it('should prefer node.attributes to additionalAttributes.attributes ', () => {
+    const newState = reducer(
+      {
+        ...mockState,
+        nodes: [],
+      },
+      {
+        type: actionTypes.ADD_NODES,
+        nodes: [{ attributes: { name: 'foo' } }],
+        additionalAttributes: { attributes: { name: 'defaultName' } },
+      },
+    );
+    expect(newState.nodes[0].attributes.name).toEqual('foo');
   });
 
   it('should handle REMOVE_NODE', () => {

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -3,6 +3,7 @@
 import faker from 'faker';
 import { times } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
+import { nodeAttributesProperty } from './network';
 
 const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
@@ -17,9 +18,11 @@ const generateNodes = (howMany = 0) =>
         type: 'person',
         promptId: 'mock',
         stageId: 'mock',
-        name: `${firstName} ${lastName}`,
-        nickname: lastName,
-        age,
+        [nodeAttributesProperty]: {
+          name: `${firstName} ${lastName}`,
+          nickname: lastName,
+          age,
+        },
         timeCreated: Date.now().toString(),
       }));
     });

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -115,8 +115,6 @@ export default function reducer(state = initialState, action = {}) {
 
         // When we find the node that matches the primary key, toggle the properties
         if (isMatch(node[nodeAttributesProperty], attributesToToggle)) {
-          // Object.assign is much slower than the following safe mutation
-          // eslint-disable-next-line no-param-reassign
           const withoutAttributes = omit(
             node[nodeAttributesProperty],
             Object.getOwnPropertyNames(attributesToToggle),

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -44,16 +44,17 @@ export const getNodeWithoutAttributes = node => omit(node, nodeAttributesPropert
 /**
  * existingNodes - Existing network.nodes
  * netNodes - nodes to be added to the network
- * additionalAttributes - node model properties
+ * additionalAttributes - static props shared to add to each member of newNodes
 */
-function getNodesWithBatchAdd(existingNodes, newNodes, nodeAttributeData) {
+function getNodesWithBatchAdd(existingNodes, newNodes, additionalAttributes = {}) {
   // Create a function to create a UUID and merge node attributes
   const withModelandAttributeData = newNode => ({
+    ...additionalAttributes,
     [nodePrimaryKeyProperty]: uuidv4(),
-    ...newNode, // second to allow existing UUID to be overwritten
+    ...newNode, // second to prevent overwriting existing node UUID (e.g., assigned to externalData)
     [nodeAttributesProperty]: {
+      ...additionalAttributes[nodeAttributesProperty],
       ...newNode[nodeAttributesProperty],
-      ...nodeAttributeData,
     },
   });
 

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -28,6 +28,8 @@ const propCardOptions = (_, props) => props.prompt.cardOptions;
 const propSortOptions = (_, props) => props.prompt.sortOptions;
 const propPanels = (_, props) => props.stage.panels;
 
+// Static props that will be added to any created/edited node on the prompt
+// Any protocol-specific props will exist in the [nodeAttributesProperty] object
 export const makeGetPromptNodeAttributes = () => {
   const getSubject = makeGetSubject();
   const getIds = makeGetIds();


### PR DESCRIPTION
This fixes remaining test failures, the CardList issue with Resume Interview, and some other issues with the secondary Name Generators (List & Autocomplete). I tried to stick to the new direction as best I could, but had to revert part of addNodes() to support those other name generators.

It's still not immediately obvious where the attributes sub-object needs to be dealt with in all cases, but I tried to add some test coverage for the problem spots I saw.

Summary by commit; they should be individually pickable:

- Fix session & node card lists
    - CardList should provide an element of the supplied data collection for formatters.
- Fix Search (no results found)
    - Search lib must be told where to find the nested attributes
- Fix node creation on NGList & NGAutocomplete
    - Nodes already exist with model attrs inside attributes; no need to pass as a separate arg. The second arg to addNodes() should be the static set of "additional attributes" so that the batch NG interfaces can create without first inserting that information into each node.
- Fix filtering on NGList (was not wired up)
- Fix ListSelect state
    - Unconditionally deriving props cleared the sort too often; for example, when selecting an item, the list would re-sort and potentially leave the just-selected item out of view if it was scrolled.
- Re-add null check to label func
- Fix mock data