### PR TITLE
Fix form submit buttons

### DIFF
--- a/src/components/Setup/ServerAddressForm.js
+++ b/src/components/Setup/ServerAddressForm.js
@@ -130,12 +130,12 @@ class ServerAddressForm extends PureComponent {
         </fieldset>
         {
           cancel &&
-          <Button color="platinum" onClick={() => cancel()} icon="close">
+          <Button color="platinum" onClick={() => cancel()} icon="close" type="button">
             Cancel
           </Button>
         }
         <span className="server-address-form__submit">
-          <Button content="Pair" />
+          <Button content="Pair" type="submit" />
         </span>
       </form>
     );

--- a/src/components/Setup/__tests__/ServerAddressForm.test.js
+++ b/src/components/Setup/__tests__/ServerAddressForm.test.js
@@ -4,13 +4,15 @@ import { shallow } from 'enzyme';
 
 import ServerAddressForm from '../ServerAddressForm';
 
+const isSumbitButton = btn => btn.prop('type') !== 'reset' && btn.prop('type') !== 'button';
+
 describe('<ServerAddressForm>', () => {
   let component;
   let selectHandler;
 
   beforeEach(() => {
     selectHandler = jest.fn();
-    component = shallow(<ServerAddressForm selectServer={selectHandler} />);
+    component = shallow(<ServerAddressForm selectServer={selectHandler} cancel={jest.fn()} />);
   });
 
   it('allows selection', () => {
@@ -18,5 +20,17 @@ describe('<ServerAddressForm>', () => {
     component.instance().setPort(9999);
     component.simulate('submit', { preventDefault: jest.fn() });
     expect(selectHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('has a submit button that pairs', () => {
+    const submitButton = component.find('Button').filterWhere(isSumbitButton);
+    expect(submitButton).toHaveLength(1);
+    expect(submitButton.prop('content')).toEqual('Pair');
+  });
+
+  it('has a cancel button', () => {
+    const cancelButton = component.find('Button').filterWhere(btn => !isSumbitButton(btn));
+    expect(cancelButton).toHaveLength(1);
+    expect(cancelButton.children().text()).toEqual('Cancel');
   });
 });

--- a/src/containers/Setup/ProtocolUrlForm.js
+++ b/src/containers/Setup/ProtocolUrlForm.js
@@ -50,8 +50,9 @@ class ProtocolUrlForm extends Component {
             color="platinum"
             icon={<Icon name="close" />}
             content="Cancel"
+            type="button"
           />,
-          <Button key="submit">Import remote protocol</Button>,
+          <Button key="submit" type="submit">Import remote protocol</Button>,
         ]}
         {...formConfig}
       />

--- a/src/containers/Setup/__tests__/ProtocolUrlForm.test.js
+++ b/src/containers/Setup/__tests__/ProtocolUrlForm.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+import ProtocolUrlForm from '../ProtocolUrlForm';
+
+const isSumbitButton = btn => btn.prop('type') !== 'reset' && btn.prop('type') !== 'button';
+
+describe('ProtocolUrlForm', () => {
+  let component;
+
+  beforeEach(() => {
+    const state = { protocol: {} };
+    // Provider is required for the inner ReduxForm
+    component = mount((
+      <Provider store={createStore(() => state)} >
+        <ProtocolUrlForm />
+      </Provider>
+    ));
+  });
+
+  it('has a submit button that imports', () => {
+    const submitButton = component.find('button').filterWhere(isSumbitButton);
+    expect(submitButton).toHaveLength(1);
+    expect(submitButton.text()).toMatch('Import');
+  });
+});


### PR DESCRIPTION
Fixes #732, as well as the "manual entry" server form.

Cancel links were replaced by buttons; type needs to be specified since 'submit' is the default.