### PR TITLE
Fix autocomplete styling & animations

### DIFF
--- a/src/containers/Search/Search.js
+++ b/src/containers/Search/Search.js
@@ -153,9 +153,9 @@ class Search extends Component {
         (prompt === SelectPrompt && !hasInput)) {
         hiddenClass = `${HeaderClass}--hidden`;
       }
-      return (<h1 className={`${HeaderClass} ${hiddenClass}`} key={`${HeaderClass}${i}`}>
+      return (<h2 className={`${HeaderClass} ${hiddenClass}`} key={`${HeaderClass}${i}`}>
         {prompt}
-      </h1>);
+      </h2>);
     });
 
 

--- a/src/styles/components/_add-count-button.scss
+++ b/src/styles/components/_add-count-button.scss
@@ -1,6 +1,6 @@
-$add-count-button-height: 7rem;
-$add-count-button-inner-size: 5rem; // width of the core circle (without badge)
+$add-count-button-height: 6rem;
 $add-count-button-width: 7rem;
+$add-count-button-inner-size: $add-count-button-width * .8; // width of the core circle (without badge)
 $module-name: add-count-button;
 
 // Provides alternate colors (e.g., to represent different node types)
@@ -23,10 +23,9 @@ $module-name: add-count-button;
   font-size: 3rem;
   font-weight: 500;
   height: $add-count-button-height;
-  line-height: 1.6;
+  padding-bottom: 0;
   padding-left: 0;
   padding-right: $add-count-button-width - $add-count-button-inner-size;
-  padding-top: $add-count-button-height - $add-count-button-inner-size;
   text-align: center;
   text-indent: 0; // override svg-button text hiding
   width: $add-count-button-width;

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -30,10 +30,16 @@ $results-height: calc(100vh - 23rem);
   }
 
   &__close-button {
+    margin: 1rem;
     position: absolute;
     right: 0;
     top: 0;
     z-index: 1;
+
+    &[name='close'] { // specificity needed to override NC-UI
+      height: 1rem;
+      width: 1rem;
+    }
   }
 
   &__content {

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -7,6 +7,7 @@ $results-height: calc(100vh - 23rem);
 
 .#{$module-name} {
   --border-radius: var(--border-radius);
+  --collapsed-square-size-js: 6.5rem;
   --content-padding: 1rem;
 
   background-color: color('cyber-grape');

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -6,7 +6,6 @@ $results-height: calc(100vh - 23rem);
 @include text-input('#{$module-name}__input');
 
 .#{$module-name} {
-  --border-radius: var(--border-radius);
   --collapsed-square-size-js: 6.5rem;
   --content-padding: 1rem;
 

--- a/src/styles/containers/_name-generator-auto-complete-interface.scss
+++ b/src/styles/containers/_name-generator-auto-complete-interface.scss
@@ -15,13 +15,13 @@ $search-z-index: var(--z-global-ui);
   }
 
   &__search {
-    --right-collapsed: 3rem; // align with 'core' of button
+    --right-collapsed-js: 3rem; // align with 'core' of button
     --right-offset: var(--timeline-width); // margin equal to left menu width
 
     // Position collapsed search element around the 'core' of the icon
     bottom: $search-icon-offset-y;
     right: var(--right-offset);
-    width: calc(100% - calc(var(--right-offset)*2));
+    width: calc(100% - calc(var(--right-offset)*2) - var(--timeline-width));
     z-index: $search-z-index;
   }
 


### PR DESCRIPTION
This fixes the styling and animation problems described in #722, though I'll leave that open since discussion has started around a redesign there.

This also adjusts the width of the Search component to match the centering of other prompt content.