### PR TITLE
Fix prompt setting when index/ID is 0

### DIFF
--- a/src/behaviours/__tests__/withPrompt.test.js
+++ b/src/behaviours/__tests__/withPrompt.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { createStore } from 'redux';
+
+import withPrompt from '../withPrompt';
+
+jest.mock('../../selectors/session', () => ({
+  getPromptForCurrentSession: jest.fn().mockReturnValue(99),
+  stages: jest.fn().mockReturnValue([{}]),
+}));
+
+describe('withPrompt', () => {
+  const MockWithPrompt = withPrompt(() => (<div />));
+  const mockState = {
+    session: '1',
+    sessions: {},
+    protocol: {
+      stages: [{}, {}],
+    },
+  };
+
+  it('gets prompt from promptId', () => {
+    const subj = shallow(<MockWithPrompt promptId={2} store={createStore(() => mockState)} />);
+    expect(subj.prop('promptIndex')).toBe(2);
+  });
+
+  it('gets cached prompt when promptId not set', () => {
+    const subj = shallow(<MockWithPrompt store={createStore(() => mockState)} />);
+    expect(subj.prop('promptIndex')).toBe(99);
+  });
+
+  it('gets prompt from promptId when 0', () => {
+    const subj = shallow(<MockWithPrompt promptId={0} store={createStore(() => mockState)} />);
+    expect(subj.prop('promptIndex')).toBe(0);
+  });
+});

--- a/src/behaviours/withPrompt.js
+++ b/src/behaviours/withPrompt.js
@@ -62,8 +62,12 @@ export default function withPrompt(WrappedComponent) {
   };
 
   function mapStateToProps(state, ownProps) {
+    let promptIndex = ownProps.promptId;
+    if (promptIndex === undefined) {
+      promptIndex = getPromptForCurrentSession(state);
+    }
     return {
-      promptIndex: ownProps.promptId || getPromptForCurrentSession(state),
+      promptIndex,
       stage: ownProps.stage || stages(state)[ownProps.stageIndex],
     };
   }


### PR DESCRIPTION
Fixes #656.

One way to reproduce #656 (on master):
1. Start a session with the development protocol
2. Go to the third stage (ordinal bin with orange headers)
3. Double-click the 'next' timeline button (bottom left)

The promptIndex should be selected for the currentSession only when undefined (not 0). During the transition, the stage has already changed, and promptIndex may be out of range.