### PR TITLE
Improve server error message

### DIFF
--- a/src/components/Setup/ServerUnavailable.js
+++ b/src/components/Setup/ServerUnavailable.js
@@ -4,7 +4,7 @@ import { Button } from '../../ui/components/';
 
 const ServerUnavailable = ({ errorMessage, handleRetry }) => (
   <div className="server-unavailable">
-    <h1>Currently unavailable</h1>
+    <h1>Server unavailable</h1>
     <p>{errorMessage}</p>
     <Button
       size="small"

--- a/src/containers/Setup/ServerProtocols.js
+++ b/src/containers/Setup/ServerProtocols.js
@@ -64,7 +64,7 @@ class ServerProtocols extends Component {
     if (error) {
       content = (
         <ServerUnavailable
-          errorMessage={error.message}
+          errorMessage={error.friendlyMessage || error.message}
           handleRetry={this.handleRetry}
         />
       );


### PR DESCRIPTION
This clarifies the "unavailable server" error messaging.

- Use "friendlyMessage" if defined
- Replace title text since error may be "permanent" (e.g., Unauthorized)