### PR TITLE
Fix node updating during drag

### DIFF
--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -43,7 +43,7 @@ const dropHandlers = compose(
       props.setDropCount(props.dropCount + 1);
     },
     onDrag: props => (item) => {
-      if (!has(item.meta, props.layoutVariable)) { return; }
+      if (!has(item.meta[nodeAttributesProperty], props.layoutVariable)) { return; }
 
       props.updateNode(
         {


### PR DESCRIPTION
Fixes #657.

"meta" refers to node information; this checks the `.attributes` sub-object for layout info.

I don't see a straightforward way to add a regression test without a somewhat substantial refactor, so I've skipped that for now.