### PR TITLE
Fix/reset linking state

### DIFF
--- a/src/containers/ConcentricCircles/ConcentricCircles.js
+++ b/src/containers/ConcentricCircles/ConcentricCircles.js
@@ -5,7 +5,7 @@ import NodeLayout from './NodeLayout';
 import EdgeLayout from './EdgeLayout';
 import Background from './Background';
 
-const ConcentricCircles = ({ stage, prompt }) => (
+const ConcentricCircles = React.forwardRef(({ stage, prompt }, ref) => (
   <div className="sociogram">
     <Background stage={stage} prompt={prompt} />
     {
@@ -19,6 +19,7 @@ const ConcentricCircles = ({ stage, prompt }) => (
       id="NODE_LAYOUT"
       stage={stage}
       prompt={prompt}
+      ref={ref}
     />
     <NodeBucket
       id="NODE_BUCKET"
@@ -26,7 +27,7 @@ const ConcentricCircles = ({ stage, prompt }) => (
       prompt={prompt}
     />
   </div>
-);
+));
 
 ConcentricCircles.propTypes = {
   stage: PropTypes.object.isRequired,

--- a/src/containers/ConcentricCircles/ConcentricCircles.js
+++ b/src/containers/ConcentricCircles/ConcentricCircles.js
@@ -1,33 +1,56 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { NodeBucket } from '../../containers';
 import NodeLayout from './NodeLayout';
 import EdgeLayout from './EdgeLayout';
 import Background from './Background';
 
-const ConcentricCircles = React.forwardRef(({ stage, prompt }, ref) => (
-  <div className="sociogram">
-    <Background stage={stage} prompt={prompt} />
-    {
-      prompt.edges &&
-      <EdgeLayout
-        stage={stage}
-        prompt={prompt}
-      />
-    }
-    <NodeLayout
-      id="NODE_LAYOUT"
-      stage={stage}
-      prompt={prompt}
-      ref={ref}
-    />
-    <NodeBucket
-      id="NODE_BUCKET"
-      stage={stage}
-      prompt={prompt}
-    />
-  </div>
-));
+class ConcentricCircles extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      connectFrom: null,
+    };
+  }
+
+  updateLinkFrom = (id) => {
+    this.setState({ connectFrom: id });
+  }
+
+  resetLinking = () => {
+    this.setState({ connectFrom: null });
+  }
+
+  render() {
+    const { stage, prompt } = this.props;
+
+    return (
+      <div className="sociogram">
+        <Background stage={stage} prompt={prompt} />
+        {
+          prompt.edges &&
+          <EdgeLayout
+            stage={stage}
+            prompt={prompt}
+          />
+        }
+        <NodeLayout
+          id="NODE_LAYOUT"
+          stage={stage}
+          prompt={prompt}
+          connectFrom={this.state.connectFrom}
+          updateLinkFrom={this.updateLinkFrom}
+        />
+        <NodeBucket
+          id="NODE_BUCKET"
+          stage={stage}
+          prompt={prompt}
+        />
+      </div>
+    );
+  }
+}
 
 ConcentricCircles.propTypes = {
   stage: PropTypes.object.isRequired,

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -144,6 +144,10 @@ class NodeLayout extends Component {
       node[nodePrimaryKeyProperty] === this.state.connectFrom;
   }
 
+  resetLinking() {
+    this.setState({ connectFrom: null });
+  }
+
   render() {
     const {
       nodes,
@@ -201,7 +205,7 @@ function mapDispatchToProps(dispatch) {
 export { NodeLayout };
 
 export default compose(
-  connect(makeMapStateToProps, mapDispatchToProps),
+  connect(makeMapStateToProps, mapDispatchToProps, null, { withRef: true }),
   withBounds,
   dropHandlers,
   DropTarget,

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -64,22 +64,16 @@ class NodeLayout extends Component {
     nodes: PropTypes.array,
     toggleEdge: PropTypes.func.isRequired,
     toggleHighlight: PropTypes.func.isRequired,
+    connectFrom: PropTypes.string,
     ...sociogramOptionsProps,
   };
 
   static defaultProps = {
+    connectFrom: null,
     nodes: [],
     allowPositioning: true,
     allowSelect: true,
   };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      connectFrom: null,
-    };
-  }
 
   shouldComponentUpdate(nextProps) {
     if (nodesLengthChanged(nextProps, this.props)) { return true; }
@@ -103,13 +97,12 @@ class NodeLayout extends Component {
   }
 
   connectNode(nodeId) {
-    const { createEdge, canCreateEdge } = this.props;
-    const { connectFrom } = this.state;
+    const { createEdge, canCreateEdge, connectFrom } = this.props;
 
     if (!canCreateEdge) { return; }
 
     if (!connectFrom) {
-      this.setState({ connectFrom: nodeId });
+      this.props.updateLinkFrom(nodeId);
       return;
     }
 
@@ -121,7 +114,7 @@ class NodeLayout extends Component {
       });
     }
 
-    this.setState({ connectFrom: null });
+    this.props.updateLinkFrom(null);
   }
 
   toggleHighlightAttributes(nodeId) {
@@ -141,11 +134,7 @@ class NodeLayout extends Component {
   isLinking(node) {
     return this.props.allowSelect &&
       this.props.canCreateEdge &&
-      node[nodePrimaryKeyProperty] === this.state.connectFrom;
-  }
-
-  resetLinking() {
-    this.setState({ connectFrom: null });
+      node[nodePrimaryKeyProperty] === this.props.connectFrom;
   }
 
   render() {
@@ -205,7 +194,7 @@ function mapDispatchToProps(dispatch) {
 export { NodeLayout };
 
 export default compose(
-  connect(makeMapStateToProps, mapDispatchToProps, null, { withRef: true }),
+  connect(makeMapStateToProps, mapDispatchToProps),
   withBounds,
   dropHandlers,
   DropTarget,

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/ConcentricCircles.test.js.snap
@@ -39,6 +39,7 @@ ShallowWrapper {
         />,
         undefined,
         <Connect(Component)
+          connectFrom={null}
           id="NODE_LAYOUT"
           prompt={
             Object {
@@ -48,6 +49,7 @@ ShallowWrapper {
             }
           }
           stage={Object {}}
+          updateLinkFrom={[Function]}
         />,
         <DropObstacle
           id="NODE_BUCKET"
@@ -87,6 +89,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "connectFrom": null,
           "id": "NODE_LAYOUT",
           "prompt": Object {
             "sociogram": Object {
@@ -94,6 +97,7 @@ ShallowWrapper {
             },
           },
           "stage": Object {},
+          "updateLinkFrom": [Function],
         },
         "ref": null,
         "rendered": null,
@@ -138,6 +142,7 @@ ShallowWrapper {
           />,
           undefined,
           <Connect(Component)
+            connectFrom={null}
             id="NODE_LAYOUT"
             prompt={
               Object {
@@ -147,6 +152,7 @@ ShallowWrapper {
               }
             }
             stage={Object {}}
+            updateLinkFrom={[Function]}
           />,
           <DropObstacle
             id="NODE_BUCKET"
@@ -186,6 +192,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "connectFrom": null,
             "id": "NODE_LAYOUT",
             "prompt": Object {
               "sociogram": Object {
@@ -193,6 +200,7 @@ ShallowWrapper {
               },
             },
             "stage": Object {},
+            "updateLinkFrom": [Function],
           },
           "ref": null,
           "rendered": null,

--- a/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
+++ b/src/containers/ConcentricCircles/__tests__/__snapshots__/NodeLayout.test.js.snap
@@ -10,6 +10,7 @@ ShallowWrapper {
     canCreateEdge={false}
     canHighlight={false}
     concentricCircles={0}
+    connectFrom={null}
     createEdge="bar"
     displayEdges={Array []}
     height={456}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -17,7 +17,7 @@ import { actionCreators as resetActions } from '../../ducks/modules/reset';
 class Sociogram extends Component {
   constructor(props) {
     super(props);
-    this.myRef = React.createRef();
+    this.linkingRef = React.createRef();
   }
 
   render() {
@@ -46,7 +46,7 @@ class Sociogram extends Component {
             stage={stage}
             prompt={prompt}
             key={prompt.id}
-            ref={this.myRef}
+            ref={this.linkingRef}
           />
         </div>
         <div style={{ position: 'absolute', right: '3rem', bottom: '3rem' }}>
@@ -54,7 +54,7 @@ class Sociogram extends Component {
             id="RESET_BUTTON_OBSTACLE"
             label="RESET"
             size="small"
-            onClick={() => { resetInterface(stage.prompts, this.myRef); }}
+            onClick={() => { resetInterface(stage.prompts, this.linkingRef); }}
           />
         </div>
       </div>
@@ -78,15 +78,14 @@ const mapDispatchToProps = dispatch => ({
 export default compose(
   connect(null, mapDispatchToProps),
   withHandlers({
-    resetInterface: props => (prompts, nodeLayout) => {
+    resetInterface: props => (prompts, linkingRef) => {
+      linkingRef.current.resetLinking();
       prompts.forEach((prompt) => {
         props.resetPropertyForAllNodes(prompt.layout.layoutVariable);
         if (prompt.edges) {
           props.resetEdgesOfType(prompt.edges.creates);
         }
       });
-      console.log(nodeLayout.current.getWrappedInstance());
-      // nodeLayout.current.getWrappedInstance().resetLinking();
     },
   }),
   withPrompt,

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withHandlers, compose } from 'recompose';
@@ -14,41 +14,53 @@ import { actionCreators as resetActions } from '../../ducks/modules/reset';
   * Sociogram Interface
   * @extends Component
   */
-const Sociogram = ({
-  promptForward,
-  promptBackward,
-  prompt,
-  stage,
-  resetInterface,
-}) => (
-  <div className="sociogram-interface">
-    <PromptObstacle
-      id="PROMPTS_OBSTACLE"
-      className="sociogram-interface__prompts"
-      forward={promptForward}
-      backward={promptBackward}
-      prompts={stage.prompts}
-      prompt={prompt}
-      floating
-      minimizable
-    />
-    <div className="sociogram-interface__sociogram">
-      <ConcentricCircles
-        stage={stage}
-        prompt={prompt}
-        key={prompt.id}
-      />
-    </div>
-    <div style={{ position: 'absolute', right: '3rem', bottom: '3rem' }}>
-      <ButtonObstacle
-        id="RESET_BUTTON_OBSTACLE"
-        label="RESET"
-        size="small"
-        onClick={() => { resetInterface(stage.prompts); }}
-      />
-    </div>
-  </div>
-);
+class Sociogram extends Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+
+  render() {
+    const {
+      promptForward,
+      promptBackward,
+      prompt,
+      stage,
+      resetInterface,
+    } = this.props;
+
+    return (
+      <div className="sociogram-interface">
+        <PromptObstacle
+          id="PROMPTS_OBSTACLE"
+          className="sociogram-interface__prompts"
+          forward={promptForward}
+          backward={promptBackward}
+          prompts={stage.prompts}
+          prompt={prompt}
+          floating
+          minimizable
+        />
+        <div className="sociogram-interface__sociogram">
+          <ConcentricCircles
+            stage={stage}
+            prompt={prompt}
+            key={prompt.id}
+            ref={this.myRef}
+          />
+        </div>
+        <div style={{ position: 'absolute', right: '3rem', bottom: '3rem' }}>
+          <ButtonObstacle
+            id="RESET_BUTTON_OBSTACLE"
+            label="RESET"
+            size="small"
+            onClick={() => { resetInterface(stage.prompts, this.myRef); }}
+          />
+        </div>
+      </div>
+    );
+  }
+}
 
 Sociogram.propTypes = {
   stage: PropTypes.object.isRequired,
@@ -66,13 +78,15 @@ const mapDispatchToProps = dispatch => ({
 export default compose(
   connect(null, mapDispatchToProps),
   withHandlers({
-    resetInterface: props => (prompts) => {
+    resetInterface: props => (prompts, nodeLayout) => {
       prompts.forEach((prompt) => {
         props.resetPropertyForAllNodes(prompt.layout.layoutVariable);
         if (prompt.edges) {
           props.resetEdgesOfType(prompt.edges.creates);
         }
       });
+      console.log(nodeLayout.current.getWrappedInstance());
+      // nodeLayout.current.getWrappedInstance().resetLinking();
     },
   }),
   withPrompt,


### PR DESCRIPTION
Fixes #690. This resets the state for the sociogram's `connectFrom` link when "reset" button is clicked, so unintentional edges aren't created after a reset. Verification steps are in the issue.