### PR TITLE
remove highlight.value from factory protocols

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1097,7 +1097,6 @@
           },
           "highlight": {
             "variable": "has_given_advice",
-            "value": true,
             "allowHighlighting": true
           },
           "disable":
@@ -1134,7 +1133,6 @@
           },
           "highlight": {
             "variable": "has_given_advice",
-            "value": true,
             "allowHighlighting": true
           },
           "disable":
@@ -1170,7 +1168,6 @@
           },
           "highlight": {
             "variable": "has_given_advice",
-            "value": true,
             "allowHighlighting": true
           },
           "disable":

--- a/public/protocols/teaching-protocol.netcanvas/protocol.json
+++ b/public/protocols/teaching-protocol.netcanvas/protocol.json
@@ -610,7 +610,6 @@
           },
           "highlight": {
             "variable": "lives_nearby",
-            "value": true,
             "allowHighlighting": true
           }
         },
@@ -640,7 +639,6 @@
           },
           "highlight": {
             "variable": "facebook_friend",
-            "value": true,
             "allowHighlighting": true
           }
         }

--- a/src/containers/ConcentricCircles/NodeLayout.js
+++ b/src/containers/ConcentricCircles/NodeLayout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { compose, withHandlers, withState } from 'recompose';
-import { isEqual, isEmpty, pick, isMatch, has } from 'lodash';
+import { isEqual, isEmpty, pick, has } from 'lodash';
 import LayoutNode from './LayoutNode';
 import { withBounds } from '../../behaviours';
 import { makeGetSociogramOptions, makeGetPlacedNodes } from '../../selectors/sociogram';
@@ -91,7 +91,7 @@ class NodeLayout extends Component {
 
     this.connectNode(node[nodePrimaryKeyProperty]);
 
-    this.toggleHighlightAttributes(node[nodePrimaryKeyProperty]);
+    this.toggleHighlightAttribute(node);
 
     this.forceUpdate();
   }
@@ -117,18 +117,18 @@ class NodeLayout extends Component {
     this.props.updateLinkFrom(null);
   }
 
-  toggleHighlightAttributes(nodeId) {
+  toggleHighlightAttribute(node) {
     if (!this.props.allowHighlighting) { return; }
-
+    const newVal = !node[nodeAttributesProperty][this.props.highlightAttribute];
     this.props.toggleHighlight(
-      nodeId,
-      { ...this.props.highlightAttributes },
+      node[nodePrimaryKeyProperty],
+      { [this.props.highlightAttribute]: newVal },
     );
   }
 
   isHighlighted(node) {
-    return !isEmpty(this.props.highlightAttributes) &&
-      isMatch(node[nodeAttributesProperty], this.props.highlightAttributes);
+    return !isEmpty(this.props.highlightAttribute) &&
+      node[nodeAttributesProperty][this.props.highlightAttribute] === true;
   }
 
   isLinking(node) {

--- a/src/selectors/sociogram.js
+++ b/src/selectors/sociogram.js
@@ -60,9 +60,9 @@ const makeGetHighlightOptions = () =>
       const allowHighlighting = highlight && !edges.canCreateEdge ? get(highlight, 'allowHighlighting', true) : false;
       return ({
         allowHighlighting,
-        highlightAttributes: has(highlight, 'variable') ?
-          { [highlight.variable]: highlight.value } :
-          undefined,
+        highlightAttribute: has(highlight, 'variable') ?
+          get(highlight, 'variable') :
+          false,
       });
     },
   );


### PR DESCRIPTION
Fixes #731 

This was caused by sociogram incorrectly setting the value of toggled values, and using an incorrect protocol property not generated by architect.