### PR TITLE
Specify "submit" on default form button

### DIFF
--- a/src/containers/Form.js
+++ b/src/containers/Form.js
@@ -80,7 +80,7 @@ Form.propTypes = {
 Form.defaultProps = {
   autoFocus: false,
   autoPopulate: null,
-  controls: [<Button key="submit" aria-label="Submit">Submit</Button>],
+  controls: [<Button type="submit" key="submit" aria-label="Submit">Submit</Button>],
   className: null,
   tooltip: 'none',
 };
@@ -107,3 +107,7 @@ export default compose(
     touchOnBlur: false,
   }),
 )(Form);
+
+export {
+  Form,
+};

--- a/src/containers/NodeForm.js
+++ b/src/containers/NodeForm.js
@@ -55,7 +55,7 @@ class NodeForm extends Component {
           onCheck={this.onToggleClick}
           inline
         />),
-        <Button key="submit" aria-label="Submit">Finished</Button>,
+        <Button type="submit" key="submit" aria-label="Submit">Finished</Button>,
       ].filter(notEmpty),
       form: reduxFormName,
     };

--- a/src/containers/__tests__/Form.test.js
+++ b/src/containers/__tests__/Form.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
-import Form from '../Form';
+import Form, { Form as UnconnectedForm } from '../Form';
 import Field from '../Field';
 
 jest.mock('../../utils/CSSVariables');
@@ -88,4 +88,9 @@ describe('<Form />', () => {
     expect(subject.find('input[type="hidden"]').length).toBe(1);
   });
   it('Calls autoPopulate on Field blur');
+
+  it('renders a submit button control by default', () => {
+    const subject = shallow(<UnconnectedForm {...props()} />);
+    expect(subject.find('Button').prop('type')).toEqual('submit');
+  });
 });


### PR DESCRIPTION
In NC-UI, a `Button`'s type now defaults to "button". This PR ensures the NodeForm will still be submittable once that UI change is included.