### PR TITLE
Supply node UIDs to user workers

### DIFF
--- a/public/protocols/development.netcanvas/nodeLabelWorker.js
+++ b/public/protocols/development.netcanvas/nodeLabelWorker.js
@@ -11,9 +11,14 @@
  *
  * @param  {Object} data
  * @param  {Object} data.node All props for the node requiring a label
+ * @param  {string} data.node.networkCanvasId Unique ID for the node. Note that if your data
+ *                                            happens to already contain a property named
+ *                                            "networkCanvasId", your prop will take precedence,
+ *                                            and this cannot be used to identify edge connections.
  * @param  {Object} data.network The current state of the network in this session
- * @param  {Array} data.network.nodes
- * @param  {Array} data.network.edges
+ * @param  {Array} data.network.nodes Each node has a unique `networkCanvasId` prop
+ * @param  {Array} data.network.edges Edges contain `to` and `from` props which
+ *                                    correspond to nodes' `networkCanvasId` values
  *
  * @return {string|Promise} a label for the input node, or
  *                          a promise that resolves to the label
@@ -25,15 +30,17 @@ function nodeLabelWorker({ node, network }) {
   // const label = `${node.name} ${(node.last_name && `${node.last_name[0]}.`) || ''}`;
   //
   // 2. Counter based on data set or subset (here, the network nodes)
-  // const index = network.nodes.findIndex(n => n.uid === node.uid);
+  // const index = network.nodes.findIndex(n => n.networkCanvasId === node.networkCanvasId);
   // const label = index > -1 ? `${node.name} ${index + 1}` : node.name;
   //
   // 3. Counter, based on network as well. Access to `externalData` TBD.
   // const networkNodeIds = {};
-  // network.nodes.forEach((n) => { networkNodeIds[n.uid] = 1; });
-  // const externalNodes = externalData.previousInterview.nodes.filter(n => !networkNodeIds[n.uid]);
-  // const nodes = [...network.nodes, ...externalNodes].sort((a, b) => a.uid.localeCompare(b.uid));
-  // const index = nodes.findIndex(n => n.uid === node.uid);
+  // network.nodes.forEach((n) => { networkNodeIds[n.networkCanvasId] = 1; });
+  // const externalNodes = externalData.previousInterview.nodes
+  //    .filter(n => !networkNodeIds[n.networkCanvasId]);
+  // const nodes = [...network.nodes, ...externalNodes]
+  //    .sort((a, b) => a.networkCanvasId.localeCompare(b.networkCanvasId));
+  // const index = nodes.findIndex(n => n.networkCanvasId === node.networkCanvasId);
   // const label = index > -1 ? `${node.name} ${index + 1}` : node.name;
   //
   // 4. Add emoji suffix based on a node property
@@ -43,7 +50,7 @@ function nodeLabelWorker({ node, network }) {
 
   // 5. Add emoji based on an edge or node property
   let label = node.name;
-  if (network.edges.some(e => e.from === node._uid || e.to === node._uid)) {
+  if (network.edges.some(e => e.from === node.networkCanvasId || e.to === node.networkCanvasId)) {
     label += '😎';
   } else if (node.close_friend) {
     label += '😇';

--- a/src/containers/Node.js
+++ b/src/containers/Node.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 
 import WorkerAgent from '../utils/WorkerAgent';
 import { Node as UINode } from '../ui/components';
-import { getNetwork, getNodeLabelFunction } from '../selectors/interface';
+import { getWorkerNetwork, getNodeLabelFunction } from '../selectors/interface';
 import { getNodeLabelWorkerUrl, makeGetNodeColor } from '../selectors/protocol';
-import { nodeAttributesProperty } from '../ducks/modules/network';
+import { asWorkerAgentNode } from '../ducks/modules/network';
 
 /**
   * Renders a Node.
@@ -40,7 +40,7 @@ class Node extends PureComponent {
     }
 
     // Create an object containing the node's model properties
-    const node = { ...this.props[nodeAttributesProperty] };
+    const node = asWorkerAgentNode(this.props);
 
     // Send the worker the node model properties along with the network
     const msgPromise = this.webWorker.sendMessageAsync({
@@ -84,7 +84,7 @@ function mapStateToProps(state, props) {
     color: getNodeColor(state, props),
     getLabel: getNodeLabelFunction(state),
     workerUrl: getNodeLabelWorkerUrl(state),
-    workerNetwork: (getNodeLabelWorkerUrl(state) && getNetwork(state)) || null,
+    workerNetwork: (getNodeLabelWorkerUrl(state) && getWorkerNetwork(state)) || null,
   };
 }
 

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -1,6 +1,11 @@
 /* eslint-env jest */
 
-import reducer, { actionTypes, nodePrimaryKeyProperty as PK } from '../network';
+import reducer,
+{ actionTypes,
+  asWorkerAgentNode,
+  nodePrimaryKeyProperty as PK,
+  primaryKeyPropertyForWorker,
+} from '../network';
 
 const mockState = {
   ego: {},
@@ -219,5 +224,27 @@ describe('network reducer', () => {
         edges: [edgeB],
       },
     );
+  });
+});
+
+describe('asWorkerAgentNode', () => {
+  const nodeInNetwork = {
+    attributes: {
+      userProp1: 'userProp1',
+    },
+    [PK]: 'node1',
+    stageId: 42,
+  };
+
+  it('returns a node’s attributes', () => {
+    expect(asWorkerAgentNode(nodeInNetwork).userProp1).toEqual('userProp1');
+  });
+
+  it('returns a unique ID for the node', () => {
+    expect(asWorkerAgentNode(nodeInNetwork)[primaryKeyPropertyForWorker]).toEqual('node1');
+  });
+
+  it('does not contain other private attrs props', () => {
+    expect(asWorkerAgentNode(nodeInNetwork)).not.toHaveProperty('stageId');
   });
 });

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -18,6 +18,7 @@ export const REMOVE_EDGE = 'REMOVE_EDGE';
 export const SET_EGO = 'SET_EGO';
 export const UNSET_EGO = 'UNSET_EGO';
 
+export const primaryKeyPropertyForWorker = 'networkCanvasId';
 
 // Initial network model structure
 const initialState = {
@@ -38,6 +39,14 @@ function edgeExists(edges, edge) {
 }
 
 export const getNodeAttributes = node => node[nodeAttributesProperty] || {};
+
+// Returns node data safe to supply to user-defined workers.
+// Contains all user attributes flattened with the node's unique ID.
+// `primaryKeyPropertyForWorker` is used to minimize conflicts, but user data is always preserved.
+export const asWorkerAgentNode = node => ({
+  [primaryKeyPropertyForWorker]: node[nodePrimaryKeyProperty],
+  ...getNodeAttributes(node),
+});
 
 /**
  * existingNodes - Existing network.nodes

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -5,7 +5,7 @@ import { findKey, filter, has, isMatch, reject } from 'lodash';
 import { createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
 import { getCurrentSession } from './session';
-import { getNodeAttributes, nodeAttributesProperty } from '../ducks/modules/network';
+import { getNodeAttributes, nodeAttributesProperty, asWorkerAgentNode } from '../ducks/modules/network';
 
 // Selectors that are generic between interfaces
 
@@ -38,6 +38,14 @@ export const networkNodes = createDeepEqualSelector(
 export const networkEdges = createDeepEqualSelector(
   getNetwork,
   network => network.edges,
+);
+
+export const getWorkerNetwork = createDeepEqualSelector(
+  networkNodes, networkEdges,
+  (nodes = [], edges = []) => ({
+    nodes: nodes.map(asWorkerAgentNode),
+    edges,
+  }),
 );
 
 export const makeGetIds = () =>


### PR DESCRIPTION
Fixes #668. Makes the sociogram cool again.

![cool](https://user-images.githubusercontent.com/39674/45438445-2c017a00-b685-11e8-9bc1-b993409a4e61.png)

- the ID is added at the same level as user props
- to minimize conflicts and self-document, uses "networkCanvasId" as key

The node info provided to the worker will look something like:
```
{
    "networkCanvasId":"2f92b04bbd7842d4ae90da7f2a1a178101f6ca51",
    "support_friend":true,
    "name":"Eustace",
    "age":"24"
}
```

I've updated [the Node Labeling wiki](https://github.com/codaco/Network-Canvas/wiki/Node-Labeling).