### PR TITLE
Fix key on bucket node

### DIFF
--- a/src/containers/NodeBucket.js
+++ b/src/containers/NodeBucket.js
@@ -7,6 +7,7 @@ import Node from './Node';
 import { makeGetNextUnplacedNode, makeGetSociogramOptions } from '../selectors/sociogram';
 import { DragSource } from '../behaviours/DragAndDrop';
 import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
+import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 
 const EnhancedNode = DragSource(Node);
 
@@ -33,7 +34,7 @@ class NodeBucket extends PureComponent {
       <div className="node-bucket">
         { node &&
           <EnhancedNode
-            key={node.uid}
+            key={node[nodePrimaryKeyProperty]}
             meta={() => ({ ...node, itemType: 'POSITIONED_NODE' })}
             scrollDirection={NO_SCROLL}
             {...node}


### PR DESCRIPTION
Key is used to ensure that previous label is cleared when the next node
is ready to display. This is especially important for async node label
workers.

Fixes #667.
