### PR TITLE
Fix/timeline hitbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only:
     - master
 node_js:
-  - "10.11"
+  - "8.11"
 cache:
   directories:
     - node_modules # NPM packages

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ProgressBar = ({ percentProgress }) =>
+const ProgressBar = ({ percentProgress, onClick }) =>
   (
-    <div className="progress-bar">
+    <div className="progress-bar" onClick={onClick}>
       <div className="progress-bar__filler" style={{ height: `${percentProgress}%` }} />
     </div>
   );
 
 ProgressBar.propTypes = {
   percentProgress: PropTypes.number,
+  onClick: PropTypes.func,
 };
 
 ProgressBar.defaultProps = {
   percentProgress: 0,
+  onClick: () => {},
 };
 
 export default ProgressBar;

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -17,7 +17,7 @@ class Timeline extends PureComponent {
     } = this.props;
 
     return (
-      <div className="timeline" onClick={toggleMenu}>
+      <div className="timeline">
         <div className="timeline-nav timeline-nav--back">
           <Icon
             onClick={(e) => {
@@ -30,7 +30,7 @@ class Timeline extends PureComponent {
             name="chevron-up"
           />
         </div>
-        <ProgressBar percentProgress={percentProgress} />
+        <ProgressBar percentProgress={percentProgress} onClick={toggleMenu} />
         <div
           className="timeline-nav timeline-nav--next"
           onClick={(e) => {

--- a/src/components/__tests__/Timeline.test.js
+++ b/src/components/__tests__/Timeline.test.js
@@ -1,15 +1,16 @@
 /* eslint-env jest */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Timeline } from '../Timeline';
+
 
 describe('Timeline component', () => {
   const toggleMock = jest.fn();
   const backMock = jest.fn();
   const nextMock = jest.fn();
 
-  const component = shallow(
+  const component = mount(
     <Timeline
       percentProgress="40"
       onClickBack={backMock}
@@ -24,7 +25,7 @@ describe('Timeline component', () => {
 
   it('toggles menu on timeline click', () => {
     expect(toggleMock.mock.calls.length).toBe(0);
-    component.find('.timeline').simulate('click');
+    component.find('.progress-bar').simulate('click');
     expect(toggleMock.mock.calls.length).toBe(1);
   });
 

--- a/src/components/__tests__/Timeline.test.js
+++ b/src/components/__tests__/Timeline.test.js
@@ -19,10 +19,6 @@ describe('Timeline component', () => {
     />,
   );
 
-  it('renders Timeline', () => {
-    expect(component).toMatchSnapshot();
-  });
-
   it('toggles menu on timeline click', () => {
     expect(toggleMock.mock.calls.length).toBe(0);
     component.find('.progress-bar').simulate('click');

--- a/src/components/__tests__/__snapshots__/ProgressBar.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.test.js.snap
@@ -4,6 +4,7 @@ exports[`ProgressBar component renders ProgressBar 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ProgressBar
+    onClick={[Function]}
     percentProgress="40"
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -28,6 +29,7 @@ ShallowWrapper {
         }
       />,
       "className": "progress-bar",
+      "onClick": [Function],
     },
     "ref": null,
     "rendered": Object {
@@ -61,6 +63,7 @@ ShallowWrapper {
           }
         />,
         "className": "progress-bar",
+        "onClick": [Function],
       },
       "ref": null,
       "rendered": Object {

--- a/src/styles/components/_timeline.scss
+++ b/src/styles/components/_timeline.scss
@@ -11,7 +11,6 @@ $timeline-button-size: 6rem;
   top: 0;
   left: 0;
   z-index: 2000;
-  overflow: hidden;
 
   svg {
     height: 2rem;
@@ -42,8 +41,8 @@ $timeline-button-size: 6rem;
         transition: transform var(--animation-duration-fast) var(--animation-easing), opacity var(--animation-duration-fast) var(--animation-easing);
         display: block;
         position: absolute;
-        height: $timeline-button-size * 2;
-        width: $timeline-button-size * 2;
+        height: 9rem;
+        width: 9rem;
         border-radius: 50%;
         z-index: -1;
         background: var(--primary);


### PR DESCRIPTION
- Resolves an issue where the timeline buttons were clipping without reintroducing the overscroll issue.
- Resolves #733. An issue where button clicks were triggering the menu open when they shouldn't.