### PR TITLE
Ensure device is defined before reading

### DIFF
--- a/src/ducks/modules/deviceSettings.js
+++ b/src/ducks/modules/deviceSettings.js
@@ -11,7 +11,7 @@ const initialState = {
   // useFullScrenForms should be false for most larger devices, and true for most tablets
   useFullScreenForms: !(window.matchMedia('screen and (min-device-aspect-ratio: 8/5), (min-device-height: 1800px)').matches),
   // Disable dynamic scaling on android because vmin is resized by software keyboard
-  useDynamicScaling: !(isCordova() && device.platform === 'Android'),
+  useDynamicScaling: !(isCordova() && typeof device !== 'undefined' && device.platform === 'Android'),
   interfaceScale: 100,
 };
 

--- a/src/utils/DeviceInfo.js
+++ b/src/utils/DeviceInfo.js
@@ -59,11 +59,13 @@ const iosDescription = () => {
 };
 
 const deviceDescription = () => {
-  if (isCordova() && device.platform === 'iOS') {
-    return iosDescription();
-  }
-  if (isCordova() && device.platform === 'Android') {
-    return androidDescription();
+  if (isCordova() && typeof device !== 'undefined') {
+    if (device.platform === 'iOS') {
+      return iosDescription();
+    }
+    if (device.platform === 'Android') {
+      return androidDescription();
+    }
   }
   if (isElectron()) {
     return electronDescription();


### PR DESCRIPTION
'device' may not be ready until after store is created. In this case, the device will now have an 'Undefined' name (and Android may use dynamic scaling by default).

This is an interim fix for #787 to prevent throwing. The actual desired behavior would be to ensure device settings is populated with correct values.

We could dispatch an 'initialized' event from `startApp`, but it's possible that would fire after rehydration, in which case we might overwrite user preferences. So we'll either need to change when the store is initialized, or treat anything matching a static initialState as not user-set.