### PR TITLE
Add null check for apiInfo

### DIFF
--- a/src/utils/__tests__/serverAddressing.test.js
+++ b/src/utils/__tests__/serverAddressing.test.js
@@ -10,6 +10,13 @@ describe('the serverAddressing util', () => {
     expect(augmented.pairingServiceUrl).toMatch('127.0.0.1:123');
   });
 
+  it('contains a null pairingServiceUrl if none can be created', () => {
+    const linkLocal = 'fe80::';
+    const unusableService = { port: 123, addresses: [linkLocal] };
+    const augmented = util.addPairingUrlToService(unusableService);
+    expect(augmented.pairingServiceUrl).toBe(null);
+  });
+
   describe('port validation', () => {
     it('validates 9999', () => expect(util.isValidPort(9999)).toBe(true));
     it('validates a string port', () => expect(util.isValidPort('9999')).toBe(true));

--- a/src/utils/serverAddressing.js
+++ b/src/utils/serverAddressing.js
@@ -84,7 +84,7 @@ const addPairingUrlToService = (service) => {
     apiInfo = validApiUrl(addr, service.port);
     return !!apiInfo;
   });
-  apiService.pairingServiceUrl = apiInfo.toString();
+  apiService.pairingServiceUrl = apiInfo && apiInfo.toString();
   return apiService;
 };
 


### PR DESCRIPTION
MDNS may send back announcements containing only information that we consider to be invalid.

This doesn't mean discovery has failed; additional (or previous) announcements may contain the needed information. Returning null here allows discovery to proceed.