### PR TITLE
Fix downloaded asset URLs

### DIFF
--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -410,6 +410,8 @@ const writeStream = inEnvironment((environment) => {
   throw new Error(`writeStream() not available on platform ${environment}`);
 });
 
+// FIXME: this implies that it will recursively create directories, but if targetPath's parent
+//        doesn't already exist, this will error on both platforms
 const ensurePathExists = inEnvironment((environment) => {
   if (environment === environments.ELECTRON) {
     const path = require('path');

--- a/src/utils/filesystem.js
+++ b/src/utils/filesystem.js
@@ -98,6 +98,13 @@ const readFile = inEnvironment((environment) => {
   throw new Error(`readFile() not available on platform ${environment}`);
 });
 
+/**
+ * Deprecated.
+ * This reads the binary contents of a file into a base-64 encoded data URL,
+ * which works as long as the file is small enough (but is slow).
+ * On iOS, asset loading currently relies on observed behavior of the tmp fs;
+ * this may be useful as a fallback in the future (see #681).
+ */
 const readFileAsDataUrl = inEnvironment((environment) => {
   if (environment === environments.CORDOVA) {
     const fileReader = fileEntry =>
@@ -439,14 +446,47 @@ const ensurePathExists = inEnvironment((environment) => {
   throw new Error(`ensurePathExists() not available on platform ${environment}`);
 });
 
+/**
+ * Creates a temp file from a given source filename if it doesn't already exist.
+ * This is useful on iOS, where video can be served using native file:// URLs.
+ * Note that this should not be needed on Android, but if called there, the
+ * cache directory will be used.
+ *
+ * Resolves with the fileEntry of the temp file.
+ *
+ * @param {string} sourceFilename existing file on the permanent FS
+ * @param {string} tmpFilename unique name for the temporary file
+ * @async
+ *
+ */
+const makeTmpDirCopy = inEnvironment((environment) => {
+  if (environment === environments.CORDOVA) {
+    return (sourceFilename, tmpFilename) => new Promise((resolve, reject) => {
+      window.requestFileSystem(window.TEMPORARY, 0, (tempFs) => {
+        tempFs.root.getFile(tmpFilename, { create: false }, (fileEntry) => {
+          resolve(fileEntry); // Temp file already exists
+        }, () => {
+          window.resolveLocalFileSystemURL(sourceFilename, (sourceEntry) => {
+            sourceEntry.copyTo(tempFs.root, tmpFilename, resolve, reject);
+          }, reject);
+        });
+      }, reject);
+    });
+  }
+
+  throw new Error(`makeTmpDirCopy() not available on platform ${environment}`);
+});
+
 export {
   userDataPath,
   appPath,
   getNestedPaths,
   ensurePathExists,
+  makeTmpDirCopy,
   removeDirectory,
   readFile,
   readFileAsDataUrl,
+  resolveFileSystemUrl,
   writeFile,
   writeStream,
   inSequence,

--- a/src/utils/protocol/assetUrl.js
+++ b/src/utils/protocol/assetUrl.js
@@ -1,6 +1,8 @@
+/* global device */
+
 import environments from '../environments';
 import inEnvironment from '../Environment';
-import { readFileAsDataUrl } from '../filesystem';
+import { makeTmpDirCopy, resolveFileSystemUrl } from '../filesystem';
 import protocolPath from './protocolPath';
 
 const isRequired = (param) => { throw new Error(`${param} is required`); };
@@ -25,9 +27,28 @@ const assetUrl = (environment) => {
         return Promise.resolve(`protocols/${protocolName}/assets/${assetPath}`);
       }
 
-      // FIXME: this will fail on large assets [#681]
-      const filename = protocolPath(protocolName, `assets/${assetPath}`);
-      return readFileAsDataUrl(filename);
+      const sourceFilename = protocolPath(protocolName, `assets/${assetPath}`);
+
+      // Android supports native URLs to the permanent filesystem
+      if ((/Android/i).test(device.platform)) {
+        return resolveFileSystemUrl(sourceFilename)
+          .then(url => url.nativeURL);
+      }
+
+      // iOS will happily serve video assets from the tmp directory
+      // files stored in a flat hierarchy under tmp/; prepend protocolName to ensure uniqueness
+      const tmpFilename = `${protocolName}-${assetPath}`;
+      return makeTmpDirCopy(sourceFilename, tmpFilename)
+        .then(fileEntry => fileEntry.nativeURL)
+        .catch((err) => {
+          console.error(err); // eslint-disable-line no-console
+          return '';
+        });
+
+      // The original version read binary data to a data:// URL
+      // This could be used as a fallback if the asset is small enough
+      // (if it's too large, the app will reload or crash).
+      // return readFileAsDataUrl(sourceFilename);
     };
   }
 


### PR DESCRIPTION
Fixes #681 (large assets included in `download` protocols; the counterpart to #696).

This changes the asset URLs for all assets included in a downloaded protocol on Cordova:
- On Android, sets the asset URL directly from the saved protocol path
- On iOS, copies the asset to the device's tmp directory (for reasons discussed in #681)

To test: download (from Server or a URL) a protocol that contains large assets; for example, an external copy of the development protocol.

Limitations:
- As discussed in #681, this is intended as a temporary workaround until Cordova (or we) support `WKURLSchemeHandler` changes in the future
- Will not run in our [iOS & Android] development mode (i.e., the page must be loaded from `file://`)

To make protocols behave better in development, we could (for example) choose to only apply this to Video and Audio assets. That would mean images would display again in development, but that large images would still cause issues in production (at best, they load slowly).