### PR TITLE
Fix factory asset loading

### DIFF
--- a/config/nc-dev-utils.js
+++ b/config/nc-dev-utils.js
@@ -54,7 +54,7 @@ const devServerContentBase = () => {
   let cordovaBase;
   switch (platform) {
     case 'android':
-      cordovaBase = path.resolve(paths.cordovaPlatforms, platform, 'platform_www');
+      cordovaBase = path.resolve(paths.cordovaPlatforms, platform, 'app', 'src', 'main', 'assets', 'www');
       break;
     case 'ios':
       cordovaBase = path.resolve(paths.cordovaPlatforms, platform, 'www');

--- a/src/behaviours/injectAssetUrl.js
+++ b/src/behaviours/injectAssetUrl.js
@@ -5,7 +5,7 @@ import { assetUrl } from '../utils/protocol';
 
 // curry asset fetcher with protocol path from state
 const mapStateToProps = state => ({
-  getAssetUrl: url => assetUrl(state.protocol.path, url),
+  getAssetUrl: url => assetUrl(state.protocol.path, url, state.protocol.type),
 });
 
 const injectAssetUrl = compose(

--- a/src/utils/protocol/__tests__/assetUrl.test.js
+++ b/src/utils/protocol/__tests__/assetUrl.test.js
@@ -4,14 +4,28 @@ import environments from '../../environments';
 import { getEnvironment } from '../../Environment';
 import assetUrl from '../assetUrl';
 
+jest.mock('../../filesystem');
+
 describe('assetUrl', () => {
+  describe('Cordova', () => {
+    beforeAll(() => {
+      getEnvironment.mockReturnValue(environments.CORDOVA);
+    });
+
+    it('Generates a relative asset path for a factory protocol', async () => {
+      await expect(assetUrl('foo.canvas', 'bar.mp3', 'factory')).resolves.toEqual('protocols/foo.canvas/assets/bar.mp3');
+    });
+
+    it.skip('Generates a usable URL for a downloaded protocol'); // TBD how to handle [#681]
+  });
+
   describe('Electron', () => {
     beforeAll(() => {
       getEnvironment.mockReturnValue(environments.ELECTRON);
     });
 
-    it('Generates an asset URL for the protocol', () => {
-      expect(assetUrl('foo.canvas', 'bar.mp3')).resolves.toEqual('asset://foo.canvas/assets/bar.mp3');
+    it('Generates an asset URL for the protocol', async () => {
+      await expect(assetUrl('foo.canvas', 'bar.mp3')).resolves.toEqual('asset://foo.canvas/assets/bar.mp3');
     });
 
     describe('with missing parameters', () => {

--- a/src/utils/protocol/assetUrl.js
+++ b/src/utils/protocol/assetUrl.js
@@ -2,7 +2,6 @@ import environments from '../environments';
 import inEnvironment from '../Environment';
 import { readFileAsDataUrl } from '../filesystem';
 import protocolPath from './protocolPath';
-import factoryProtocolPath from './factoryProtocolPath';
 
 const isRequired = (param) => { throw new Error(`${param} is required`); };
 
@@ -11,6 +10,7 @@ const assetUrl = (environment) => {
     return (
       protocolName = isRequired('protocolName'),
       assetPath = isRequired('assetPath'),
+      /* protocolType, */
     ) =>
       Promise.resolve(`asset://${protocolName}/assets/${assetPath}`);
   }
@@ -19,11 +19,15 @@ const assetUrl = (environment) => {
     return (
       protocolName = isRequired('protocolName'),
       assetPath = isRequired('assetPath'),
+      protocolType,
     ) => {
-      const factoryFilename = factoryProtocolPath(protocolName, `assets/${assetPath}`);
+      if (protocolType === 'factory') {
+        return Promise.resolve(`protocols/${protocolName}/assets/${assetPath}`);
+      }
+
+      // FIXME: this will fail on large assets [#681]
       const filename = protocolPath(protocolName, `assets/${assetPath}`);
-      return readFileAsDataUrl(factoryFilename)
-        .catch(() => readFileAsDataUrl(filename));
+      return readFileAsDataUrl(filename);
     };
   }
 


### PR DESCRIPTION
This is a short-term/partial fix for #681: the app will no longer crash or reload when dealing with assets from factory protocols. Specifically, the video in the development protocol should no longer cause issues; however, the change affects all assets including images & audio.

Downloaded (user-provided) protocols are still an issue; the difference is the relative location of the assets to the app source. Discussion in #681 will determine the best path forward.

I tested both production and dev builds on an iPad Air (12.0)& Nexus 5x (8.1).
