### PR TITLE
Fix load screen for slow protocol loading

### DIFF
--- a/src/containers/LoadScreen.js
+++ b/src/containers/LoadScreen.js
@@ -5,6 +5,8 @@ import { compose } from 'redux';
 import { Spinner } from '../ui/components';
 import Fade from '../components/Transition/Fade';
 
+const minimumTimeToDisplaySpinner = 1000;
+
 class LoadScreen extends Component {
   static getDerivedStateFromProps(props) {
     if (props.isWorking) {
@@ -22,14 +24,16 @@ class LoadScreen extends Component {
   }
 
   componentDidMount() {
-    if (this.props.isWorking) {
-      setTimeout(() => this.setState({ minimumTimeMet: true }), 1000);
-    }
+    this.scheduleSpinnerExpiration();
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.isWorking !== this.props.isWorking && this.props.isWorking) {
-      setTimeout(() => this.setState({ minimumTimeMet: true }), 1000);
+  componentDidUpdate() {
+    this.scheduleSpinnerExpiration();
+  }
+
+  scheduleSpinnerExpiration() {
+    if (this.props.isWorking) {
+      setTimeout(() => this.setState({ minimumTimeMet: true }), minimumTimeToDisplaySpinner);
     }
   }
 


### PR DESCRIPTION
Interim fix for #727.

`getDerivedStateFromProps` is called before every render (as of React 16.4), which means `setState()` triggers it, and if the protocol slowly enough then `minimumTimeMet` settles at `false`.

The change here boils down to removing the `prevProps.isWorking !== this.props.isWorking` check. This could be improved (as it may cause additional rendering), but should fix the immediate issue for now.

The easiest way to test is to download a protocol with assets on Android.