### PR TITLE
Skip tests when copying ./public during build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -145,6 +145,6 @@ function build(previousFileSizes) {
 function copyPublicFolder() {
   fs.copySync(paths.appPublic, paths.appBuild, {
     dereference: true,
-    filter: file => file !== paths.appHtml,
+    filter: file => file !== paths.appHtml && !file.includes('__tests__'),
   });
 }


### PR DESCRIPTION
Build should not include test files