### PR TITLE
Use new variables for sociogram radar colors

### DIFF
--- a/src/containers/ConcentricCircles/Radar.js
+++ b/src/containers/ConcentricCircles/Radar.js
@@ -36,8 +36,8 @@ const Radar = ({ n, skewed }) => {
     weightedAverage(equalByArea(50, num), equalByIncrement(50, num), 3) :
     equalByIncrement(50, num);
 
-  const colorRing = color(getCSSVariableAsString('--ring'));
-  const colorBackground = color(getCSSVariableAsString('--background'));
+  const colorRing = color(getCSSVariableAsString('--ring--accent'));
+  const colorBackground = color(getCSSVariableAsString('--ring--background'));
 
   const ringFill = (ring) => {
     const mix = (ring + 1) / num;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -9,7 +9,7 @@ $scroller-top-padding-small: 1rem;
 @import 'components/all';
 @import 'containers/all';
 @import 'transitions';
-@import '../../node_modules/swiper/dist/css/swiper.min.css';
+@import '~swiper/dist/css/swiper.min.css';
 
 // Remove touch and focus outlines
 * {


### PR DESCRIPTION
Outside of Network Canvas app, the global --background value may differ from the color we want for the outer edge of ther radar.

This separates it out into a new variable, which defaults to mirror --background.