### PR TITLE
Remove problematic logging config

### DIFF
--- a/public/components/log.js
+++ b/public/components/log.js
@@ -1,9 +1,4 @@
-const electron = require('electron');
-const path = require('path');
 const log = require('electron-log');
-const fs = require('fs');
-
-const userDataPath = (electron.app || electron.remote.app).getPath('userData')
 
 // Same as for console transport
 log.transports.file.level = 'log';
@@ -17,8 +12,5 @@ log.transports.file.maxSize = 5 * 1024 * 1024;
 // you can find more information at
 // https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options
 log.transports.file.streamConfig = { flags: 'w' };
-
-// set existed file stream
-log.transports.file.stream = fs.createWriteStream(path.join(userDataPath, 'debug.log'));
 
 module.exports = log;


### PR DESCRIPTION
Nothing is yet requiring this module, but if something does globally, we should not rely on the electron path existing. See https://github.com/codaco/Architect/pull/244.