### PR TITLE
Prevent node occlusion

### DIFF
--- a/src/behaviours/DragAndDrop/DragPreview.js
+++ b/src/behaviours/DragAndDrop/DragPreview.js
@@ -22,6 +22,7 @@ export default class DraggablePreview {
     this.node.setAttribute('class', 'draggable-preview');
     this.x = -1000;
     this.y = -1000;
+    this.validMove = true;
 
     this.update();
 
@@ -55,11 +56,21 @@ export default class DraggablePreview {
 
   render() {
     this.node.setAttribute('style', styles(this.x, this.y));
+
+    if (this.validMove) {
+      this.node.setAttribute('class', 'draggable-preview');
+    } else {
+      this.node.setAttribute('class', 'draggable-preview node--inactive');
+    }
   }
 
   position(coords) {
     this.x = coords.x - this.center().x;
     this.y = coords.y - this.center().y;
+  }
+
+  setValidMove(valid) {
+    this.validMove = valid;
   }
 
   cleanup() {

--- a/src/behaviours/DragAndDrop/DragSource.js
+++ b/src/behaviours/DragAndDrop/DragSource.js
@@ -73,6 +73,10 @@ const dragSource = WrappedComponent =>
       }
     }
 
+    setValidMove = (valid) => {
+      this.preview.setValidMove(valid);
+    }
+
     onDragStart = (movement) => {
       this.createPreview();
 
@@ -91,7 +95,7 @@ const dragSource = WrappedComponent =>
 
       store.dispatch(
         actions.dragMove({
-          x, y, ...rest,
+          x, y, setValidMove: this.setValidMove, ...rest,
         }),
       );
     }

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -14,7 +14,7 @@ const dropObstacle = WrappedComponent =>
     static propTypes = {
       id: PropTypes.string.isRequired,
       accepts: PropTypes.func,
-      watchProps: PropTypes.arr,
+      watchProps: PropTypes.array,
     }
 
     static defaultProps = {
@@ -74,10 +74,11 @@ const dropObstacle = WrappedComponent =>
     }
 
     render() {
+      const { watchProps, ...rest } = this.props;
       return (
         <WrappedComponent
           ref={(component) => { this.component = component; }}
-          {...this.props}
+          {...rest}
         />
       );
     }

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -1,0 +1,84 @@
+/* eslint-disable react/no-find-dom-node */
+
+import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
+import PropTypes from 'prop-types';
+import { isEqual, pick } from 'lodash';
+
+import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
+import { actionCreators as actions } from './reducer';
+import store from './store';
+
+const watchProps = ['width', 'height', 'x', 'y'];
+
+const propsChangedExcludingNodes = (nextProps, props) =>
+  !isEqual(pick(nextProps, watchProps), pick(props, watchProps));
+
+const dropObstacle = WrappedComponent =>
+  class DropObstacle extends Component {
+    static propTypes = {
+      id: PropTypes.string.isRequired,
+      accepts: PropTypes.func,
+    }
+
+    static defaultProps = {
+      accepts: () => false,
+    }
+
+    componentDidMount() {
+      if (!this.component) { return; }
+      this.node = findDOMNode(this.component);
+      this.update();
+    }
+
+    shouldComponentUpdate(nextProps) {
+      if (propsChangedExcludingNodes(nextProps, this.props)) {
+        this.update();
+        return true;
+      }
+
+      return false;
+    }
+
+    componentWillUnmount() {
+      this.removeObstacle();
+    }
+
+    removeObstacle = () => {
+      store.dispatch(
+        actions.removeObstacle(this.props.id),
+      );
+    }
+
+    update = () => {
+      this.updateObstacle();
+    }
+
+    updateObstacle = () => {
+      if (!this.node) { return; }
+
+      const boundingClientRect = getAbsoluteBoundingRect(this.node);
+
+      store.dispatch(
+        actions.upsertObstacle({
+          id: this.props.id,
+          accepts: this.props.accepts,
+          width: boundingClientRect.width,
+          height: boundingClientRect.height,
+          y: boundingClientRect.top,
+          x: boundingClientRect.left,
+        }),
+      );
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          ref={(component) => { this.component = component; }}
+          {...this.props}
+        />
+      );
+    }
+  };
+
+export default dropObstacle;

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -7,18 +7,12 @@ import PropTypes from 'prop-types';
 import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import { actionCreators as actions } from './reducer';
 import store from './store';
-
-const maxFramesPerSecond = 10;
+import { maxFramesPerSecond } from './DropTarget';
 
 const dropObstacle = WrappedComponent =>
   class DropObstacle extends Component {
     static propTypes = {
       id: PropTypes.string.isRequired,
-      accepts: PropTypes.func,
-    }
-
-    static defaultProps = {
-      accepts: () => false,
     }
 
     componentDidMount() {
@@ -58,7 +52,6 @@ const dropObstacle = WrappedComponent =>
       store.dispatch(
         actions.upsertObstacle({
           id: this.props.id,
-          accepts: this.props.accepts,
           width: boundingClientRect.width,
           height: boundingClientRect.height,
           y: boundingClientRect.top,

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -9,20 +9,17 @@ import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import { actionCreators as actions } from './reducer';
 import store from './store';
 
-const watchProps = ['width', 'height', 'x', 'y'];
-
-const propsChangedExcludingNodes = (nextProps, props) =>
-  !isEqual(pick(nextProps, watchProps), pick(props, watchProps));
-
 const dropObstacle = WrappedComponent =>
   class DropObstacle extends Component {
     static propTypes = {
       id: PropTypes.string.isRequired,
       accepts: PropTypes.func,
+      watchProps: PropTypes.arr,
     }
 
     static defaultProps = {
       accepts: () => false,
+      watchProps: [],
     }
 
     componentDidMount() {
@@ -32,7 +29,7 @@ const dropObstacle = WrappedComponent =>
     }
 
     shouldComponentUpdate(nextProps) {
-      if (propsChangedExcludingNodes(nextProps, this.props)) {
+      if (this.propsChangedExcludingNodes(nextProps, this.props)) {
         this.update();
         return true;
       }
@@ -43,6 +40,11 @@ const dropObstacle = WrappedComponent =>
     componentWillUnmount() {
       this.removeObstacle();
     }
+
+    watchProps = ['width', 'height', 'x', 'y', ...this.props.watchProps];
+
+    propsChangedExcludingNodes = (nextProps, props) =>
+      !isEqual(pick(nextProps, this.watchProps), pick(props, this.watchProps));
 
     removeObstacle = () => {
       store.dispatch(

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -9,6 +9,8 @@ import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import { actionCreators as actions } from './reducer';
 import store from './store';
 
+const maxFramesPerSecond = 10;
+
 const dropObstacle = WrappedComponent =>
   class DropObstacle extends Component {
     static propTypes = {
@@ -39,6 +41,8 @@ const dropObstacle = WrappedComponent =>
 
     componentWillUnmount() {
       this.removeObstacle();
+      clearTimeout(this.interval);
+      cancelAnimationFrame(this.animationFrame);
     }
 
     watchProps = ['width', 'height', 'x', 'y', ...this.props.watchProps];
@@ -54,6 +58,13 @@ const dropObstacle = WrappedComponent =>
 
     update = () => {
       this.updateObstacle();
+
+      this.interval = setTimeout(
+        () => {
+          this.animationFrame = requestAnimationFrame(this.update);
+        },
+        1000 / maxFramesPerSecond,
+      );
     }
 
     updateObstacle = () => {

--- a/src/behaviours/DragAndDrop/DropObstacle.js
+++ b/src/behaviours/DragAndDrop/DropObstacle.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
-import { isEqual, pick } from 'lodash';
 
 import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import { actionCreators as actions } from './reducer';
@@ -16,12 +15,10 @@ const dropObstacle = WrappedComponent =>
     static propTypes = {
       id: PropTypes.string.isRequired,
       accepts: PropTypes.func,
-      watchProps: PropTypes.array,
     }
 
     static defaultProps = {
       accepts: () => false,
-      watchProps: [],
     }
 
     componentDidMount() {
@@ -30,25 +27,11 @@ const dropObstacle = WrappedComponent =>
       this.update();
     }
 
-    shouldComponentUpdate(nextProps) {
-      if (this.propsChangedExcludingNodes(nextProps, this.props)) {
-        this.update();
-        return true;
-      }
-
-      return false;
-    }
-
     componentWillUnmount() {
       this.removeObstacle();
       clearTimeout(this.interval);
       cancelAnimationFrame(this.animationFrame);
     }
-
-    watchProps = ['width', 'height', 'x', 'y', ...this.props.watchProps];
-
-    propsChangedExcludingNodes = (nextProps, props) =>
-      !isEqual(pick(nextProps, this.watchProps), pick(props, this.watchProps));
 
     removeObstacle = () => {
       store.dispatch(
@@ -85,11 +68,10 @@ const dropObstacle = WrappedComponent =>
     }
 
     render() {
-      const { watchProps, ...rest } = this.props;
       return (
         <WrappedComponent
           ref={(component) => { this.component = component; }}
-          {...rest}
+          {...this.props}
         />
       );
     }

--- a/src/behaviours/DragAndDrop/DropTarget.js
+++ b/src/behaviours/DragAndDrop/DropTarget.js
@@ -15,6 +15,7 @@ const dropTarget = WrappedComponent =>
       id: PropTypes.string.isRequired,
       onDrop: PropTypes.func,
       onDrag: PropTypes.func,
+      onDragEnd: PropTypes.func,
       accepts: PropTypes.func,
       meta: PropTypes.func,
     }
@@ -24,6 +25,7 @@ const dropTarget = WrappedComponent =>
       accepts: () => false,
       onDrop: () => {},
       onDrag: () => {},
+      onDragEnd: () => {},
     }
 
     componentDidMount() {
@@ -65,6 +67,7 @@ const dropTarget = WrappedComponent =>
           id: this.props.id,
           onDrop: this.props.onDrop,
           onDrag: this.props.onDrag,
+          onDragEnd: this.props.onDragEnd,
           accepts: this.props.accepts,
           meta: this.props.meta(),
           width: boundingClientRect.width,

--- a/src/behaviours/DragAndDrop/DropTarget.js
+++ b/src/behaviours/DragAndDrop/DropTarget.js
@@ -95,3 +95,5 @@ const dropTarget = WrappedComponent =>
   };
 
 export default dropTarget;
+
+export { maxFramesPerSecond };

--- a/src/behaviours/DragAndDrop/__mocks__/reducer.js
+++ b/src/behaviours/DragAndDrop/__mocks__/reducer.js
@@ -4,6 +4,9 @@ const upsertTarget = jest.fn(() => ({ type: null }));
 const renameTarget = jest.fn(() => ({ type: null }));
 const removeTarget = jest.fn(() => ({ type: null }));
 
+const upsertObstacle = jest.fn(() => ({ type: null }));
+const removeObstacle = jest.fn(() => ({ type: null }));
+
 const dragStart = jest.fn(() => ({ type: null }));
 const dragMove = jest.fn(() => ({ type: null }));
 const dragEnd = jest.fn(() => ({ type: null }));
@@ -12,6 +15,8 @@ const actionCreators = {
   upsertTarget,
   renameTarget,
   removeTarget,
+  upsertObstacle,
+  removeObstacle,
   dragStart,
   dragMove,
   dragEnd,

--- a/src/behaviours/DragAndDrop/__mocks__/store.js
+++ b/src/behaviours/DragAndDrop/__mocks__/store.js
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 const mockStore = configureStore([thunk]);
 
 export default mockStore({
+  obstacles: [],
   targets: [],
   source: null,
 });

--- a/src/behaviours/DragAndDrop/__tests__/DropObstacle.test.js
+++ b/src/behaviours/DragAndDrop/__tests__/DropObstacle.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { actionCreators as actions } from '../reducer';
-import DropTarget from '../DropTarget';
+import DropObstacle from '../DropObstacle';
 
 jest.mock('../store');
 jest.mock('../reducer');
@@ -13,13 +13,13 @@ const mockProps = {
   id: 'foo',
 };
 
-describe('DropTarget', () => {
+describe('DropObstacle', () => {
   describe('on mount', () => {
     let component;
 
     beforeEach(() => {
-      actions.upsertTarget.mockClear();
-      const MockComponent = DropTarget('div');
+      actions.upsertObstacle.mockClear();
+      const MockComponent = DropObstacle('div');
 
       component = mount((
         <MockComponent {...mockProps} />
@@ -30,8 +30,8 @@ describe('DropTarget', () => {
       component.unmount();
     });
 
-    it('registers target with UPSERT_TARGET on mount', () => {
-      expect(actions.upsertTarget.mock.calls.length).toEqual(1);
+    it('registers obstacle with UPSERT_OBSTACLE on mount', () => {
+      expect(actions.upsertObstacle.mock.calls.length).toEqual(1);
     });
   });
 
@@ -39,8 +39,8 @@ describe('DropTarget', () => {
     let component;
 
     beforeEach(() => {
-      actions.upsertTarget.mockClear();
-      const MockComponent = DropTarget('div');
+      actions.upsertObstacle.mockClear();
+      const MockComponent = DropObstacle('div');
 
       component = mount((
         <MockComponent {...mockProps} />
@@ -51,24 +51,24 @@ describe('DropTarget', () => {
       component.unmount();
     });
 
-    it('upserts target with UPSERT_TARGET on interval', () => {
+    it('upserts obstacle with UPSERT_OBSTACLE on interval', () => {
       jest.runTimersToTime(1000);
-      expect(actions.upsertTarget.mock.calls.length).toEqual(10); // 10 fps
+      expect(actions.upsertObstacle.mock.calls.length).toEqual(10); // 10 fps
     });
   });
 
   describe('on unmount', () => {
     beforeEach(() => {
-      actions.removeTarget.mockClear();
-      const MockComponent = DropTarget('div');
+      actions.removeObstacle.mockClear();
+      const MockComponent = DropObstacle('div');
 
       mount((
         <MockComponent {...mockProps} />
       )).unmount();
     });
 
-    it('deregisters target with REMOVE_TARGET on unmount', () => {
-      expect(actions.removeTarget.mock.calls.length).toEqual(1);
+    it('deregisters obstacle with REMOVE_OBSTACLE on unmount', () => {
+      expect(actions.removeObstacle.mock.calls.length).toEqual(1);
     });
   });
 });

--- a/src/behaviours/DragAndDrop/__tests__/reducer.test.js
+++ b/src/behaviours/DragAndDrop/__tests__/reducer.test.js
@@ -164,6 +164,7 @@ describe('reducer', () => {
       expect(result.source).toEqual({
         bazz: 'buzz',
         isOver: false,
+        isOutOfBounds: false,
       });
     });
   });
@@ -177,15 +178,19 @@ describe('reducer', () => {
           source: null,
         });
 
+        const setValidMove = jest.fn();
         store.dispatch(actions.dragMove({
           bazz: 'buzz',
+          setValidMove,
         }));
 
+        expect(setValidMove.mock.calls.length).toBe(1);
         expect(store.getActions()).toEqual([
           {
             type: actionTypes.DRAG_MOVE,
             source: {
               bazz: 'buzz',
+              setValidMove,
             },
           },
         ]);
@@ -194,6 +199,7 @@ describe('reducer', () => {
       it('calls onDrag on targets', () => {
         const onDrag = jest.fn();
         const missedTargetOnDrag = jest.fn();
+        const setValidMove = jest.fn();
 
         const store = mockStore({
           targets: [
@@ -222,17 +228,21 @@ describe('reducer', () => {
           foo: 'bar',
           x: 50,
           y: 50,
+          setValidMove,
         }));
 
         expect(onDrag.mock.calls).toEqual([
           [{
             foo: 'bar',
             isOver: true,
+            isOutOfBounds: false,
             x: 50,
             y: 50,
+            setValidMove,
           }],
         ]);
 
+        expect(setValidMove.mock.calls.length).toBe(2);
         expect(missedTargetOnDrag.mock.calls).toEqual([]);
       });
     });
@@ -261,6 +271,7 @@ describe('reducer', () => {
         y: 50,
         z: 200,
         isOver: false,
+        isOutOfBounds: false,
       });
     });
   });
@@ -324,6 +335,7 @@ describe('reducer', () => {
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 50,
           y: 50,
         }],
@@ -337,12 +349,14 @@ describe('reducer', () => {
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 50,
           y: 50,
         }],
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 50,
           y: 50,
         }],
@@ -405,12 +419,14 @@ describe('reducer', () => {
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 50,
           y: 50,
         }],
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 50,
           y: 50,
         }],
@@ -426,6 +442,7 @@ describe('reducer', () => {
         [{
           foo: 'bar',
           isOver: true,
+          isOutOfBounds: false,
           x: 90,
           y: 90,
         }],

--- a/src/behaviours/DragAndDrop/__tests__/reducer.test.js
+++ b/src/behaviours/DragAndDrop/__tests__/reducer.test.js
@@ -20,6 +20,7 @@ describe('reducer', () => {
     expect(
       reducer(undefined, { action: null }),
     ).toEqual({
+      obstacles: [],
       targets: [],
       source: null,
     });
@@ -119,6 +120,7 @@ describe('reducer', () => {
     describe('dragMove', () => {
       it('triggers DRAG_MOVE', () => {
         const store = mockStore({
+          obstacles: [],
           targets: [],
           source: null,
         });
@@ -161,6 +163,7 @@ describe('reducer', () => {
             },
           ],
           source: null,
+          obstacles: [],
         });
 
         store.dispatch(actions.dragMove({
@@ -213,6 +216,7 @@ describe('reducer', () => {
   describe('DRAG_END', () => {
     it('triggers DRAG_MOVE', () => {
       const store = mockStore({
+        obstacles: [],
         targets: [],
         source: null,
       });
@@ -229,6 +233,7 @@ describe('reducer', () => {
     it('calls onDrop on targets', () => {
       const onDrop = jest.fn();
       const onDrag = jest.fn();
+      const onDragEnd = jest.fn();
       const missedTargetOnDrop = jest.fn();
 
       const store = mockStore({
@@ -241,6 +246,7 @@ describe('reducer', () => {
             accepts: () => true,
             onDrag,
             onDrop,
+            onDragEnd,
           },
           {
             x: 100,
@@ -249,9 +255,11 @@ describe('reducer', () => {
             height: 100,
             accepts: () => true,
             onDrop: missedTargetOnDrop,
+            onDragEnd,
           },
         ],
         source: null,
+        obstacles: [],
       });
 
       store.dispatch(actions.dragEnd({
@@ -272,6 +280,21 @@ describe('reducer', () => {
       expect(onDrag.mock.calls).toEqual([]);
 
       expect(missedTargetOnDrop.mock.calls).toEqual([]);
+
+      expect(onDragEnd.mock.calls).toEqual([
+        [{
+          foo: 'bar',
+          isOver: true,
+          x: 50,
+          y: 50,
+        }],
+        [{
+          foo: 'bar',
+          isOver: true,
+          x: 50,
+          y: 50,
+        }],
+      ]);
     });
 
     it('set source to null', () => {

--- a/src/behaviours/DragAndDrop/index.js
+++ b/src/behaviours/DragAndDrop/index.js
@@ -1,4 +1,5 @@
 export { default as DragSource } from './DragSource';
 export { default as DropTarget } from './DropTarget';
+export { default as DropObstacle } from './DropObstacle';
 export { default as MonitorDropTarget } from './MonitorDropTarget';
 export { default as MonitorDragSource } from './MonitorDragSource';

--- a/src/behaviours/DragAndDrop/reducer.js
+++ b/src/behaviours/DragAndDrop/reducer.js
@@ -32,14 +32,25 @@ const willAccept = (accepts, source) => {
   }
 };
 
+const markOutOfBounds = (source) => {
+  const isOutOfBounds = (
+    source.x > window.innerWidth ||
+    source.x < 0 ||
+    source.y > window.innerHeight ||
+    source.y < 0
+  );
+
+  return isOutOfBounds;
+};
+
 const markHitTarget = ({ target, source }) => {
   if (!source) { return { ...target, isOver: false, willAccept: false }; }
 
   const isOver = (
-    source.x > target.x &&
-    source.x < target.x + target.width &&
-    source.y > target.y &&
-    source.y < target.y + target.height
+    source.x >= target.x &&
+    source.x <= target.x + target.width &&
+    source.y >= target.y &&
+    source.y <= target.y + target.height
   );
 
   return {
@@ -59,6 +70,7 @@ const markHitSource = ({ targets, source }) =>
     return {
       ...s,
       isOver: filter(targets, 'isOver').length > 0,
+      isOutOfBounds: markOutOfBounds(s),
     };
   });
 
@@ -89,12 +101,16 @@ const triggerDrag = (state, source) => {
     },
   });
 
-  if (some(hits.obstacles, { isOver: true })) {
+  source.setValidMove(true);
+
+  if (some(hits.obstacles, { isOver: true }) || hits.source.isOutOfBounds) {
+    source.setValidMove(false);
     return;
   }
 
   filter(hits.targets, { isOver: true, willAccept: true })
     .forEach((target) => {
+      source.setValidMove(true);
       target.onDrag(hits.source);
     });
 };

--- a/src/behaviours/DragAndDrop/reducer.js
+++ b/src/behaviours/DragAndDrop/reducer.js
@@ -42,7 +42,11 @@ const markHitTarget = ({ target, source }) => {
     source.y < target.y + target.height
   );
 
-  return { ...target, isOver, willAccept: willAccept(target.accepts, source) };
+  return {
+    ...target,
+    isOver,
+    willAccept: target.accepts ? willAccept(target.accepts, source) : false,
+  };
 };
 
 const markHitTargets = ({ targets, source }) =>
@@ -85,7 +89,7 @@ const triggerDrag = (state, source) => {
     },
   });
 
-  if (some(hits.obstacles, { isOver: true, willAccept: true })) {
+  if (some(hits.obstacles, { isOver: true })) {
     return;
   }
 
@@ -109,7 +113,7 @@ const triggerDrop = (state, source) => {
       target.onDragEnd(hits.source);
     });
 
-  if (some(hits.obstacles, { isOver: true, willAccept: true })) {
+  if (some(hits.obstacles, { isOver: true })) {
     return;
   }
 

--- a/src/behaviours/DragAndDrop/reducer.js
+++ b/src/behaviours/DragAndDrop/reducer.js
@@ -95,6 +95,11 @@ const triggerDrop = (state, source) => {
     },
   });
 
+  filter(hits.targets, { willAccept: true })
+    .forEach((target) => {
+      target.onDragEnd(hits.source);
+    });
+
   filter(hits.targets, { isOver: true, willAccept: true })
     .forEach((target) => {
       target.onDrop(hits.source);

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,38 +1,52 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
+import { withHandlers, compose } from 'recompose';
 import PropTypes from 'prop-types';
 
 import { Icon } from '../ui/components';
 import { ProgressBar } from '../components';
+import { withBounds } from '../behaviours';
+import { DropObstacle } from '../behaviours/DragAndDrop';
 
-const Timeline = ({ onClickBack, onClickNext, percentProgress, toggleMenu }) => (
-  <div className="timeline" onClick={toggleMenu}>
-    <div className="timeline-nav timeline-nav--back">
-      <Icon
-        onClick={(e) => {
-          if (e) {
-            e.stopPropagation();
-            e.preventDefault();
-          }
-          onClickBack(e);
-        }}
-        name="chevron-up"
-      />
-    </div>
-    <ProgressBar percentProgress={percentProgress} />
-    <div
-      className="timeline-nav timeline-nav--next"
-      onClick={(e) => {
-        if (e) {
-          e.stopPropagation();
-          e.preventDefault();
-        }
-        onClickNext(e);
-      }}
-    >
-      <Icon name="chevron-down" />
-    </div>
-  </div>
-);
+class Timeline extends PureComponent {
+  render() {
+    const {
+      onClickBack,
+      onClickNext,
+      percentProgress,
+      toggleMenu,
+    } = this.props;
+
+    return (
+      <div className="timeline" onClick={toggleMenu}>
+        <div className="timeline-nav timeline-nav--back">
+          <Icon
+            onClick={(e) => {
+              if (e) {
+                e.stopPropagation();
+                e.preventDefault();
+              }
+              onClickBack(e);
+            }}
+            name="chevron-up"
+          />
+        </div>
+        <ProgressBar percentProgress={percentProgress} />
+        <div
+          className="timeline-nav timeline-nav--next"
+          onClick={(e) => {
+            if (e) {
+              e.stopPropagation();
+              e.preventDefault();
+            }
+            onClickNext(e);
+          }}
+        >
+          <Icon name="chevron-down" />
+        </div>
+      </div>
+    );
+  }
+}
 
 Timeline.propTypes = {
   onClickBack: PropTypes.func,
@@ -48,4 +62,10 @@ Timeline.defaultProps = {
   toggleMenu: () => {},
 };
 
-export default Timeline;
+export default compose(
+  withBounds,
+  withHandlers({
+    accepts: () => () => true,
+  }),
+  DropObstacle,
+)(Timeline);

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,10 +1,9 @@
 import React, { PureComponent } from 'react';
-import { withHandlers, compose } from 'recompose';
+import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 
 import { Icon } from '../ui/components';
 import { ProgressBar } from '../components';
-import { withBounds } from '../behaviours';
 import { DropObstacle } from '../behaviours/DragAndDrop';
 
 class Timeline extends PureComponent {
@@ -65,9 +64,5 @@ Timeline.defaultProps = {
 export { Timeline };
 
 export default compose(
-  withBounds,
-  withHandlers({
-    accepts: () => () => true,
-  }),
   DropObstacle,
 )(Timeline);

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -62,6 +62,8 @@ Timeline.defaultProps = {
   toggleMenu: () => {},
 };
 
+export { Timeline };
+
 export default compose(
   withBounds,
   withHandlers({

--- a/src/components/__tests__/Timeline.test.js
+++ b/src/components/__tests__/Timeline.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import Timeline from '../Timeline';
+import { Timeline } from '../Timeline';
 
 describe('Timeline component', () => {
   const toggleMock = jest.fn();

--- a/src/components/__tests__/__snapshots__/DropZone.test.js.snap
+++ b/src/components/__tests__/__snapshots__/DropZone.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     id="foo"
     meta={[Function]}
     onDrag={[Function]}
+    onDragEnd={[Function]}
     onDrop={[Function]}
     store={
       Object {
@@ -34,6 +35,7 @@ ShallowWrapper {
       "children": null,
       "id": "foo",
       "onDrag": [Function],
+      "onDragEnd": [Function],
       "onDrop": [Function],
       "store": Object {
         "dispatch": [Function],
@@ -56,6 +58,7 @@ ShallowWrapper {
         "children": null,
         "id": "foo",
         "onDrag": [Function],
+        "onDragEnd": [Function],
         "onDrop": [Function],
         "store": Object {
           "dispatch": [Function],

--- a/src/components/__tests__/__snapshots__/NodeList.test.js.snap
+++ b/src/components/__tests__/__snapshots__/NodeList.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     id="foo"
     meta={[Function]}
     onDrag={[Function]}
+    onDragEnd={[Function]}
     onDrop={[Function]}
     store={
       Object {
@@ -33,6 +34,7 @@ ShallowWrapper {
     "props": Object {
       "id": "foo",
       "onDrag": [Function],
+      "onDragEnd": [Function],
       "onDrop": [Function],
       "store": Object {
         "dispatch": [Function],
@@ -54,6 +56,7 @@ ShallowWrapper {
       "props": Object {
         "id": "foo",
         "onDrag": [Function],
+        "onDragEnd": [Function],
         "onDrop": [Function],
         "store": Object {
           "dispatch": [Function],

--- a/src/containers/ConcentricCircles/ButtonObstacle.js
+++ b/src/containers/ConcentricCircles/ButtonObstacle.js
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react';
+import { withHandlers, compose } from 'recompose';
+import PropTypes from 'prop-types';
+
+import { Button } from '../../ui/components';
+import { withBounds } from '../../behaviours';
+import { DropObstacle } from '../../behaviours/DragAndDrop';
+
+class ButtonObstacle extends PureComponent {
+  render() {
+    const {
+      label,
+      accepts,
+      ...rest
+    } = this.props;
+
+    return (
+      <Button
+        {...rest}
+      >
+        {label}
+      </Button>
+    );
+  }
+}
+
+ButtonObstacle.propTypes = {
+  accepts: PropTypes.func.isRequired,
+  label: PropTypes.string,
+};
+
+ButtonObstacle.defaultProps = {
+  label: '',
+};
+
+export default compose(
+  withBounds,
+  withHandlers({
+    accepts: () => () => true,
+  }),
+  DropObstacle,
+)(ButtonObstacle);

--- a/src/containers/ConcentricCircles/ButtonObstacle.js
+++ b/src/containers/ConcentricCircles/ButtonObstacle.js
@@ -1,16 +1,14 @@
 import React, { PureComponent } from 'react';
-import { withHandlers, compose } from 'recompose';
+import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 
 import { Button } from '../../ui/components';
-import { withBounds } from '../../behaviours';
 import { DropObstacle } from '../../behaviours/DragAndDrop';
 
 class ButtonObstacle extends PureComponent {
   render() {
     const {
       label,
-      accepts,
       ...rest
     } = this.props;
 
@@ -25,7 +23,6 @@ class ButtonObstacle extends PureComponent {
 }
 
 ButtonObstacle.propTypes = {
-  accepts: PropTypes.func.isRequired,
   label: PropTypes.string,
 };
 
@@ -34,9 +31,5 @@ ButtonObstacle.defaultProps = {
 };
 
 export default compose(
-  withBounds,
-  withHandlers({
-    accepts: () => () => true,
-  }),
   DropObstacle,
 )(ButtonObstacle);

--- a/src/containers/ConcentricCircles/ConcentricCircles.js
+++ b/src/containers/ConcentricCircles/ConcentricCircles.js
@@ -21,6 +21,7 @@ const ConcentricCircles = ({ stage, prompt }) => (
       prompt={prompt}
     />
     <NodeBucket
+      id="NODE_BUCKET"
       stage={stage}
       prompt={prompt}
     />

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -50,6 +50,14 @@ const dropHandlers = compose(
         },
       );
     },
+    onDragEnd: props => (item) => {
+      if (!has(item.meta[nodeAttributesProperty], props.layoutVariable)) { return; }
+
+      if (!item.isOver) {
+        // make sure to also re-render nodes that were updated on drag end
+        props.setDropCount(props.dropCount + 1);
+      }
+    },
   }),
 );
 

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -53,10 +53,8 @@ const dropHandlers = compose(
     onDragEnd: props => (item) => {
       if (!has(item.meta[nodeAttributesProperty], props.layoutVariable)) { return; }
 
-      if (!item.isOver) {
-        // make sure to also re-render nodes that were updated on drag end
-        props.setDropCount(props.dropCount + 1);
-      }
+      // make sure to also re-render nodes that were updated on drag end
+      props.setDropCount(props.dropCount + 1);
     },
   }),
 );

--- a/src/containers/ConcentricCircles/PromptObstacle.js
+++ b/src/containers/ConcentricCircles/PromptObstacle.js
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
-import { withHandlers, compose } from 'recompose';
+import { compose } from 'recompose';
 import PropTypes from 'prop-types';
 
 import { PromptSwiper } from '../../containers';
-import { withBounds } from '../../behaviours';
 import { DropObstacle } from '../../behaviours/DragAndDrop';
 
 class PromptObstacle extends PureComponent {
@@ -30,9 +29,5 @@ PromptObstacle.defaultProps = {
 };
 
 export default compose(
-  withBounds,
-  withHandlers({
-    accepts: () => () => true,
-  }),
   DropObstacle,
 )(PromptObstacle);

--- a/src/containers/ConcentricCircles/PromptObstacle.js
+++ b/src/containers/ConcentricCircles/PromptObstacle.js
@@ -1,0 +1,38 @@
+import React, { PureComponent } from 'react';
+import { withHandlers, compose } from 'recompose';
+import PropTypes from 'prop-types';
+
+import { PromptSwiper } from '../../containers';
+import { withBounds } from '../../behaviours';
+import { DropObstacle } from '../../behaviours/DragAndDrop';
+
+class PromptObstacle extends PureComponent {
+  render() {
+    const {
+      className,
+      ...rest
+    } = this.props;
+
+    return (
+      <div className={className}>
+        <PromptSwiper {...rest} />
+      </div>
+    );
+  }
+}
+
+PromptObstacle.propTypes = {
+  className: PropTypes.string,
+};
+
+PromptObstacle.defaultProps = {
+  className: '',
+};
+
+export default compose(
+  withBounds,
+  withHandlers({
+    accepts: () => () => true,
+  }),
+  DropObstacle,
+)(PromptObstacle);

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
@@ -48,7 +48,7 @@ ShallowWrapper {
           }
           stage={Object {}}
         />,
-        <Component
+        <DropObstacle
           id="NODE_BUCKET"
           prompt={
             Object {
@@ -147,7 +147,7 @@ ShallowWrapper {
             }
             stage={Object {}}
           />,
-          <Component
+          <DropObstacle
             id="NODE_BUCKET"
             prompt={
               Object {

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
@@ -48,7 +48,8 @@ ShallowWrapper {
           }
           stage={Object {}}
         />,
-        <Connect(NodeBucket)
+        <Component
+          id="NODE_BUCKET"
           prompt={
             Object {
               "sociogram": Object {
@@ -102,6 +103,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "id": "NODE_BUCKET",
           "prompt": Object {
             "sociogram": Object {
               "background": Object {},
@@ -145,7 +147,8 @@ ShallowWrapper {
             }
             stage={Object {}}
           />,
-          <Connect(NodeBucket)
+          <Component
+            id="NODE_BUCKET"
             prompt={
               Object {
                 "sociogram": Object {
@@ -199,6 +202,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "id": "NODE_BUCKET",
             "prompt": Object {
               "sociogram": Object {
                 "background": Object {},

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,12 +1,37 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withHandlers, compose } from 'recompose';
 import PropTypes from 'prop-types';
+
 import { Button } from '../../ui/components';
 import withPrompt from '../../behaviours/withPrompt';
+import { withBounds } from '../../behaviours';
+import { DropObstacle } from '../../behaviours/DragAndDrop';
 import { PromptSwiper, ConcentricCircles } from '../../containers/';
 import { actionCreators as resetActions } from '../../ducks/modules/reset';
+
+class PromptSwipable extends PureComponent {
+  render() {
+    return (
+      <div className="sociogram-interface__prompts" component="sociogram-interface__prompts">
+        <PromptSwiper {...this.props} />
+      </div>
+    );
+  }
+}
+
+PromptSwipable.propTypes = {
+  prompt: PropTypes.object.isRequired,
+};
+
+const PromptObstacle = compose(
+  withBounds,
+  withHandlers({
+    accepts: () => () => true,
+  }),
+  DropObstacle,
+)(PromptSwipable);
 
 /**
   * Sociogram Interface
@@ -20,16 +45,15 @@ const Sociogram = ({
   resetInterface,
 }) => (
   <div className="sociogram-interface">
-    <div className="sociogram-interface__prompts">
-      <PromptSwiper
-        forward={promptForward}
-        backward={promptBackward}
-        prompts={stage.prompts}
-        prompt={prompt}
-        floating
-        minimizable
-      />
-    </div>
+    <PromptObstacle
+      id="PROMPTS_OBSTACLE"
+      forward={promptForward}
+      backward={promptBackward}
+      prompts={stage.prompts}
+      prompt={prompt}
+      floating
+      minimizable
+    />
     <div className="sociogram-interface__sociogram">
       <ConcentricCircles
         stage={stage}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,37 +1,14 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withHandlers, compose } from 'recompose';
 import PropTypes from 'prop-types';
 
-import { Button } from '../../ui/components';
 import withPrompt from '../../behaviours/withPrompt';
-import { withBounds } from '../../behaviours';
-import { DropObstacle } from '../../behaviours/DragAndDrop';
-import { PromptSwiper, ConcentricCircles } from '../../containers/';
+import { ConcentricCircles } from '../../containers/';
+import PromptObstacle from '../../containers/ConcentricCircles/PromptObstacle';
+import ButtonObstacle from '../../containers/ConcentricCircles/ButtonObstacle';
 import { actionCreators as resetActions } from '../../ducks/modules/reset';
-
-class PromptSwipable extends PureComponent {
-  render() {
-    return (
-      <div className="sociogram-interface__prompts" component="sociogram-interface__prompts">
-        <PromptSwiper {...this.props} />
-      </div>
-    );
-  }
-}
-
-PromptSwipable.propTypes = {
-  prompt: PropTypes.object.isRequired,
-};
-
-const PromptObstacle = compose(
-  withBounds,
-  withHandlers({
-    accepts: () => () => true,
-  }),
-  DropObstacle,
-)(PromptSwipable);
 
 /**
   * Sociogram Interface
@@ -47,12 +24,14 @@ const Sociogram = ({
   <div className="sociogram-interface">
     <PromptObstacle
       id="PROMPTS_OBSTACLE"
+      className="sociogram-interface__prompts"
       forward={promptForward}
       backward={promptBackward}
       prompts={stage.prompts}
       prompt={prompt}
       floating
       minimizable
+      watchProps={['prompt']}
     />
     <div className="sociogram-interface__sociogram">
       <ConcentricCircles
@@ -62,12 +41,12 @@ const Sociogram = ({
       />
     </div>
     <div style={{ position: 'absolute', right: '50px', bottom: '50px' }}>
-      <Button
+      <ButtonObstacle
+        id="RESET_BUTTON_OBSTACLE"
+        label="RESET"
         size="small"
         onClick={() => { resetInterface(stage.prompts); }}
-      >
-        Reset
-      </Button>
+      />
     </div>
   </div>
 );

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -31,7 +31,6 @@ const Sociogram = ({
       prompt={prompt}
       floating
       minimizable
-      watchProps={['prompt']}
     />
     <div className="sociogram-interface__sociogram">
       <ConcentricCircles

--- a/src/containers/NodeBucket.js
+++ b/src/containers/NodeBucket.js
@@ -1,11 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
+import { compose, withHandlers } from 'recompose';
 
 import Node from './Node';
 import { makeGetNextUnplacedNode, makeGetSociogramOptions } from '../selectors/sociogram';
-import { DragSource } from '../behaviours/DragAndDrop';
+import { DragSource, DropObstacle } from '../behaviours/DragAndDrop';
+import { withBounds } from '../behaviours';
+
 import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
 import { nodePrimaryKeyProperty } from '../ducks/modules/network';
 
@@ -28,7 +30,7 @@ class NodeBucket extends PureComponent {
       node,
     } = this.props;
 
-    if (!allowPositioning || !node) { return null; }
+    if (!allowPositioning || !node) { return (<div />); }
 
     return (
       <div className="node-bucket">
@@ -60,5 +62,10 @@ function makeMapStateToProps() {
 export { NodeBucket };
 
 export default compose(
+  withBounds,
+  withHandlers({
+    accepts: () => () => true,
+  }),
+  DropObstacle,
   connect(makeMapStateToProps),
 )(NodeBucket);

--- a/src/containers/NodeBucket.js
+++ b/src/containers/NodeBucket.js
@@ -1,12 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { compose, withHandlers } from 'recompose';
+import { compose } from 'recompose';
 
 import Node from './Node';
 import { makeGetNextUnplacedNode, makeGetSociogramOptions } from '../selectors/sociogram';
 import { DragSource, DropObstacle } from '../behaviours/DragAndDrop';
-import { withBounds } from '../behaviours';
 
 import { NO_SCROLL } from '../behaviours/DragAndDrop/DragManager';
 import { nodePrimaryKeyProperty } from '../ducks/modules/network';
@@ -62,10 +61,6 @@ function makeMapStateToProps() {
 export { NodeBucket };
 
 export default compose(
-  withBounds,
-  withHandlers({
-    accepts: () => () => true,
-  }),
   DropObstacle,
   connect(makeMapStateToProps),
 )(NodeBucket);

--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -55,6 +55,7 @@ class Protocol extends Component {
     return (
       <div className="protocol">
         <Timeline
+          id="TIMELINE"
           onClickBack={this.onClickBack}
           onClickNext={this.onClickNext}
           percentProgress={percentProgress}

--- a/src/styles/containers/_sociogram-interface.scss
+++ b/src/styles/containers/_sociogram-interface.scss
@@ -1,7 +1,4 @@
 .sociogram-interface {
-  --vertical-margin: var(--interface-right-margin);
-  @include interface-centering;
-
   align-items: center;
   display: flex;
   flex: 1 1 auto;
@@ -12,13 +9,11 @@
   &__sociogram {
     flex: 1 1 auto;
     width: 100%;
-    height: calc(100% - var(--vertical-margin));
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
-    margin-bottom: calc(var(--vertical-margin) / 2);
-    margin-top: calc(var(--vertical-margin) / 2);
   }
 
   &__prompts {


### PR DESCRIPTION
Resolves #371 and #469. This adds the notion of a `DropObstacle`. Currently, the "reset" button, prompt, timeline, and node bucket on Sociogram are obstacles, meaning nothing can be dropped on those components. This also makes Sociogram full screen again. The off-screen node drops in #469 were resolved by adding a render on dragEnd.

Feedback welcome as always.