### PR TITLE
Check protocol paths before unzipping

### DIFF
--- a/src/utils/protocol/__tests__/importProtocol.test.js
+++ b/src/utils/protocol/__tests__/importProtocol.test.js
@@ -14,9 +14,9 @@ const absolutePath = ['/example'];
 const emptyPath = [''];
 const mixedPaths = ['protocol.json', 'assets/example', '../example'];
 
-const traversalError = { message: /directory traversal not allowed/ };
-const absPathError = { message: /absolute paths not allowed/ };
-const emptyPathError = { message: /empty paths not allowed/ };
+const traversalError = /directory traversal not allowed/;
+const absPathError = /absolute paths not allowed/;
+const emptyPathError = /empty paths not allowed/;
 
 describe('importProtocol', () => {
   ([environments.CORDOVA, environments.ELECTRON]).forEach((platform) => {
@@ -38,22 +38,22 @@ describe('importProtocol', () => {
       });
 
       it('rejects traversing paths', async () => {
-        await expect(checkZipPaths(traversingPath)).rejects.toMatchObject(traversalError);
-        await expect(checkZipPaths(traversingInnerPath)).rejects.toMatchObject(traversalError);
+        await expect(checkZipPaths(traversingPath)).rejects.toThrow(traversalError);
+        await expect(checkZipPaths(traversingInnerPath)).rejects.toThrow(traversalError);
         // Technically only a problem on windows, but rejected outright anyway
-        await expect(checkZipPaths(traversingWindowsPath)).rejects.toMatchObject(traversalError);
+        await expect(checkZipPaths(traversingWindowsPath)).rejects.toThrow(traversalError);
       });
 
       it('rejects absolute paths', async () => {
-        await expect(checkZipPaths(absolutePath)).rejects.toMatchObject(absPathError);
+        await expect(checkZipPaths(absolutePath)).rejects.toThrow(absPathError);
       });
 
       it('rejects empty paths', async () => {
-        await expect(checkZipPaths(emptyPath)).rejects.toMatchObject(emptyPathError);
+        await expect(checkZipPaths(emptyPath)).rejects.toThrow(emptyPathError);
       });
 
       it('rejects when any path is invalid', async () => {
-        await expect(checkZipPaths(mixedPaths)).rejects.toMatchObject(traversalError);
+        await expect(checkZipPaths(mixedPaths)).rejects.toThrow(traversalError);
       });
     });
   });

--- a/src/utils/protocol/__tests__/importProtocol.test.js
+++ b/src/utils/protocol/__tests__/importProtocol.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+
+import environments from '../../environments';
+import { getEnvironment } from '../../Environment';
+import { checkZipPaths } from '../importProtocol';
+
+const validZipPath = ['assets/example'];
+const protocolPath = ['protocol.json'];
+const doubleDotPath = ['assets/example..text'];
+const traversingPath = ['../example'];
+const traversingInnerPath = ['assets/../../example'];
+const traversingWindowsPath = ['..\\example'];
+const absolutePath = ['/example'];
+const emptyPath = [''];
+const mixedPaths = ['protocol.json', 'assets/example', '../example'];
+
+const traversalError = { message: /directory traversal not allowed/ };
+const absPathError = { message: /absolute paths not allowed/ };
+const emptyPathError = { message: /empty paths not allowed/ };
+
+describe('importProtocol', () => {
+  ([environments.CORDOVA, environments.ELECTRON]).forEach((platform) => {
+    describe(`with platform ${platform.toString()}`, () => {
+      beforeAll(() => {
+        getEnvironment.mockReturnValue(platform);
+      });
+
+      it('allows valid assets', async () => {
+        await expect(checkZipPaths(validZipPath)).resolves.toBe(undefined);
+      });
+
+      it('allows protocol.json', async () => {
+        await expect(checkZipPaths(protocolPath)).resolves.toBe(undefined);
+      });
+
+      it('allows consecutive dots', async () => {
+        await expect(checkZipPaths(doubleDotPath)).resolves.toBe(undefined);
+      });
+
+      it('rejects traversing paths', async () => {
+        await expect(checkZipPaths(traversingPath)).rejects.toMatchObject(traversalError);
+        await expect(checkZipPaths(traversingInnerPath)).rejects.toMatchObject(traversalError);
+        // Technically only a problem on windows, but rejected outright anyway
+        await expect(checkZipPaths(traversingWindowsPath)).rejects.toMatchObject(traversalError);
+      });
+
+      it('rejects absolute paths', async () => {
+        await expect(checkZipPaths(absolutePath)).rejects.toMatchObject(absPathError);
+      });
+
+      it('rejects empty paths', async () => {
+        await expect(checkZipPaths(emptyPath)).rejects.toMatchObject(emptyPathError);
+      });
+
+      it('rejects when any path is invalid', async () => {
+        await expect(checkZipPaths(mixedPaths)).rejects.toMatchObject(traversalError);
+      });
+    });
+  });
+});

--- a/src/utils/protocol/importProtocol.js
+++ b/src/utils/protocol/importProtocol.js
@@ -66,7 +66,7 @@ const checkZipPaths = inEnvironment((environment) => {
         const path = require('path');
         zipPaths.some((zipPath) => {
           const normalizedPath = path.normalize(zipPath);
-          if (!normalizedPath) {
+          if (!zipPath) {
             reject(new Error('Invalid archive (empty paths not allowed)'));
             return true;
           }
@@ -90,7 +90,7 @@ const checkZipPaths = inEnvironment((environment) => {
           reject(new Error('Invalid archive (empty paths not allowed)'));
         }
         if (zipPaths.some(f => f.startsWith('/'))) {
-          reject('Invalid archive (absolute paths not allowed)');
+          reject(new Error('Invalid archive (absolute paths not allowed)'));
         }
         if (zipPaths.some(f => f.startsWith('..') || f.includes('../'))) {
           reject(new Error('Invalid archive (directory traversal not allowed)'));
@@ -170,3 +170,7 @@ const importProtocol = inEnvironment((environment) => {
 });
 
 export default importProtocol;
+
+export {
+  checkZipPaths,
+};

--- a/src/utils/protocol/importProtocol.js
+++ b/src/utils/protocol/importProtocol.js
@@ -74,7 +74,7 @@ const checkZipPaths = inEnvironment((environment) => {
             reject(new Error('Invalid archive (absolute paths not allowed)'));
             return true;
           }
-          if ((/^\.\./.test(normalizedPath)) || normalizedPath.includes('../')) {
+          if (normalizedPath.startsWith('..')) {
             reject(new Error('Invalid archive (directory traversal not allowed)'));
             return true;
           }
@@ -92,7 +92,7 @@ const checkZipPaths = inEnvironment((environment) => {
         if (zipPaths.some(f => f.startsWith('/'))) {
           reject('Invalid archive (absolute paths not allowed)');
         }
-        if (zipPaths.some(f => f.includes('../'))) {
+        if (zipPaths.some(f => f.startsWith('..') || f.includes('../'))) {
           reject(new Error('Invalid archive (directory traversal not allowed)'));
         }
         resolve();

--- a/src/utils/protocol/protocolValidation.js
+++ b/src/utils/protocol/protocolValidation.js
@@ -1,0 +1,68 @@
+import environments from '../environments';
+import inEnvironment from '../Environment';
+
+/**
+ * @param {string} pathname a pathname contained in a protocol archive
+ * @throws {Error} if pathname is falsy
+ */
+const assertNonEmptyPath = (pathname) => {
+  if (!pathname) {
+    throw new Error('Invalid archive (empty paths not allowed)');
+  }
+};
+
+/**
+ * Guard against directory traversal / escape
+ * On Cordova, no traversal is allowed (even if it doesn't result in escaping the directory).
+ * @param {string} pathname a pathname contained in a protocol archive
+ * @throws {Error} If pathname escapes directory
+ */
+const assertNoTraversalInPath = inEnvironment((environment) => {
+  const message = 'Invalid archive (directory traversal not allowed)';
+  if (environment === environments.ELECTRON) {
+    return (pathname) => {
+      // eslint-disable-next-line global-require
+      if (require('path').normalize(pathname).startsWith('..')) {
+        throw new Error(message);
+      }
+    };
+  }
+  if (environment === environments.CORDOVA) {
+    return (pathname) => {
+      if (pathname.startsWith('..') || pathname.includes('../')) {
+        throw new Error(message);
+      }
+    };
+  }
+  throw new Error('assertNoTraversalInPath() not available on platform');
+});
+
+/**
+ * @param {string} pathname a pathname contained in a protocol archive
+ * @throws {Error} If pathname is absolute
+ */
+const assertRelativePath = inEnvironment((environment) => {
+  const message = 'Invalid archive (absolute paths not allowed)';
+  if (environment === environments.ELECTRON) {
+    return (pathname) => {
+      // eslint-disable-next-line global-require
+      if (require('path').isAbsolute(pathname)) {
+        throw new Error(message);
+      }
+    };
+  }
+  if (environment === environments.CORDOVA) {
+    return (pathname) => {
+      if (pathname.startsWith('/')) {
+        throw new Error(message);
+      }
+    };
+  }
+  throw new Error('assertRelativePath() not available on platform');
+});
+
+export {
+  assertNonEmptyPath,
+  assertNoTraversalInPath,
+  assertRelativePath,
+};


### PR DESCRIPTION
This checks the zipped file paths in a protocol before writing output to those paths.

To support [flexibility in the directory structure](https://github.com/codaco/Network-Canvas/wiki/Protocol-Overview), this detects problems. If we standardize on a top-level structure (perhaps moving worker scripts into `workers/`, then we could more easily check against a whitelist here, which is probably preferable.