### PR TITLE
Fix node updating

### DIFF
--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -31,9 +31,7 @@ const dropHandlers = compose(
     accepts: () => ({ meta }) => meta.itemType === 'POSITIONED_NODE',
     onDrop: props => (item) => {
       props.updateNode(
-        {
-          [nodePrimaryKeyProperty]: item.meta[nodePrimaryKeyProperty],
-        },
+        item.meta,
         {
           [props.layoutVariable]: relativeCoords(props, item),
         },
@@ -46,9 +44,7 @@ const dropHandlers = compose(
       if (!has(item.meta[nodeAttributesProperty], props.layoutVariable)) { return; }
 
       props.updateNode(
-        {
-          [nodePrimaryKeyProperty]: item.meta[nodePrimaryKeyProperty],
-        },
+        item.meta,
         {
           [props.layoutVariable]: relativeCoords(props, item),
         },

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { get, has, merge, omit } from 'lodash';
+import { get, has } from 'lodash';
 import withPrompt from '../../behaviours/withPrompt';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { actionCreators as modalActions } from '../../ducks/modules/modals';
@@ -11,7 +11,6 @@ import { makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper, NodePanels, NodeForm } from '../';
 import { NodeList, NodeBin } from '../../components/';
 import { makeRehydrateForm } from '../../selectors/forms';
-import { getNodeWithoutAttributes } from '../../ducks/modules/network';
 
 /**
   * Name Generator Interface
@@ -70,16 +69,9 @@ class NameGenerator extends Component {
    */
   onDrop = (item) => {
     const node = { ...item.meta };
-    const nodeModelData = getNodeWithoutAttributes(node);
-
-    const promptModelData = omit(this.props.newNodeAttributes);
-
     // Test if we are updating an existing network node, or adding it to the network
     if (has(node, 'promptId') || has(node, 'stageId')) {
-      this.props.updateNode(
-        { ...merge(nodeModelData, promptModelData) },
-        { ...this.props.activePromptAttributes },
-      );
+      this.props.updateNode(node, { ...this.props.activePromptAttributes });
     } else {
       this.props.addNodes(node, this.props.newNodeAttributes);
     }

--- a/src/containers/OrdinalBins.js
+++ b/src/containers/OrdinalBins.js
@@ -8,7 +8,7 @@ import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
 import { NodeList } from '../components/';
 import { MonitorDragSource } from '../behaviours/DragAndDrop';
 import { getCSSVariableAsString } from '../utils/CSSVariables';
-import { nodeAttributesProperty } from '../ducks/modules/network';
+import { nodeAttributesProperty, nodePrimaryKeyProperty } from '../ducks/modules/network';
 
 class OrdinalBins extends PureComponent {
   static propTypes = {
@@ -16,7 +16,7 @@ class OrdinalBins extends PureComponent {
     bins: PropTypes.array.isRequired,
     prompt: PropTypes.object.isRequired,
     stage: PropTypes.object.isRequired,
-    updateNode: PropTypes.func.isRequired,
+    toggleNodeAttributes: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -63,7 +63,7 @@ class OrdinalBins extends PureComponent {
 
       const newValue = {};
       newValue[this.props.activePromptVariable] = bin.value;
-      this.props.updateNode(meta, newValue);
+      this.props.toggleNodeAttributes(meta[nodePrimaryKeyProperty], newValue);
     };
 
     const accentColor = this.calculateAccentColor(index, missingValue);
@@ -128,7 +128,7 @@ function makeMapStateToProps() {
 
 function mapDispatchToProps(dispatch) {
   return {
-    updateNode: bindActionCreators(sessionsActions.updateNode, dispatch),
+    toggleNodeAttributes: bindActionCreators(sessionsActions.toggleNodeAttributes, dispatch),
   };
 }
 

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -143,7 +143,7 @@ describe('network reducer', () => {
     expect(newState.nodes[0]).toEqual({ [PK]: 1, id: 1, name: 'foo' });
   });
 
-  it('should handle TOGGLE_NODE_ATTRIBUTES', () => {
+  it('toggles node attributes on', () => {
     const newState = reducer(
       {
         ...mockState,
@@ -158,7 +158,9 @@ describe('network reducer', () => {
 
     expect(newState.nodes[0].attributes.stage).toEqual(1);
     expect(newState.nodes[1].attributes.stage).toEqual(undefined);
+  });
 
+  it('toggles node attributes off', () => {
     const secondState = reducer(
       {
         ...mockState,

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -149,7 +149,7 @@ describe('sessions actions', () => {
       type: actionTypes.UPDATE_NODE,
       sessionId: 'a',
       node: {},
-      additionalAttributes: false,
+      additionalAttributes: null,
     };
 
     store.dispatch(actionCreators.updateNode({}));

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -102,26 +102,19 @@ export default function reducer(state = initialState, action = {}) {
      * TOGGLE_NODE_ATTRIBUTES
      */
     case TOGGLE_NODE_ATTRIBUTES: {
-      // attributes = object containing the attributes to remove, minus _uid
-      const attributesToToggle = omit(action.attributes, [nodePrimaryKeyProperty]);
-      // Map over the nodes
       const updatedNodes = state.nodes.map((node) => {
-        // Skip nodes with different primary keys
-        if (node[nodePrimaryKeyProperty] !== action[nodePrimaryKeyProperty]) { return node; }
-
-        // When we find the node that matches the primary key, toggle the properties
-        if (isMatch(node[nodeAttributesProperty], attributesToToggle)) {
-          const withoutAttributes = omit(
-            node[nodeAttributesProperty],
-            Object.getOwnPropertyNames(attributesToToggle),
-          );
-
-          return {
-            ...node,
-            [nodeAttributesProperty]: withoutAttributes,
-          };
+        if (node[nodePrimaryKeyProperty] !== action[nodePrimaryKeyProperty]) {
+          return node;
         }
 
+        // If the node's attrs contain the same key/vals, remove them
+        if (isMatch(node[nodeAttributesProperty], action.attributes)) {
+          const omittedKeys = Object.keys(action.attributes);
+          const nestedProps = omittedKeys.map(key => `${nodeAttributesProperty}.${key}`);
+          return omit(node, nestedProps);
+        }
+
+        // Otherwise, add/update
         return {
           ...node,
           [nodeAttributesProperty]: {

--- a/src/ducks/modules/reset.js
+++ b/src/ducks/modules/reset.js
@@ -1,5 +1,7 @@
 import { omit } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
+import { nodeAttributesProperty } from './network';
+
 
 const RESET_EDGES_OF_TYPE = 'RESET/EDGES_OF_TYPE';
 const RESET_PROPERTY_FOR_ALL_NODES = 'RESET/PROPERTY_FOR_ALL_NODES';
@@ -10,10 +12,10 @@ const resetPropertyForAllNodes = property =>
     const { sessions: { [session]: { network: { nodes } } } } = getState();
 
     nodes.forEach(node => dispatch(
-      sessionsActions.updateNode(omit(node, property), true)));
+      sessionsActions.updateNode(omit(node, `${nodeAttributesProperty}.${property}`))));
   };
 
-export const resetEdgesOfType = edgeType =>
+const resetEdgesOfType = edgeType =>
   (dispatch, getState) => {
     const { session } = getState();
     const { sessions: { [session]: { network: { edges } } } } = getState();

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -107,7 +107,7 @@ const addNodes = (nodes, additionalAttributes) => (dispatch, getState) => {
   });
 };
 
-const updateNode = (node, additionalAttributes = false) => (dispatch, getState) => {
+const updateNode = (node, additionalAttributes = null) => (dispatch, getState) => {
   const { session } = getState();
 
   dispatch({


### PR DESCRIPTION
Fixes #664. See test cases there.

This fixes nested attribute updating in a few places to match behavior from alpha.6:
- Sociogram reset
- NameGenerator drag/drop
- Ordinal Bin
