### PR TITLE
Convert lint errors to warnings on dev server

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -130,7 +130,7 @@ module.exports = {
             options: {
               formatter: eslintFormatter,
               eslintPath: require.resolve('eslint'),
-
+              emitWarning: true,
             },
             loader: require.resolve('eslint-loader'),
           },


### PR DESCRIPTION
This changes eslint errors to warnings on the dev server, so that the webview logs style violations to the console instead of stopping the show with the error overlay. Errors are still treated as errors everywhere else (build log, CI, IDE & local linting).

@wwqrd added this to Architect & I copied it in Server. It makes development easier while keeping the strict lint settings.
