### PR TITLE
Fix error checking for certain protocol format issues

### DIFF
--- a/src/containers/NodePanels.js
+++ b/src/containers/NodePanels.js
@@ -119,13 +119,17 @@ class NodePanels extends PureComponent {
 const getNodesForDataSource = ({ nodes, existingNodes, externalData, dataSource }) => (
   dataSource === 'existing' ?
     existingNodes :
-    differenceBy(externalData[dataSource].nodes, nodes, nodePrimaryKeyProperty)
+    differenceBy(
+      externalData[dataSource] && externalData[dataSource].nodes,
+      nodes,
+      nodePrimaryKeyProperty,
+    )
 );
 
 const getOriginNodeIds = ({ existingNodes, externalData, dataSource }) => (
   dataSource === 'existing' ?
     map(existingNodes, nodePrimaryKeyProperty) :
-    map(externalData[dataSource].nodes, nodePrimaryKeyProperty)
+    map(externalData[dataSource] && externalData[dataSource].nodes, nodePrimaryKeyProperty)
 );
 
 function makeMapStateToProps() {

--- a/src/selectors/__tests__/sociogram.test.js
+++ b/src/selectors/__tests__/sociogram.test.js
@@ -4,6 +4,9 @@ import { makeGetSociogramOptions } from '../sociogram';
 
 const mockPrompt = {
   layout: {},
+  subject: {
+    type: 'foo',
+  },
 };
 
 const mockProps = {
@@ -11,6 +14,9 @@ const mockProps = {
 };
 
 const mockState = {
+  protocol: {
+    variableRegistry: { node: { foo: {} } },
+  },
 };
 
 describe('sociogram selector', () => {

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -12,12 +12,13 @@ const propForm = (_, { entity, type }) => ({ entity, type });
 
 const rehydrateField = ({ registry, entity, type, field }) => {
   if (!field.variable) { return field; }
+  const entityVars = registry[entity][type] ? registry[entity][type].variables[field.variable] : {};
   const returnObject = {
     name: field.variable,
     component: field.component,
     fieldLabel: field.label,
     value: field.value,
-    ...registry[entity][type].variables[field.variable],
+    ...entityVars,
   };
 
   return returnObject;

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -78,7 +78,6 @@ export const makeGetSubject = () =>
   );
 
 const nodeTypeIsDefined = (variableRegistry, nodeType) =>
-  variableRegistry &&
   variableRegistry.node &&
   !!variableRegistry.node[nodeType];
 
@@ -96,7 +95,7 @@ export const makeGetNodeDisplayVariable = () => createDeepEqualSelector(
   protocolRegistry,
   makeGetNodeType(),
   (variableRegistry, nodeType) => {
-    const nodeInfo = variableRegistry && variableRegistry.node;
+    const nodeInfo = variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].displayVariable;
   },
 );
@@ -105,7 +104,7 @@ export const makeGetNodeVariables = () => createDeepEqualSelector(
   protocolRegistry,
   makeGetNodeType(),
   (variableRegistry, nodeType) => {
-    const nodeInfo = variableRegistry && variableRegistry.node;
+    const nodeInfo = variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].variables;
   },
 );
@@ -128,8 +127,7 @@ export const makeGetOrdinalValues = () =>
 export const getNodeLabelFunction = createDeepEqualSelector(
   protocolRegistry,
   variableRegistry => (node) => {
-    // Get the node entity section of the variable registry
-    const nodeInfo = variableRegistry && variableRegistry.node;
+    const nodeInfo = variableRegistry.node;
 
     // Get the display variable by looking up the node type in the variable registry
     const displayVariable = nodeInfo && node && node.type && nodeInfo[node.type] &&

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from 'reselect';
 import { findKey, filter, has, isMatch, reject } from 'lodash';
-import { createDeepEqualSelector } from './utils';
+import { assert, createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
 import { getCurrentSession } from './session';
 import { getNodeAttributes, nodeAttributesProperty, asWorkerAgentNode } from '../ducks/modules/network';
@@ -77,9 +77,19 @@ export const makeGetSubject = () =>
     },
   );
 
+const nodeTypeIsDefined = (variableRegistry, nodeType) =>
+  variableRegistry &&
+  variableRegistry.node &&
+  !!variableRegistry.node[nodeType];
+
 export const makeGetNodeType = () => (createSelector(
+  protocolRegistry,
   makeGetSubject(),
-  subject => subject && subject.type,
+  (variableRegistry, subject) => {
+    assert(subject, 'The "subject" property is not defined for this prompt');
+    assert(nodeTypeIsDefined(variableRegistry, subject.type), `Node type "${subject.type}" is not defined in the registry`);
+    return subject && subject.type;
+  },
 ));
 
 export const makeGetNodeDisplayVariable = () => createDeepEqualSelector(
@@ -96,7 +106,7 @@ export const makeGetNodeVariables = () => createDeepEqualSelector(
   makeGetNodeType(),
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry && variableRegistry.node;
-    return nodeInfo && nodeInfo[nodeType].variables;
+    return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].variables;
   },
 );
 

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -157,7 +157,6 @@ const edgesOfTypes = (edges, types) =>
   )(edges);
 
 const edgeTypeIsDefined = (variableRegistry, edgeType) =>
-  variableRegistry &&
   variableRegistry.edge &&
   !!variableRegistry.edge[edgeType];
 

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -19,9 +19,10 @@ import {
   makeGetNodeDisplayVariable,
   makeNetworkNodesForType,
 } from './interface';
-import { createDeepEqualSelector } from './utils';
+import { assert, createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
 import { nodePrimaryKeyProperty, getNodeAttributes, nodeAttributesProperty } from '../ducks/modules/network';
+import { protocolRegistry } from './protocol';
 
 // Selectors that are specific to the name generator
 
@@ -155,15 +156,25 @@ const edgesOfTypes = (edges, types) =>
     selectedEdges => flatten(selectedEdges),
   )(edges);
 
+const edgeTypeIsDefined = (variableRegistry, edgeType) =>
+  variableRegistry &&
+  variableRegistry.edge &&
+  !!variableRegistry.edge[edgeType];
+
 export const makeDisplayEdgesForPrompt = () => {
   const networkNodesForSubject = makeNetworkNodesForType();
 
   return createSelector(
+    protocolRegistry,
     networkNodesForSubject,
     networkEdges,
     makeGetEdgeOptions(),
     getLayoutOptions,
-    (nodes, edges, edgeOptions, { layoutVariable }) => {
+    (variableRegistry, nodes, edges, edgeOptions, { layoutVariable }) => {
+      const edgeType = edgeOptions.createEdge;
+      if (edgeOptions.canCreateEdge) {
+        assert(edgeTypeIsDefined(variableRegistry, edgeType), `Edge type "${edgeType}" is not defined in the registry`);
+      }
       const selectedEdges = edgesOfTypes(edges, edgeOptions.displayEdges);
       return edgesToCoords(
         selectedEdges,

--- a/src/selectors/utils.js
+++ b/src/selectors/utils.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import { isEqual } from 'lodash';
 
@@ -8,3 +6,11 @@ export const createDeepEqualSelector = createSelectorCreator(
   defaultMemoize,
   isEqual,
 );
+
+// If condition is not met, throws. When thrown from a selector, the error
+// will be handled by stage boundary and displayed to the user.
+export const assert = (condition, errorMessage) => {
+  if (!condition) {
+    throw new Error(errorMessage);
+  }
+};

--- a/src/utils/protocol/__tests__/loadProtocol.test.js
+++ b/src/utils/protocol/__tests__/loadProtocol.test.js
@@ -9,11 +9,13 @@ import { readFile } from '../../filesystem';
 jest.mock('../../filesystem');
 jest.mock('../protocolPath');
 
+const validProtocol = { foo: 'bar', stages: [{}], variableRegistry: {} };
+
 describe('loadProtocol', () => {
   describe('Electron', () => {
     let mockProtocol;
     beforeAll(() => {
-      mockProtocol = { foo: 'bar', stages: [{}] };
+      mockProtocol = validProtocol;
       getEnvironment.mockReturnValue(environments.ELECTRON);
     });
 
@@ -29,7 +31,17 @@ describe('loadProtocol', () => {
 
     describe('when protocol has no stages', () => {
       beforeAll(() => {
-        mockProtocol = { foo: 'bar' };
+        mockProtocol = { ...validProtocol, stages: undefined };
+      });
+
+      it('rejects loading', async () => {
+        await expect(loadProtocol('bazz.protocol')).rejects.toMatchObject({ message: 'Invalid protocol' });
+      });
+    });
+
+    describe('when protocol has no variableRegistry', () => {
+      beforeAll(() => {
+        mockProtocol = { ...validProtocol, variableRegistry: undefined };
       });
 
       it('rejects loading', async () => {

--- a/src/utils/protocol/__tests__/loadProtocol.test.js
+++ b/src/utils/protocol/__tests__/loadProtocol.test.js
@@ -11,18 +11,30 @@ jest.mock('../protocolPath');
 
 describe('loadProtocol', () => {
   describe('Electron', () => {
+    let mockProtocol;
     beforeAll(() => {
+      mockProtocol = { foo: 'bar', stages: [{}] };
       getEnvironment.mockReturnValue(environments.ELECTRON);
-      readFile.mockReturnValue(Promise.resolve('{ "foo": "bar" }'));
     });
 
-    it('returns the parsed protocol object', () => {
-      expect(loadProtocol('bazz.protocol')).resolves.toEqual({
-        foo: 'bar',
-      }); // TODO: This should return in order to work...
+    beforeEach(() => {
+      readFile.mockReturnValue(Promise.resolve(JSON.stringify(mockProtocol)));
+    });
 
+    it('returns the parsed protocol object', async () => {
+      await expect(loadProtocol('bazz.protocol')).resolves.toEqual(mockProtocol);
       expect(protocolPath.mock.calls[0]).toEqual(['bazz.protocol', 'protocol.json']);
       expect(readFile.mock.calls[0]).toEqual(['tmp/mock/path/protocols/bazz.protocol/protocol.json']);
+    });
+
+    describe('when protocol has no stages', () => {
+      beforeAll(() => {
+        mockProtocol = { foo: 'bar' };
+      });
+
+      it('rejects loading', async () => {
+        await expect(loadProtocol('bazz.protocol')).rejects.toMatchObject({ message: 'Invalid protocol' });
+      });
     });
   });
 });

--- a/src/utils/protocol/loadProtocol.js
+++ b/src/utils/protocol/loadProtocol.js
@@ -14,6 +14,11 @@ const verifyProtocol = (protocol) => {
     noStagesError.friendlyMessage = 'Invalid protocol: no stages defined';
     throw noStagesError;
   }
+  if (!protocol.variableRegistry) {
+    const noRegistryError = new Error('Invalid protocol');
+    noRegistryError.friendlyMessage = 'Invalid protocol: missing variableRegistry';
+    throw noRegistryError;
+  }
   return protocol;
 };
 

--- a/src/utils/protocol/loadProtocol.js
+++ b/src/utils/protocol/loadProtocol.js
@@ -6,11 +6,23 @@ import friendlyErrorMessage from '../../utils/friendlyErrorMessage';
 
 const openError = friendlyErrorMessage("We couldn't open that Network Canvas protocol. Check the format, and try again.");
 
+// Basic validation on protocol format;
+// any error will halt loading and display a message to the user.
+const verifyProtocol = (protocol) => {
+  if (!protocol.stages || !protocol.stages.length) {
+    const noStagesError = new Error('Invalid protocol');
+    noStagesError.friendlyMessage = 'Invalid protocol: no stages defined';
+    throw noStagesError;
+  }
+  return protocol;
+};
+
 const loadProtocol = (environment) => {
   if (environment !== environments.WEB) {
     return protocolName =>
       readFile(protocolPath(protocolName, 'protocol.json'))
         .then(data => JSON.parse(data))
+        .then(verifyProtocol)
         .catch(openError);
   }
 


### PR DESCRIPTION
Fixes #673. Fixes #674. Fixes #675.

This adds two points for validation to address the issues above.

- Adds a very basic validation step when loading a protocol. If no stages are defined, or the variableRegistry key is missing, loading will fail and the error dialog is displayed.
  - This can be replaced by [schema validation](https://github.com/codaco/Network-Canvas/pull/644) in the future
- Adds `assert` to selectors. Failures here manifest as a message on the ErrorBoundary. This is currently applied in the following cases:
  - If an interface requiring a node (subject) can't find the node definition in the registry
  - If an interface [sociogram] requiring an edge can't find the edge definition in the registry

Two other null checks were added to match the 'lenient-input' approach elsewhere in favor of explicit checks.

