### PR TITLE
set a minimum time for protocol loading spinner

### DIFF
--- a/src/components/Transition/Fade.js
+++ b/src/components/Transition/Fade.js
@@ -4,34 +4,39 @@ import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsObject, getCSSVariableAsNumber } from '../../utils/CSSVariables';
 
-const duration = {
+const durationFast = {
   enter: getCSSVariableAsNumber('--animation-duration-fast-ms'),
   exit: getCSSVariableAsNumber('--animation-duration-fast-ms'),
 };
 
-const enterAnimation = {
+const durationSlow = {
+  enter: getCSSVariableAsNumber('--animation-duration-slow-ms'),
+  exit: getCSSVariableAsNumber('--animation-duration-slow-ms'),
+};
+
+const enterAnimation = duration => ({
   opacity: [0, 1],
   elasticity: 0,
   easing: getCSSVariableAsObject('--animation-easing-js'),
   duration: duration.enter,
-};
+});
 
-const exitAnimation = {
+const exitAnimation = duration => ({
   opacity: [1, 0],
   elasticity: 0,
   easing: getCSSVariableAsObject('--animation-easing-js'),
   duration: duration.exit,
-};
+});
 
-const Fade = ({ children, ...props }) => (
+const Fade = ({ children, isSlow, ...props }) => (
   <Transition
     {...props}
-    timeout={duration}
+    timeout={isSlow ? durationSlow : durationFast}
     onEnter={
       (el) => {
         anime({
           targets: el,
-          ...enterAnimation,
+          ...enterAnimation(isSlow ? durationSlow : durationFast),
         });
       }
     }
@@ -39,7 +44,7 @@ const Fade = ({ children, ...props }) => (
       (el) => {
         anime({
           targets: el,
-          ...exitAnimation,
+          ...exitAnimation(isSlow ? durationSlow : durationFast),
         });
       }
     }
@@ -52,10 +57,12 @@ const Fade = ({ children, ...props }) => (
 
 Fade.propTypes = {
   children: PropTypes.any.isRequired,
+  isSlow: PropTypes.bool,
 };
 
 Fade.defaultProps = {
   children: null,
+  isSlow: false,
 };
 
 export default Fade;

--- a/src/containers/LoadScreen.js
+++ b/src/containers/LoadScreen.js
@@ -1,17 +1,48 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { Spinner } from '../ui/components';
 import Fade from '../components/Transition/Fade';
 
-const LoadScreen = ({ isWorking }) => (
-  <Fade in={isWorking}>
-    <div className="load-screen">
-      <Spinner large />
-    </div>
-  </Fade>
-);
+class LoadScreen extends Component {
+  static getDerivedStateFromProps(props) {
+    if (props.isWorking) {
+      return { minimumTimeMet: false };
+    }
+
+    return null;
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      minimumTimeMet: true,
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.isWorking) {
+      setTimeout(() => this.setState({ minimumTimeMet: true }), 1000);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isWorking !== this.props.isWorking && this.props.isWorking) {
+      setTimeout(() => this.setState({ minimumTimeMet: true }), 1000);
+    }
+  }
+
+  render() {
+    return (
+      <Fade in={this.props.isWorking || !this.state.minimumTimeMet}>
+        <div className="load-screen">
+          <Spinner large />
+        </div>
+      </Fade>
+    );
+  }
+}
 
 LoadScreen.propTypes = {
   isWorking: PropTypes.bool,

--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -8,7 +8,7 @@ import { push } from 'react-router-redux';
 import { actionCreators as menuActions } from '../ducks/modules/menu';
 import withPrompt from '../behaviours/withPrompt';
 import { Timeline } from '../components';
-import { Stage as StageTransition } from '../components/Transition';
+import { Fade, Stage as StageTransition } from '../components/Transition';
 import Stage from './Stage';
 import { stages, getPromptForCurrentSession } from '../selectors/session';
 
@@ -54,12 +54,14 @@ class Protocol extends Component {
 
     return (
       <div className="protocol">
-        <Timeline
-          onClickBack={this.onClickBack}
-          onClickNext={this.onClickNext}
-          percentProgress={percentProgress}
-          toggleMenu={toggleMenu}
-        />
+        <Fade in={isProtocolLoaded} isSlow>
+          <Timeline
+            onClickBack={this.onClickBack}
+            onClickNext={this.onClickNext}
+            percentProgress={percentProgress}
+            toggleMenu={toggleMenu}
+          />
+        </Fade>
         <TransitionGroup
           className="protocol__content"
           childFactory={this.childFactoryCreator(stageBackward)}


### PR DESCRIPTION
Resolves #670. This adds a minimum wait time to `LoadScreen`. To verify, add or refresh a protocol session and it should at least show the spinner for a second.