### PR TITLE
Improve ordinal bucket item drag

### DIFF
--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -8,6 +8,7 @@ import { TransitionGroup } from 'react-transition-group';
 import Node from '../containers/Node';
 import { getCSSVariableAsString, getCSSVariableAsNumber } from '../utils/CSSVariables';
 import { Node as NodeTransition } from './Transition';
+import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
 import { selectable } from '../behaviours';
 import {
   DragSource,
@@ -129,6 +130,7 @@ class OrdinalBinBucket extends Component {
                   selected={selected(node)}
                   onSelected={() => onSelect(node)}
                   meta={() => ({ ...node, itemType })}
+                  scrollDirection={NO_SCROLL}
                   {...node}
                 />
               </NodeTransition>
@@ -174,3 +176,7 @@ export default compose(
   MonitorDropTarget(['isOver', 'willAccept']),
   MonitorDragSource(['meta', 'isDragging']),
 )(OrdinalBinBucket);
+
+export {
+  OrdinalBinBucket as UnconnectedOrdinalBinBucket,
+};

--- a/src/components/OrdinalBinBucket.js
+++ b/src/components/OrdinalBinBucket.js
@@ -9,7 +9,6 @@ import Node from '../containers/Node';
 import { getCSSVariableAsString, getCSSVariableAsNumber } from '../utils/CSSVariables';
 import { Node as NodeTransition } from './Transition';
 import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
-import { selectable } from '../behaviours';
 import {
   DragSource,
   DropTarget,
@@ -19,7 +18,7 @@ import {
 import sortOrder from '../utils/sortOrder';
 import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 
-const EnhancedNode = DragSource(selectable(Node));
+const EnhancedNode = DragSource(Node);
 
 /**
   * Renders a list of Node.
@@ -79,8 +78,6 @@ class OrdinalBinBucket extends Component {
     const {
       nodeColor,
       label,
-      selected,
-      onSelect,
       itemType,
       isOver,
       willAccept,
@@ -127,8 +124,6 @@ class OrdinalBinBucket extends Component {
                   color={nodeColor}
                   inactive={index !== 0}
                   label={`${label(node)}`}
-                  selected={selected(node)}
-                  onSelected={() => onSelect(node)}
                   meta={() => ({ ...node, itemType })}
                   scrollDirection={NO_SCROLL}
                   {...node}
@@ -145,10 +140,8 @@ class OrdinalBinBucket extends Component {
 OrdinalBinBucket.propTypes = {
   nodes: PropTypes.array.isRequired,
   nodeColor: PropTypes.string,
-  onSelect: PropTypes.func,
   itemType: PropTypes.string,
   label: PropTypes.func,
-  selected: PropTypes.func,
   isOver: PropTypes.bool,
   willAccept: PropTypes.bool,
   meta: PropTypes.object,
@@ -160,8 +153,6 @@ OrdinalBinBucket.defaultProps = {
   nodes: [],
   nodeColor: '',
   label: () => (''),
-  selected: () => false,
-  onSelect: () => {},
   onDrop: () => {},
   itemType: 'NODE',
   isOver: false,

--- a/src/components/__tests__/OrdinalBinBucket.test.js
+++ b/src/components/__tests__/OrdinalBinBucket.test.js
@@ -6,7 +6,6 @@ import { UnconnectedOrdinalBinBucket as OrdinalBinBucket } from '../OrdinalBinBu
 import { NO_SCROLL } from '../../behaviours/DragAndDrop/DragManager';
 
 jest.mock('../../containers/Node');
-jest.mock('../../behaviours/selectable', () => el => el);
 
 describe('OrdinalBinBucket', () => {
   let bucket;

--- a/src/components/__tests__/OrdinalBinBucket.test.js
+++ b/src/components/__tests__/OrdinalBinBucket.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { UnconnectedOrdinalBinBucket as OrdinalBinBucket } from '../OrdinalBinBucket';
+import { NO_SCROLL } from '../../behaviours/DragAndDrop/DragManager';
+
+jest.mock('../../containers/Node');
+jest.mock('../../behaviours/selectable', () => el => el);
+
+describe('OrdinalBinBucket', () => {
+  let bucket;
+
+  beforeEach(() => {
+    bucket = mount(<OrdinalBinBucket nodes={[{}]} />);
+  });
+
+  it('renders connected node items', () => {
+    expect(bucket.find('Connect(Node)')).toHaveLength(1);
+  });
+
+  it('specifies no_scroll on items for improved drag responsiveness', () => {
+    expect(bucket.find('Connect(Node)').prop('scrollDirection')).toEqual(NO_SCROLL);
+  });
+});


### PR DESCRIPTION
This sets the `scrollDirection` prop on the wrapped nodes inside the Ordinal Bin Bucket to improve drag detection. The bucket is laid out horizontally but doesn't actually scroll, so `NO_SCROLL` is used.

I also removed the selectable/onSelect props since they're never used.

@rebeccamadsen thanks for the fix here.