### PR TITLE
Prevent navigation away from app

### DIFF
--- a/public/components/windowManager.js
+++ b/public/components/windowManager.js
@@ -68,6 +68,11 @@ function createWindow() {
       shell.openExternal(newUrl);
     });
 
+    // For now, any navigation off the SPA is unneeded
+    mainWindow.webContents.on('will-navigate', (evt) => {
+      evt.preventDefault();
+    });
+
     if (process.env.NODE_ENV === 'development') {
       mainWindow.openDevTools();
     }


### PR DESCRIPTION
Same implementation as https://github.com/codaco/Server/pull/185:

While there is no intended mechanism to navigate away from the app URL within the app, this prevents any other (unexpected/untrusted) URLs from loading in the main window.
