### PR TITLE
Fix worker node & edge props

### DIFF
--- a/src/behaviours/__tests__/withPrompt.test.js
+++ b/src/behaviours/__tests__/withPrompt.test.js
@@ -6,7 +6,7 @@ import { createStore } from 'redux';
 import withPrompt from '../withPrompt';
 
 jest.mock('../../selectors/session', () => ({
-  getPromptForCurrentSession: jest.fn().mockReturnValue(99),
+  getPromptIndexForCurrentSession: jest.fn().mockReturnValue(99),
   stages: jest.fn().mockReturnValue([{}]),
 }));
 

--- a/src/behaviours/withPrompt.js
+++ b/src/behaviours/withPrompt.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
 import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
-import { stages, getPromptForCurrentSession } from '../selectors/session';
+import { stages, getPromptIndexForCurrentSession } from '../selectors/session';
 
 export default function withPrompt(WrappedComponent) {
   class WithPrompt extends Component {
@@ -64,7 +64,7 @@ export default function withPrompt(WrappedComponent) {
   function mapStateToProps(state, ownProps) {
     let promptIndex = ownProps.promptId;
     if (promptIndex === undefined) {
-      promptIndex = getPromptForCurrentSession(state);
+      promptIndex = getPromptIndexForCurrentSession(state);
     }
     return {
       promptIndex,

--- a/src/components/MainMenu/SettingsMenu.js
+++ b/src/components/MainMenu/SettingsMenu.js
@@ -14,6 +14,7 @@ class SettingsMenu extends PureComponent {
       handleResetAppData,
       toggleUseFullScreenForms,
       useFullScreenForms,
+      shouldShowMocksItem,
       toggleUseDynamicScaling,
       useDynamicScaling,
       setDeviceDescription,
@@ -47,18 +48,21 @@ class SettingsMenu extends PureComponent {
                     fieldLabel=" "
                   />
                 </section>
-                <section>
-                  <p>
-                    During an active interview session, clicking this button will create mock nodes
-                    for testing purposes.
-                  </p>
-                  <Button
-                    color="mustard"
-                    onClick={handleAddMockNodes}
-                  >
-                    Add mock nodes
-                  </Button>
-                </section>
+                {
+                  shouldShowMocksItem &&
+                  <section>
+                    <p>
+                      During an active interview session, clicking this button will create
+                      mock nodes for testing purposes.
+                    </p>
+                    <Button
+                      color="mustard"
+                      onClick={handleAddMockNodes}
+                    >
+                      Add mock nodes
+                    </Button>
+                  </section>
+                }
                 <section>
                   <p>
                     Use the button below to reset all Network Canvas data. This will erase any
@@ -135,6 +139,7 @@ SettingsMenu.propTypes = {
   onClickInactive: PropTypes.func,
   handleResetAppData: PropTypes.func.isRequired,
   handleAddMockNodes: PropTypes.func.isRequired,
+  shouldShowMocksItem: PropTypes.bool,
   toggleUseFullScreenForms: PropTypes.func.isRequired,
   useFullScreenForms: PropTypes.bool.isRequired,
   toggleUseDynamicScaling: PropTypes.func.isRequired,
@@ -148,6 +153,7 @@ SettingsMenu.propTypes = {
 SettingsMenu.defaultProps = {
   active: false,
   onClickInactive: () => {},
+  shouldShowMocksItem: false,
 };
 
 export default SettingsMenu;

--- a/src/containers/Interfaces/NameGeneratorAutoComplete.js
+++ b/src/containers/Interfaces/NameGeneratorAutoComplete.js
@@ -10,14 +10,14 @@ import Search from '../../containers/Search';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { actionCreators as searchActions } from '../../ducks/modules/search';
 import { nodeAttributesProperty } from '../../ducks/modules/network';
-import { getNodeLabelFunction, makeGetNodeType, makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
+import { getNodeLabelFunction, makeGetSubjectType, makeNetworkNodesForPrompt, networkNodes } from '../../selectors/interface';
 import { getCardDisplayLabel, getCardAdditionalProperties, makeGetNodeIconName, makeGetPromptNodeAttributes } from '../../selectors/name-generator';
 import { PromptSwiper } from '../';
 import { NodeBin, NodeList } from '../../components/';
 
 const networkNodesForPrompt = makeNetworkNodesForPrompt();
 const getPromptNodeAttributes = makeGetPromptNodeAttributes();
-const getNodeType = makeGetNodeType();
+const getNodeType = makeGetSubjectType();
 const getNodeIconName = makeGetNodeIconName();
 
 /**

--- a/src/containers/MainMenu/SettingsMenu.js
+++ b/src/containers/MainMenu/SettingsMenu.js
@@ -8,7 +8,7 @@ import { actionCreators as uiActions } from '../../ducks/modules/ui';
 import { actionCreators as mockActions } from '../../ducks/modules/mock';
 import { actionCreators as dialogsActions } from '../../ducks/modules/dialogs';
 import { actionCreators as deviceSettingsActions } from '../../ducks/modules/deviceSettings';
-import { getNodeEntryForCurrentPrompt } from '../../selectors/session';
+import { getAdditionalAttributesForCurrentPrompt, getNodeEntryForCurrentPrompt } from '../../selectors/session';
 
 const settingsMenuHandlers = withHandlers({
   handleResetAppData: props => () => {
@@ -28,7 +28,7 @@ const settingsMenuHandlers = withHandlers({
       return;
     }
     const [typeKey, nodeDefinition] = props.nodeVariableEntry;
-    props.generateNodes(nodeDefinition.variables, typeKey, 20);
+    props.generateNodes(nodeDefinition.variables, typeKey, 20, props.additionalMockAttributes);
     props.closeMenu();
   },
 });
@@ -48,6 +48,7 @@ const mapStateToProps = state => ({
   protocol: state.protocol,
   nodeVariableEntry: getNodeEntryForCurrentPrompt(state),
   shouldShowMocksItem: !!getNodeEntryForCurrentPrompt(state),
+  additionalMockAttributes: getAdditionalAttributesForCurrentPrompt(state),
   useFullScreenForms: state.deviceSettings.useFullScreenForms,
   useDynamicScaling: state.deviceSettings.useDynamicScaling,
   deviceDescription: state.deviceSettings.description,

--- a/src/containers/MainMenu/SettingsMenu.js
+++ b/src/containers/MainMenu/SettingsMenu.js
@@ -8,6 +8,15 @@ import { actionCreators as mockActions } from '../../ducks/modules/mock';
 import { actionCreators as dialogsActions } from '../../ducks/modules/dialogs';
 import { actionCreators as deviceSettingsActions } from '../../ducks/modules/deviceSettings';
 
+const personEntry = (protocol) => {
+  const registry = protocol && protocol.variableRegistry;
+  const entry = registry && registry.node && Object.entries(registry.node).find(([, nodeType]) => nodeType.name === 'person');
+  if (!entry || entry.length !== 2) {
+    return null;
+  }
+  return entry;
+};
+
 const settingsMenuHandlers = withHandlers({
   handleResetAppData: props => () => {
     props.openDialog({
@@ -22,7 +31,12 @@ const settingsMenuHandlers = withHandlers({
     });
   },
   handleAddMockNodes: props => () => {
-    props.generateNodes(20);
+    const entry = personEntry(props.protocol);
+    if (!entry) {
+      return;
+    }
+    const [typeKey, personDef] = entry;
+    props.generateNodes(personDef.variables, typeKey, 20);
     props.closeMenu();
   },
 });
@@ -39,6 +53,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
+  protocol: state.protocol,
+  shouldShowMocksItem: !!personEntry(state.protocol),
   useFullScreenForms: state.deviceSettings.useFullScreenForms,
   useDynamicScaling: state.deviceSettings.useDynamicScaling,
   deviceDescription: state.deviceSettings.description,

--- a/src/containers/MainMenu/SettingsMenu.js
+++ b/src/containers/MainMenu/SettingsMenu.js
@@ -10,7 +10,8 @@ import { actionCreators as deviceSettingsActions } from '../../ducks/modules/dev
 
 const personEntry = (protocol) => {
   const registry = protocol && protocol.variableRegistry;
-  const entry = registry && registry.node && Object.entries(registry.node).find(([, nodeType]) => nodeType.name === 'person');
+  const nodeEntries = registry && registry.node && Object.entries(registry.node);
+  const entry = nodeEntries && nodeEntries.find(([, nodeType]) => nodeType.name === 'person');
   if (!entry || entry.length !== 2) {
     return null;
   }

--- a/src/containers/MainMenu/SettingsMenu.js
+++ b/src/containers/MainMenu/SettingsMenu.js
@@ -35,8 +35,8 @@ const settingsMenuHandlers = withHandlers({
     if (!entry) {
       return;
     }
-    const [typeKey, personDef] = entry;
-    props.generateNodes(personDef.variables, typeKey, 20);
+    const [typeKey, personDefinition] = entry;
+    props.generateNodes(personDefinition.variables, typeKey, 20);
     props.closeMenu();
   },
 });

--- a/src/containers/MainMenu/TimelineStage.js
+++ b/src/containers/MainMenu/TimelineStage.js
@@ -3,7 +3,7 @@ import { withHandlers, compose } from 'recompose';
 import { push } from 'react-router-redux';
 import TimelineStage from '../../components/MainMenu/TimelineStage';
 import { actionCreators as uiActions } from '../../ducks/modules/ui';
-import { matchSessionPath } from '../../utils/matchSessionPath';
+import { currentStageIndex } from '../../utils/matchSessionPath';
 
 const timelineStageHandlers = withHandlers({
   handleOpenStage: props =>
@@ -22,22 +22,12 @@ const timelineStageHandlers = withHandlers({
     },
 });
 
-const mapStateToProps = (state) => {
-  const currentStageIndex = (path) => {
-    const matchedPath = matchSessionPath(path);
-    if (matchedPath) {
-      return parseInt(matchedPath.params.stageIndex, 10);
-    }
-    return 0;
-  };
-
-  return ({
-    protocolPath: state.protocol.path,
-    currentStageIndex: currentStageIndex(state.router.location.pathname),
-    protocolType: state.protocol.type,
-    sessionId: state.session,
-  });
-};
+const mapStateToProps = state => ({
+  protocolPath: state.protocol.path,
+  currentStageIndex: currentStageIndex(state.router.location.pathname),
+  protocolType: state.protocol.type,
+  sessionId: state.session,
+});
 
 const mapDispatchToProps = dispatch => ({
   openStage: (path) => {

--- a/src/containers/MainMenu/__tests__/MainMenu.test.js
+++ b/src/containers/MainMenu/__tests__/MainMenu.test.js
@@ -94,6 +94,7 @@ describe('<MainMenu />', () => {
               },
             },
           },
+          stages: [{ subject: { type: 'abcdef' }, prompts: [{}] }],
         },
         session: '1234-5678',
         sessions: {

--- a/src/containers/MainMenu/__tests__/MainMenu.test.js
+++ b/src/containers/MainMenu/__tests__/MainMenu.test.js
@@ -129,7 +129,8 @@ describe('<MainMenu />', () => {
     it('Mock data button', () => {
       subject.find('Button[children="Add mock nodes"]').at(0).simulate('click');
 
-      expect(actions.filter(({ type }) => type === 'ADD_NODES').length).toBe(20);
+      expect(actions.filter(({ type }) => type === 'ADD_NODES')).toHaveLength(1);
+      expect(actions.filter(({ type }) => type === 'ADD_NODES')[0].nodes).toHaveLength(20);
       expect(isMenuOpen(subject)).toBe(false);
     });
   });

--- a/src/containers/MainMenu/__tests__/MainMenu.test.js
+++ b/src/containers/MainMenu/__tests__/MainMenu.test.js
@@ -85,6 +85,16 @@ describe('<MainMenu />', () => {
     beforeEach(() => {
       const mockStore = getMockStore({
         ui: { isMenuOpen: true },
+        protocol: {
+          variableRegistry: {
+            node: {
+              abcdef: {
+                name: 'person',
+                variables: {},
+              },
+            },
+          },
+        },
         session: '1234-5678',
         sessions: {
           '1234-5678': {

--- a/src/containers/Node.js
+++ b/src/containers/Node.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import WorkerAgent from '../utils/WorkerAgent';
 import { Node as UINode } from '../ui/components';
 import { getWorkerNetwork, getNodeLabelFunction } from '../selectors/interface';
-import { getNodeLabelWorkerUrl, makeGetNodeColor, makeGetNodeTypeName } from '../selectors/protocol';
+import { getNodeLabelWorkerUrl, makeGetNodeColor, makeGetNodeTypeDefinition } from '../selectors/protocol';
 import { asWorkerAgentNode } from '../ducks/modules/network';
 
 /**
@@ -40,7 +40,7 @@ class Node extends PureComponent {
     }
 
     // Create an object containing the node's model properties
-    const node = asWorkerAgentNode(this.props, this.props.nodeTypeName);
+    const node = asWorkerAgentNode(this.props, this.props.nodeTypeDefinition);
 
     // Send the worker the node model properties along with the network
     const msgPromise = this.webWorker.sendMessageAsync({
@@ -79,11 +79,11 @@ class Node extends PureComponent {
 
 function mapStateToProps(state, props) {
   const getNodeColor = makeGetNodeColor();
-  const getNodeTypeName = makeGetNodeTypeName();
+  const getNodeTypeDefinition = makeGetNodeTypeDefinition();
 
   return {
     color: getNodeColor(state, props),
-    nodeTypeName: getNodeTypeName(state, props),
+    nodeTypeDefinition: getNodeTypeDefinition(state, props),
     getLabel: getNodeLabelFunction(state),
     workerUrl: getNodeLabelWorkerUrl(state),
     workerNetwork: (getNodeLabelWorkerUrl(state) && getWorkerNetwork(state)) || null,
@@ -94,14 +94,14 @@ Node.propTypes = {
   type: PropTypes.string.isRequired,
   color: PropTypes.string,
   getLabel: PropTypes.func.isRequired,
-  nodeTypeName: PropTypes.string,
+  nodeTypeDefinition: PropTypes.object,
   workerUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   workerNetwork: PropTypes.object,
 };
 
 Node.defaultProps = {
   color: 'node-color-seq-1',
-  nodeTypeName: null,
+  nodeTypeDefinition: null,
   workerUrl: undefined,
   workerNetwork: null,
 };

--- a/src/containers/Node.js
+++ b/src/containers/Node.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import WorkerAgent from '../utils/WorkerAgent';
 import { Node as UINode } from '../ui/components';
 import { getWorkerNetwork, getNodeLabelFunction } from '../selectors/interface';
-import { getNodeLabelWorkerUrl, makeGetNodeColor } from '../selectors/protocol';
+import { getNodeLabelWorkerUrl, makeGetNodeColor, makeGetNodeTypeName } from '../selectors/protocol';
 import { asWorkerAgentNode } from '../ducks/modules/network';
 
 /**
@@ -40,7 +40,7 @@ class Node extends PureComponent {
     }
 
     // Create an object containing the node's model properties
-    const node = asWorkerAgentNode(this.props);
+    const node = asWorkerAgentNode(this.props, this.props.nodeTypeName);
 
     // Send the worker the node model properties along with the network
     const msgPromise = this.webWorker.sendMessageAsync({
@@ -79,9 +79,11 @@ class Node extends PureComponent {
 
 function mapStateToProps(state, props) {
   const getNodeColor = makeGetNodeColor();
+  const getNodeTypeName = makeGetNodeTypeName();
 
   return {
     color: getNodeColor(state, props),
+    nodeTypeName: getNodeTypeName(state, props),
     getLabel: getNodeLabelFunction(state),
     workerUrl: getNodeLabelWorkerUrl(state),
     workerNetwork: (getNodeLabelWorkerUrl(state) && getWorkerNetwork(state)) || null,
@@ -92,12 +94,14 @@ Node.propTypes = {
   type: PropTypes.string.isRequired,
   color: PropTypes.string,
   getLabel: PropTypes.func.isRequired,
+  nodeTypeName: PropTypes.string,
   workerUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   workerNetwork: PropTypes.object,
 };
 
 Node.defaultProps = {
   color: 'node-color-seq-1',
+  nodeTypeName: null,
   workerUrl: undefined,
   workerNetwork: null,
 };

--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -9,7 +9,7 @@ import withPrompt from '../behaviours/withPrompt';
 import { Timeline } from '../components';
 import { Fade, Stage as StageTransition } from '../components/Transition';
 import Stage from './Stage';
-import { stages, getPromptForCurrentSession } from '../selectors/session';
+import { stages, getPromptIndexForCurrentSession } from '../selectors/session';
 import { getCSSVariableAsNumber } from '../utils/CSSVariables';
 
 /**
@@ -117,7 +117,7 @@ function mapStateToProps(state, ownProps) {
   const protocolType = state.protocol.type;
   const stage = stages(state)[ownProps.stageIndex] || {};
   const stageIndex = Math.trunc(ownProps.stageIndex) || 0;
-  const promptId = getPromptForCurrentSession(state);
+  const promptId = getPromptIndexForCurrentSession(state);
   const stageProgress = stageIndex / (maxLength - 1);
   const promptProgress = stage.prompts ? (promptId / stage.prompts.length) : 0;
 

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -4,6 +4,7 @@ import reducer,
 { actionTypes,
   asWorkerAgentNode,
   nodePrimaryKeyProperty as PK,
+  nodeTypePropertyForWorker,
   primaryKeyPropertyForWorker,
 } from '../network';
 
@@ -230,21 +231,32 @@ describe('network reducer', () => {
 describe('asWorkerAgentNode', () => {
   const nodeInNetwork = {
     attributes: {
-      userProp1: 'userProp1',
+      1234: 'userProp1value',
     },
     [PK]: 'node1',
     stageId: 42,
   };
 
+  const nodeTypeDefinition = {
+    name: 'person',
+    variables: {
+      1234: { name: 'userProp1' },
+    },
+  };
+
   it('returns a node’s attributes', () => {
-    expect(asWorkerAgentNode(nodeInNetwork).userProp1).toEqual('userProp1');
+    expect(asWorkerAgentNode(nodeInNetwork, nodeTypeDefinition).userProp1).toEqual('userProp1value');
   });
 
   it('returns a unique ID for the node', () => {
-    expect(asWorkerAgentNode(nodeInNetwork)[primaryKeyPropertyForWorker]).toEqual('node1');
+    expect(asWorkerAgentNode(nodeInNetwork, nodeTypeDefinition)[primaryKeyPropertyForWorker]).toEqual('node1');
+  });
+
+  it('returns a type for the node', () => {
+    expect(asWorkerAgentNode(nodeInNetwork, nodeTypeDefinition)[nodeTypePropertyForWorker]).toEqual('person');
   });
 
   it('does not contain other private attrs props', () => {
-    expect(asWorkerAgentNode(nodeInNetwork)).not.toHaveProperty('stageId');
+    expect(asWorkerAgentNode(nodeInNetwork, nodeTypeDefinition)).not.toHaveProperty('stageId');
   });
 });

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -71,7 +71,7 @@ describe('network reducer', () => {
     expect(newState.nodes[0][PK]).toEqual('22');
   });
 
-  it('should support additionalAttributes for ADD_NODES', () => {
+  it('should support additionalProperties for ADD_NODES', () => {
     const newState = reducer(
       {
         ...mockState,
@@ -80,7 +80,7 @@ describe('network reducer', () => {
       {
         type: actionTypes.ADD_NODES,
         nodes: [{ attributes: { name: 'foo' } }, { attributes: { name: 'bar' } }],
-        additionalAttributes: { stageId: '2', attributes: { isFriend: true } },
+        additionalProperties: { stageId: '2', attributes: { isFriend: true } },
       },
     );
 

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -2,6 +2,7 @@
 
 import reducer,
 { actionTypes,
+  asWorkerAgentEdge,
   asWorkerAgentNode,
   nodePrimaryKeyProperty as PK,
   nodeTypePropertyForWorker,
@@ -258,5 +259,27 @@ describe('asWorkerAgentNode', () => {
 
   it('does not contain other private attrs props', () => {
     expect(asWorkerAgentNode(nodeInNetwork, nodeTypeDefinition)).not.toHaveProperty('stageId');
+  });
+});
+
+describe('asWorkerAgentEdge', () => {
+  const edgeInNetwork = {
+    from: 'node1',
+    to: 'node2',
+    type: '1234',
+  };
+
+  const edgeTypeDefinition = {
+    name: 'friend',
+  };
+
+  it('returns node IDs', () => {
+    const workerEdge = asWorkerAgentEdge(edgeInNetwork, edgeTypeDefinition);
+    expect(workerEdge.from).toEqual(edgeInNetwork.from);
+    expect(workerEdge.to).toEqual(edgeInNetwork.to);
+  });
+
+  it('returns a user-friendly edge type', () => {
+    expect(asWorkerAgentEdge(edgeInNetwork, edgeTypeDefinition).type).toEqual('friend');
   });
 });

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -149,7 +149,7 @@ describe('sessions actions', () => {
       type: actionTypes.UPDATE_NODE,
       sessionId: 'a',
       node: {},
-      additionalAttributes: null,
+      additionalProperties: null,
     };
 
     store.dispatch(actionCreators.updateNode({}));

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -3,14 +3,9 @@
 import faker from 'faker';
 import { times } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
-import { nodeAttributesProperty } from './network';
+import { getNodeWithIdAttributes, nodeAttributesProperty } from './network';
 
 const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
-
-const keyForVarName = (vars, name) => {
-  const entry = Object.entries(vars).find(([, val]) => val.name === name);
-  return entry && entry[0];
-};
 
 const generateNodes = (variableDefs, typeKey, howMany = 0) =>
   (dispatch) => {
@@ -19,16 +14,18 @@ const generateNodes = (variableDefs, typeKey, howMany = 0) =>
       const lastName = faker.name.lastName();
       const age = faker.random.number({ min: 16, max: 99 });
 
-      return dispatch(sessionsActions.addNodes({
+      const mockNode = getNodeWithIdAttributes({
         type: typeKey,
         promptId: 'mock',
         stageId: 'mock',
         [nodeAttributesProperty]: {
-          [keyForVarName(variableDefs, 'name')]: `${firstName} ${lastName}`,
-          [keyForVarName(variableDefs, 'nickname')]: lastName,
-          [keyForVarName(variableDefs, 'age')]: age,
+          name: `${firstName} ${lastName}`,
+          nickname: lastName,
+          age,
         },
-      }));
+      }, variableDefs);
+
+      return dispatch(sessionsActions.addNodes(mockNode));
     });
   };
 

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -3,7 +3,7 @@
 import faker from 'faker';
 import { has, times } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
-import { getNodeWithIdAttributes, nodeAttributesProperty } from './network';
+import { nodeAttributesProperty } from './network';
 
 const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
@@ -33,15 +33,15 @@ const generateNodes = (variableDefs, typeKey, howMany = 0, additionalAttributes 
         return acc;
       }, {});
 
-      return getNodeWithIdAttributes({
-        type: typeKey,
+      return {
         [nodeAttributesProperty]: mockAttrs,
-      }, variableDefs);
+      };
     });
 
     const additionalProperties = {
       promptId: 'mock',
       stageId: 'mock',
+      type: typeKey,
       [nodeAttributesProperty]: additionalAttributes,
     };
 

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -7,22 +7,36 @@ import { getNodeWithIdAttributes, nodeAttributesProperty } from './network';
 
 const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
+const mockCoord = () => faker.random.number({ min: 0, max: 1, precision: 0.000001 });
+
+const mockValue = (nodeVariable) => {
+  switch (nodeVariable.type) {
+    case 'boolean':
+      return faker.random.boolean();
+    case 'number':
+      return faker.random.number({ min: 20, max: 100 });
+    case 'ordinal':
+      return faker.random.arrayElement(nodeVariable.options);
+    case 'layout':
+      return { x: mockCoord(), y: mockCoord() };
+    default: return faker.random.word();
+  }
+};
+
+// TODO: ignore additionalAttributes?
 const generateNodes = (variableDefs, typeKey, howMany = 0) =>
   (dispatch) => {
     const mockNodes = times(howMany, () => {
-      const firstName = faker.name.firstName();
-      const lastName = faker.name.lastName();
-      const age = faker.random.number({ min: 16, max: 99 });
+      const mockAttrs = Object.entries(variableDefs).reduce((acc, [variableId, variable]) => {
+        acc[variableId] = mockValue(variable);
+        return acc;
+      }, {});
 
       return getNodeWithIdAttributes({
         type: typeKey,
         promptId: 'mock',
         stageId: 'mock',
-        [nodeAttributesProperty]: {
-          name: `${firstName} ${lastName}`,
-          nickname: lastName,
-          age,
-        },
+        [nodeAttributesProperty]: mockAttrs,
       }, variableDefs);
     });
 

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import faker from 'faker';
-import { times } from 'lodash';
+import { has, times } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
 import { getNodeWithIdAttributes, nodeAttributesProperty } from './network';
 
@@ -23,24 +23,29 @@ const mockValue = (nodeVariable) => {
   }
 };
 
-// TODO: ignore additionalAttributes?
-const generateNodes = (variableDefs, typeKey, howMany = 0) =>
+const generateNodes = (variableDefs, typeKey, howMany = 0, additionalAttributes = {}) =>
   (dispatch) => {
     const mockNodes = times(howMany, () => {
       const mockAttrs = Object.entries(variableDefs).reduce((acc, [variableId, variable]) => {
-        acc[variableId] = mockValue(variable);
+        if (!has(additionalAttributes, variableId)) {
+          acc[variableId] = mockValue(variable);
+        }
         return acc;
       }, {});
 
       return getNodeWithIdAttributes({
         type: typeKey,
-        promptId: 'mock',
-        stageId: 'mock',
         [nodeAttributesProperty]: mockAttrs,
       }, variableDefs);
     });
 
-    return dispatch(sessionsActions.addNodes(mockNodes));
+    const additionalProperties = {
+      promptId: 'mock',
+      stageId: 'mock',
+      [nodeAttributesProperty]: additionalAttributes,
+    };
+
+    return dispatch(sessionsActions.addNodes(mockNodes, { ...additionalProperties }));
   };
 
 const actionCreators = {

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -9,12 +9,12 @@ const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
 const generateNodes = (variableDefs, typeKey, howMany = 0) =>
   (dispatch) => {
-    times(howMany, () => {
+    const mockNodes = times(howMany, () => {
       const firstName = faker.name.firstName();
       const lastName = faker.name.lastName();
       const age = faker.random.number({ min: 16, max: 99 });
 
-      const mockNode = getNodeWithIdAttributes({
+      return getNodeWithIdAttributes({
         type: typeKey,
         promptId: 'mock',
         stageId: 'mock',
@@ -24,9 +24,9 @@ const generateNodes = (variableDefs, typeKey, howMany = 0) =>
           age,
         },
       }, variableDefs);
-
-      return dispatch(sessionsActions.addNodes(mockNode));
     });
+
+    return dispatch(sessionsActions.addNodes(mockNodes));
   };
 
 const actionCreators = {

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -7,7 +7,12 @@ import { nodeAttributesProperty } from './network';
 
 const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
-const generateNodes = (howMany = 0) =>
+const keyForVarName = (vars, name) => {
+  const entry = Object.entries(vars).find(([, val]) => val.name === name);
+  return entry && entry[0];
+};
+
+const generateNodes = (variableDefs, typeKey, howMany = 0) =>
   (dispatch) => {
     times(howMany, () => {
       const firstName = faker.name.firstName();
@@ -15,15 +20,14 @@ const generateNodes = (howMany = 0) =>
       const age = faker.random.number({ min: 16, max: 99 });
 
       return dispatch(sessionsActions.addNodes({
-        type: 'person',
+        type: typeKey,
         promptId: 'mock',
         stageId: 'mock',
         [nodeAttributesProperty]: {
-          name: `${firstName} ${lastName}`,
-          nickname: lastName,
-          age,
+          [keyForVarName(variableDefs, 'name')]: `${firstName} ${lastName}`,
+          [keyForVarName(variableDefs, 'nickname')]: lastName,
+          [keyForVarName(variableDefs, 'age')]: age,
         },
-        timeCreated: Date.now().toString(),
       }));
     });
   };

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -117,16 +117,16 @@ export const asWorkerAgentEdge = (edge, edgeTypeDefinition) => ({
 /**
  * existingNodes - Existing network.nodes
  * netNodes - nodes to be added to the network
- * additionalAttributes - static props shared to add to each member of newNodes
+ * additionalProperties - static props shared to add to each member of newNodes
 */
-function getNodesWithBatchAdd(existingNodes, newNodes, additionalAttributes = {}) {
+function getNodesWithBatchAdd(existingNodes, newNodes, additionalProperties = {}) {
   // Create a function to create a UUID and merge node attributes
   const withModelandAttributeData = newNode => ({
-    ...additionalAttributes,
+    ...additionalProperties,
     [nodePrimaryKeyProperty]: uuidv4(),
     ...newNode, // second to prevent overwriting existing node UUID (e.g., assigned to externalData)
     [nodeAttributesProperty]: {
-      ...additionalAttributes[nodeAttributesProperty],
+      ...additionalProperties[nodeAttributesProperty],
       ...newNode[nodeAttributesProperty],
     },
   });
@@ -170,7 +170,7 @@ export default function reducer(state = initialState, action = {}) {
     case ADD_NODES: {
       return {
         ...state,
-        nodes: getNodesWithBatchAdd(state.nodes, action.nodes, action.additionalAttributes),
+        nodes: getNodesWithBatchAdd(state.nodes, action.nodes, action.additionalProperties),
       };
     }
     /**
@@ -207,7 +207,7 @@ export default function reducer(state = initialState, action = {}) {
     case UPDATE_NODE: {
       return {
         ...state,
-        nodes: getUpdatedNodes(state.nodes, action.node, action.additionalAttributes),
+        nodes: getUpdatedNodes(state.nodes, action.node, action.additionalProperties),
       };
     }
     case REMOVE_NODE: {

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -44,9 +44,9 @@ export const getNodeAttributes = node => node[nodeAttributesProperty] || {};
 // Returns node data safe to supply to user-defined workers.
 // Contains all user attributes flattened with the node's unique ID.
 // `primaryKeyPropertyForWorker` is used to minimize conflicts, but user data is always preserved.
-export const asWorkerAgentNode = node => ({
+export const asWorkerAgentNode = (node, nodeTypeName) => ({
   [primaryKeyPropertyForWorker]: node[nodePrimaryKeyProperty],
-  [nodeTypePropertyForWorker]: node.type,
+  [nodeTypePropertyForWorker]: nodeTypeName,
   ...getNodeAttributes(node),
 });
 

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -63,6 +63,37 @@ const getNodeAttributesWithNamesResolved = (node, nodeVariableDefs) => {
 };
 
 /**
+ * Given a variable name ("age") and the relevant section of the variable registry, returns the
+ * ID/key for that name.
+ */
+const getVariableIdFromName = (variableName, variableDefs) => {
+  const entry = Object.entries(variableDefs).find(([, variable]) => variable.name === variableName);
+  return entry && entry[0];
+};
+
+/**
+ * The inverse of getNodeAttributesWithNamesResolved
+ */
+export const getNodeWithIdAttributes = (node, nodeVariableDefs) => {
+  if (!nodeVariableDefs) {
+    return {};
+  }
+  const attrs = getNodeAttributes(node);
+  const mappedAttrs = Object.keys(attrs).reduce((acc, varName) => {
+    const variableId = getVariableIdFromName(varName, nodeVariableDefs);
+    if (variableId) {
+      acc[variableId] = attrs[varName];
+    }
+    return acc;
+  }, {});
+
+  return {
+    ...node,
+    [nodeAttributesProperty]: mappedAttrs,
+  };
+};
+
+/**
  * Contains all user attributes flattened with the node's unique ID.
  *
  *`primaryKeyPropertyForWorker` and `nodeTypePropertyForWorker` are used to minimize conflicts,

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -78,6 +78,11 @@ export const asWorkerAgentNode = (node, nodeTypeDefinition) => ({
   ...getNodeAttribtuesWithNamesResolved(node, nodeTypeDefinition && nodeTypeDefinition.variables),
 });
 
+export const asWorkerAgentEdge = (edge, edgeTypeDefinition) => ({
+  ...edge,
+  type: edgeTypeDefinition && edgeTypeDefinition.name,
+});
+
 /**
  * existingNodes - Existing network.nodes
  * netNodes - nodes to be added to the network

--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -49,7 +49,7 @@ export const getNodeAttributes = node => node[nodeAttributesProperty] || {};
  * This resolves those UUIDs to variable names based on the definitions in the variable registry,
  * appropriate for user scripts and export.
  */
-const getNodeAttribtuesWithNamesResolved = (node, nodeVariableDefs) => {
+const getNodeAttributesWithNamesResolved = (node, nodeVariableDefs) => {
   if (!nodeVariableDefs) {
     return {};
   }
@@ -75,7 +75,7 @@ const getNodeAttribtuesWithNamesResolved = (node, nodeVariableDefs) => {
 export const asWorkerAgentNode = (node, nodeTypeDefinition) => ({
   [primaryKeyPropertyForWorker]: node[nodePrimaryKeyProperty],
   [nodeTypePropertyForWorker]: nodeTypeDefinition && nodeTypeDefinition.name,
-  ...getNodeAttribtuesWithNamesResolved(node, nodeTypeDefinition && nodeTypeDefinition.variables),
+  ...getNodeAttributesWithNamesResolved(node, nodeTypeDefinition && nodeTypeDefinition.variables),
 });
 
 export const asWorkerAgentEdge = (edge, edgeTypeDefinition) => ({

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -86,11 +86,14 @@ export default function reducer(state = initialState, action = {}) {
  * Add a node or nodes to the state.
  *
  * @param {Array|Object} nodes - one or more nodes to add
- * @param {Object} [additionalAttributes] shared attributes to apply to every new node
+ * @param {Object} [additionalProperties] shared properties to apply to every new node. Note that
+ *                                        user data (e.g., the "additionalAttributes" defined in
+ *                                        a protocol) should exist under a child property named
+ *                                        'attributes'.
  *
  * @memberof! NetworkActionCreators
  */
-const addNodes = (nodes, additionalAttributes) => (dispatch, getState) => {
+const addNodes = (nodes, additionalProperties) => (dispatch, getState) => {
   const { session } = getState();
 
   let nodeOrNodes = nodes;
@@ -101,18 +104,18 @@ const addNodes = (nodes, additionalAttributes) => (dispatch, getState) => {
     type: ADD_NODES,
     sessionId: session,
     nodes: nodeOrNodes,
-    additionalAttributes,
+    additionalProperties,
   });
 };
 
-const updateNode = (node, additionalAttributes = null) => (dispatch, getState) => {
+const updateNode = (node, additionalProperties = null) => (dispatch, getState) => {
   const { session } = getState();
 
   dispatch({
     type: UPDATE_NODE,
     sessionId: session,
     node,
-    additionalAttributes,
+    additionalProperties,
   });
 };
 

--- a/src/selectors/__tests__/interface.test.js
+++ b/src/selectors/__tests__/interface.test.js
@@ -143,8 +143,8 @@ describe('interface selector', () => {
       expect(selected(null, emptyProps)).toEqual({});
     });
 
-    it('should get node type', () => {
-      const selected = Interface.makeGetNodeType();
+    it('should get subject type', () => {
+      const selected = Interface.makeGetSubjectType();
       expect(selected(mockState, mockProps)).toEqual('person');
     });
 

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -89,8 +89,7 @@ const nodeTypeIsDefined = (variableRegistry, nodeType) =>
   variableRegistry.node &&
   !!variableRegistry.node[nodeType];
 
-// TODO: rename to subjectType?
-export const makeGetNodeType = () => (createSelector(
+export const makeGetSubjectType = () => (createSelector(
   protocolRegistry,
   makeGetSubject(),
   (variableRegistry, subject) => {
@@ -102,7 +101,7 @@ export const makeGetNodeType = () => (createSelector(
 
 export const makeGetNodeDisplayVariable = () => createDeepEqualSelector(
   protocolRegistry,
-  makeGetNodeType(),
+  makeGetSubjectType(),
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].displayVariable;
@@ -111,7 +110,7 @@ export const makeGetNodeDisplayVariable = () => createDeepEqualSelector(
 
 export const makeGetNodeVariables = () => createDeepEqualSelector(
   protocolRegistry,
-  makeGetNodeType(),
+  makeGetSubjectType(),
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].variables;

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -5,7 +5,12 @@ import { findKey, filter, has, isMatch, reject } from 'lodash';
 import { assert, createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
 import { getCurrentSession } from './session';
-import { getNodeAttributes, nodeAttributesProperty, asWorkerAgentNode } from '../ducks/modules/network';
+import {
+  asWorkerAgentEdge,
+  asWorkerAgentNode,
+  getNodeAttributes,
+  nodeAttributesProperty,
+} from '../ducks/modules/network';
 
 // Selectors that are generic between interfaces
 
@@ -46,9 +51,10 @@ export const getWorkerNetwork = createDeepEqualSelector(
   protocolRegistry,
   (nodes = [], edges = [], registry) => {
     const nodeRegistry = registry.node || {};
+    const edgeRegistry = registry.edge || {};
     return ({
       nodes: nodes.map(node => asWorkerAgentNode(node, nodeRegistry[node.type])),
-      edges,
+      edges: edges.map(edge => asWorkerAgentEdge(edge, edgeRegistry[edge.type])),
     });
   },
 );

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -1,10 +1,10 @@
 /* eslint-disable import/prefer-default-export */
 
 import { createSelector } from 'reselect';
-import { findKey, filter, has, isMatch, reject } from 'lodash';
+import { findKey, filter, isMatch, reject } from 'lodash';
 import { assert, createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
-import { getSubject } from '../utils/protocol/accessors';
+import { getAdditionalAttributes, getSubject } from '../utils/protocol/accessors';
 import { getCurrentSession } from './session';
 import {
   asWorkerAgentEdge,
@@ -69,15 +69,7 @@ export const makeGetIds = () =>
 export const makeGetAdditionalAttributes = () =>
   createSelector(
     propStage, propPrompt,
-    (stage, prompt) => {
-      const stageAttributes = (has(stage, 'additionalAttributes') ? stage.additionalAttributes : {});
-      const promptAttributes = (has(prompt, 'additionalAttributes') ? prompt.additionalAttributes : {});
-
-      return {
-        ...stageAttributes,
-        ...promptAttributes,
-      };
-    },
+    (stage, prompt) => getAdditionalAttributes(stage, prompt),
   );
 
 export const makeGetSubject = () =>

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -92,6 +92,7 @@ const nodeTypeIsDefined = (variableRegistry, nodeType) =>
   variableRegistry.node &&
   !!variableRegistry.node[nodeType];
 
+// TODO: Once schema validation is in place, we don't need these asserts.
 export const makeGetSubjectType = () => (createSelector(
   protocolRegistry,
   makeGetSubject(),

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -41,11 +41,19 @@ export const networkEdges = createDeepEqualSelector(
 );
 
 export const getWorkerNetwork = createDeepEqualSelector(
-  networkNodes, networkEdges,
-  (nodes = [], edges = []) => ({
-    nodes: nodes.map(asWorkerAgentNode),
-    edges,
-  }),
+  networkNodes,
+  networkEdges,
+  protocolRegistry,
+  (nodes = [], edges = [], registry) => {
+    const nodeRegistry = registry.node || {};
+    return ({
+      nodes: nodes.map((node) => {
+        const nodeType = nodeRegistry[node.type];
+        return asWorkerAgentNode(node, nodeType && nodeType.name);
+      }),
+      edges,
+    });
+  },
 );
 
 export const makeGetIds = () =>
@@ -81,6 +89,7 @@ const nodeTypeIsDefined = (variableRegistry, nodeType) =>
   variableRegistry.node &&
   !!variableRegistry.node[nodeType];
 
+// TODO: rename to subjectType?
 export const makeGetNodeType = () => (createSelector(
   protocolRegistry,
   makeGetSubject(),

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 import { findKey, filter, has, isMatch, reject } from 'lodash';
 import { assert, createDeepEqualSelector } from './utils';
 import { protocolRegistry } from './protocol';
+import { getSubject } from '../utils/protocol/accessors';
 import { getCurrentSession } from './session';
 import {
   asWorkerAgentEdge,
@@ -82,10 +83,7 @@ export const makeGetAdditionalAttributes = () =>
 export const makeGetSubject = () =>
   createSelector(
     propStage, propPrompt,
-    (stage, prompt) => {
-      if (has(stage, 'subject')) { return stage.subject; }
-      return prompt.subject;
-    },
+    (stage, prompt) => getSubject(stage, prompt),
   );
 
 const nodeTypeIsDefined = (variableRegistry, nodeType) =>
@@ -167,13 +165,12 @@ export const getNodeLabelFunction = createDeepEqualSelector(
  * Get the current prompt/stage subject, and filter the network by this node type.
 */
 
-export const makeNetworkNodesForType = () => {
-  const getSubject = makeGetSubject();
-  return createSelector(
-    networkNodes, getSubject,
+export const makeNetworkNodesForType = () =>
+  createSelector(
+    networkNodes,
+    makeGetSubject(),
     (nodes, subject) => filter(nodes, ['type', subject.type]),
   );
-};
 
 /**
  * makeNetworkNodesForPrompt

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -47,10 +47,7 @@ export const getWorkerNetwork = createDeepEqualSelector(
   (nodes = [], edges = [], registry) => {
     const nodeRegistry = registry.node || {};
     return ({
-      nodes: nodes.map((node) => {
-        const nodeType = nodeRegistry[node.type];
-        return asWorkerAgentNode(node, nodeType && nodeType.name);
-      }),
+      nodes: nodes.map(node => asWorkerAgentNode(node, nodeRegistry[node.type])),
       edges,
     });
   },

--- a/src/selectors/name-generator.js
+++ b/src/selectors/name-generator.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from 'reselect';
 import { has } from 'lodash';
-import { makeGetSubject, makeGetIds, makeGetNodeType, makeGetAdditionalAttributes } from './interface';
+import { makeGetSubject, makeGetIds, makeGetSubjectType, makeGetAdditionalAttributes } from './interface';
 import { nodeAttributesProperty } from '../ducks/modules/network';
 import { protocolRegistry } from './protocol';
 import { getExternalData } from './externalData';
@@ -83,7 +83,7 @@ export const getDataByPrompt = createSelector(
 
 export const makeGetNodeIconName = () => createSelector(
   protocolRegistry,
-  makeGetNodeType(),
+  makeGetSubjectType(),
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].iconVariant;

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -25,6 +25,7 @@ export const getRemoteProtocolId = createDeepEqualSelector(
   remoteName => nameDigest(remoteName) || null,
 );
 
+// The user-defined name of a node type; e.g. `variableRegistry.node[uuid].name == 'person'`
 export const makeGetNodeTypeName = () => createDeepEqualSelector(
   protocolRegistry,
   (state, props) => props.type,

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -30,7 +30,7 @@ export const makeGetNodeTypeDefinition = () => createDeepEqualSelector(
   protocolRegistry,
   (state, props) => props.type,
   (variableRegistry, nodeType) => {
-    const nodeInfo = variableRegistry.node;
+    const nodeInfo = variableRegistry && variableRegistry.node;
     return nodeInfo && nodeInfo[nodeType];
   },
 );

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -25,6 +25,15 @@ export const getRemoteProtocolId = createDeepEqualSelector(
   remoteName => nameDigest(remoteName) || null,
 );
 
+export const makeGetNodeTypeName = () => createDeepEqualSelector(
+  protocolRegistry,
+  (state, props) => props.type,
+  (variableRegistry, nodeType) => {
+    const nodeInfo = variableRegistry.node;
+    return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].name;
+  },
+);
+
 export const makeGetNodeColor = () => createDeepEqualSelector(
   protocolRegistry,
   (state, props) => props.type,

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -26,12 +26,12 @@ export const getRemoteProtocolId = createDeepEqualSelector(
 );
 
 // The user-defined name of a node type; e.g. `variableRegistry.node[uuid].name == 'person'`
-export const makeGetNodeTypeName = () => createDeepEqualSelector(
+export const makeGetNodeTypeDefinition = () => createDeepEqualSelector(
   protocolRegistry,
   (state, props) => props.type,
   (variableRegistry, nodeType) => {
     const nodeInfo = variableRegistry.node;
-    return nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].name;
+    return nodeInfo && nodeInfo[nodeType];
   },
 );
 

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 
 import uuidv4 from '../utils/uuid';
 import { currentStageIndex } from '../utils/matchSessionPath';
+import { getSubject } from '../utils/protocol/accessors';
 import { initialState } from '../ducks/modules/session';
 import { protocolRegistry } from './protocol';
 
@@ -54,8 +55,7 @@ export const getNodeEntryForCurrentPrompt = createSelector(
     if (!registry || !prompt || !stage) {
       return null;
     }
-    // TODO: refactor with makeGetSubject
-    const subject = stage.subject || prompt.subject;
+    const subject = getSubject(stage, prompt);
     const nodeType = subject && subject.type;
     // TODO: need nodeTypeName? Simplify?
     const nodeEntries = registry && registry.node && Object.entries(registry.node);

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -2,7 +2,9 @@
 import { createSelector } from 'reselect';
 
 import uuidv4 from '../utils/uuid';
+import { currentStageIndex } from '../utils/matchSessionPath';
 import { initialState } from '../ducks/modules/session';
+import { protocolRegistry } from './protocol';
 
 const DefaultFinishStage = {
   // `id` is used as component key; must be unique from user input
@@ -12,17 +14,55 @@ const DefaultFinishStage = {
 };
 
 const protocol = state => state.protocol;
-const withFinishStage = stages => (stages.length ? [...stages, DefaultFinishStage] : []);
+const currentPathname = router => router && router.location && router.location.pathname;
+const stageIndexForCurrentSession = state => currentStageIndex(currentPathname(state.router));
+const withFinishStage = stages => (stages && stages.length ? [...stages, DefaultFinishStage] : []);
 
 export const getCurrentSession = state => state.sessions[state.session];
 export const anySessionIsActive = state => state.session && state.session !== initialState;
 
+export const stages = createSelector(
+  protocol,
+  protocol => withFinishStage(protocol.stages),
+);
+
+export const getStageForCurrentSession = createSelector(
+  stages,
+  stageIndexForCurrentSession,
+  (stages, stageIndex) => stages[stageIndex],
+);
+
+// TODO: naming
 export const getPromptForCurrentSession = createSelector(
   state => (state.sessions[state.session] && state.sessions[state.session].promptIndex) || 0,
   promptIndex => promptIndex,
 );
 
-export const stages = createSelector(
-  protocol,
-  protocol => withFinishStage(protocol.stages),
+export const getPromptObjectForCurrentSession = createSelector(
+  getStageForCurrentSession,
+  getPromptForCurrentSession,
+  (stage, promptIndex) => stage && stage.prompts && stage.prompts[promptIndex],
+);
+
+// @return {Array} An object entry ([key, object]) for the current node type
+//  from the variable registry
+export const getNodeEntryForCurrentPrompt = createSelector(
+  protocolRegistry,
+  getPromptObjectForCurrentSession,
+  getStageForCurrentSession,
+  (registry, prompt, stage) => {
+    if (!registry || !prompt || !stage) {
+      return null;
+    }
+    // TODO: refactor with makeGetSubject
+    const subject = stage.subject || prompt.subject;
+    const nodeType = subject && subject.type;
+    // TODO: need nodeTypeName? Simplify?
+    const nodeEntries = registry && registry.node && Object.entries(registry.node);
+    const entry = nodeEntries && nodeEntries.find(([key]) => key === nodeType);
+    if (!entry || entry.length !== 2) {
+      return null;
+    }
+    return entry;
+  },
 );

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 
 import uuidv4 from '../utils/uuid';
 import { currentStageIndex } from '../utils/matchSessionPath';
-import { getSubject } from '../utils/protocol/accessors';
+import { getAdditionalAttributes, getSubject } from '../utils/protocol/accessors';
 import { initialState } from '../ducks/modules/session';
 import { protocolRegistry } from './protocol';
 
@@ -63,4 +63,10 @@ export const getNodeEntryForCurrentPrompt = createSelector(
     }
     return null;
   },
+);
+
+export const getAdditionalAttributesForCurrentPrompt = createSelector(
+  getPromptObjectForCurrentSession,
+  getStageForCurrentSession,
+  (prompt, stage) => getAdditionalAttributes(stage, prompt),
 );

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -52,17 +52,15 @@ export const getNodeEntryForCurrentPrompt = createSelector(
   getPromptObjectForCurrentSession,
   getStageForCurrentSession,
   (registry, prompt, stage) => {
-    if (!registry || !prompt || !stage) {
+    if (!registry || !registry.node || !prompt || !stage) {
       return null;
     }
     const subject = getSubject(stage, prompt);
     const nodeType = subject && subject.type;
-    // TODO: need nodeTypeName? Simplify?
-    const nodeEntries = registry && registry.node && Object.entries(registry.node);
-    const entry = nodeEntries && nodeEntries.find(([key]) => key === nodeType);
-    if (!entry || entry.length !== 2) {
-      return null;
+    const nodeTypeDefinition = nodeType && registry.node[nodeType];
+    if (nodeTypeDefinition) {
+      return [nodeType, nodeTypeDefinition];
     }
-    return entry;
+    return null;
   },
 );

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -33,15 +33,14 @@ export const getStageForCurrentSession = createSelector(
   (stages, stageIndex) => stages[stageIndex],
 );
 
-// TODO: naming
-export const getPromptForCurrentSession = createSelector(
+export const getPromptIndexForCurrentSession = createSelector(
   state => (state.sessions[state.session] && state.sessions[state.session].promptIndex) || 0,
   promptIndex => promptIndex,
 );
 
-export const getPromptObjectForCurrentSession = createSelector(
+const getPromptForCurrentSession = createSelector(
   getStageForCurrentSession,
-  getPromptForCurrentSession,
+  getPromptIndexForCurrentSession,
   (stage, promptIndex) => stage && stage.prompts && stage.prompts[promptIndex],
 );
 
@@ -49,7 +48,7 @@ export const getPromptObjectForCurrentSession = createSelector(
 //  from the variable registry
 export const getNodeEntryForCurrentPrompt = createSelector(
   protocolRegistry,
-  getPromptObjectForCurrentSession,
+  getPromptForCurrentSession,
   getStageForCurrentSession,
   (registry, prompt, stage) => {
     if (!registry || !registry.node || !prompt || !stage) {
@@ -66,7 +65,7 @@ export const getNodeEntryForCurrentPrompt = createSelector(
 );
 
 export const getAdditionalAttributesForCurrentPrompt = createSelector(
-  getPromptObjectForCurrentSession,
+  getPromptForCurrentSession,
   getStageForCurrentSession,
   (prompt, stage) => getAdditionalAttributes(stage, prompt),
 );

--- a/src/utils/matchSessionPath.js
+++ b/src/utils/matchSessionPath.js
@@ -17,7 +17,16 @@ const protocolIdFromSessionPath = (pathname) => {
   return pathInfo && pathInfo.params[ProtocolIdKey];
 };
 
+const currentStageIndex = (path) => {
+  const matchedPath = matchSessionPath(path);
+  if (matchedPath) {
+    return parseInt(matchedPath.params.stageIndex, 10);
+  }
+  return 0;
+};
+
 export {
+  currentStageIndex,
   matchSessionPath,
   protocolIdFromSessionPath,
 };

--- a/src/utils/protocol/accessors.js
+++ b/src/utils/protocol/accessors.js
@@ -1,0 +1,7 @@
+import { has } from 'lodash';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getSubject = (stage, prompt) => {
+  if (has(stage, 'subject')) { return stage.subject; }
+  return prompt.subject;
+};

--- a/src/utils/protocol/accessors.js
+++ b/src/utils/protocol/accessors.js
@@ -1,7 +1,16 @@
 import { has } from 'lodash';
 
-// eslint-disable-next-line import/prefer-default-export
 export const getSubject = (stage, prompt) => {
   if (has(stage, 'subject')) { return stage.subject; }
   return prompt.subject;
+};
+
+export const getAdditionalAttributes = (stage, prompt) => {
+  const stageAttributes = (has(stage, 'additionalAttributes') ? stage.additionalAttributes : {});
+  const promptAttributes = (has(prompt, 'additionalAttributes') ? prompt.additionalAttributes : {});
+
+  return {
+    ...stageAttributes,
+    ...promptAttributes,
+  };
 };


### PR DESCRIPTION
This fixes the node information sent to worker label scripts; for example, from:

```json
{
    "0e75ec18-2cb1-4606-9f18-034d28b07c19": "Dee",
    "networkCanvasType": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466"
}
```

to:
```json
{
    "name": "Dee",
    "networkCanvasType": "person",
}
```

Also fixes both node & edge information in the network passed to workers.

To test, you can replace the development protocol with [one that uses ID keys](https://raw.githubusercontent.com/codaco/Network-Canvas/chore/dynamic-validation/public/protocols/development.netcanvas/protocol.json).

Fixes #771. Fixes #719.