### PR TITLE
Fix device settings on startup

### DIFF
--- a/src/containers/LoadParamsRoute.js
+++ b/src/containers/LoadParamsRoute.js
@@ -5,7 +5,7 @@ import { bindActionCreators, compose } from 'redux';
 import { Redirect } from 'react-router-dom';
 
 import { actionCreators as protocolActions } from '../ducks/modules/protocol';
-import { actionCreators as rootActions } from '../ducks/modules/rootReducer';
+import { actionCreators as resetActions } from '../ducks/modules/reset';
 import { actionCreators as sessionActions } from '../ducks/modules/session';
 import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
 import { getNextIndex, isStageSkipped } from '../selectors/skip-logic';
@@ -152,7 +152,7 @@ function mapDispatchToProps(dispatch) {
   return {
     loadFactoryProtocol: bindActionCreators(protocolActions.loadFactoryProtocol, dispatch),
     loadProtocol: bindActionCreators(protocolActions.loadProtocol, dispatch),
-    resetState: bindActionCreators(rootActions.resetState, dispatch),
+    resetState: bindActionCreators(resetActions.resetAppState, dispatch),
     setSession: bindActionCreators(sessionActions.setSession, dispatch),
     updateSession: bindActionCreators(sessionsActions.updateSession, dispatch),
   };

--- a/src/ducks/modules/__tests__/deviceSettings.test.js
+++ b/src/ducks/modules/__tests__/deviceSettings.test.js
@@ -4,7 +4,7 @@ import reducer, { actionCreators, actionTypes } from '../deviceSettings';
 const initialState = {
   description: 'Unknown device',
   useFullScreenForms: true,
-  useDynamicScaling: true,
+  useDynamicScaling: undefined,
   interfaceScale: 100,
 };
 const mockDescription = 'My Android Tablet';
@@ -25,7 +25,8 @@ describe('deviceSettings reducer', () => {
   it('should toggle a device setting', () => {
     const reduced = reducer(initialState,
       { type: actionTypes.TOGGLE_SETTING, item: mockSettingToToggle });
-    expect(reduced).toEqual({ ...initialState, [mockSettingToToggle]: false });
+    expect(reduced).toEqual({ ...initialState,
+      [mockSettingToToggle]: !initialState[mockSettingToToggle] });
   });
 
   it('should set an interface scale', () => {

--- a/src/ducks/modules/__tests__/deviceSettings.test.js
+++ b/src/ducks/modules/__tests__/deviceSettings.test.js
@@ -16,6 +16,26 @@ describe('deviceSettings reducer', () => {
     expect(reducer(undefined, {})).toEqual(initialState);
   });
 
+  describe('Cordova', () => {
+    beforeEach(() => {
+      global.cordova = {};
+    });
+
+    it('provides better Android defaults after device_ready', () => {
+      global.device = { platform: 'Android', isVirtual: true };
+      const newState = reducer(initialState, { type: actionTypes.DEVICE_READY });
+      expect(newState.description).toMatch('Android');
+      expect(newState.useDynamicScaling).toBe(false);
+    });
+
+    it('provides better iOS defaults after device_ready', () => {
+      global.device = { platform: 'iOS', isVirtual: true };
+      const newState = reducer(initialState, { type: actionTypes.DEVICE_READY });
+      expect(newState.description).toMatch('iOS');
+      expect(newState.useDynamicScaling).toBe(true);
+    });
+  });
+
   it('should return a device description', () => {
     const reduced = reducer(initialState,
       { type: actionTypes.SET_DESCRIPTION, description: mockDescription });

--- a/src/ducks/modules/deviceSettings.js
+++ b/src/ducks/modules/deviceSettings.js
@@ -87,6 +87,7 @@ const actionCreators = {
 };
 
 const actionTypes = {
+  DEVICE_READY,
   SET_DESCRIPTION,
   SET_INTERFACE_SCALE,
   TOGGLE_SETTING,

--- a/src/ducks/modules/deviceSettings.js
+++ b/src/ducks/modules/deviceSettings.js
@@ -1,6 +1,4 @@
-/* globals device */
-import deviceDescription from '../../utils/DeviceInfo';
-import { isCordova } from '../../utils/Environment';
+import { deviceDescription, shouldUseDynamicScaling } from '../../utils/DeviceInfo';
 
 const SET_DESCRIPTION = 'SETTINGS/SET_DESCRIPTION';
 const SET_INTERFACE_SCALE = 'SETTINGS/SET_INTERFACE_SCALE';
@@ -26,8 +24,7 @@ const getDeviceReadyState = (state) => {
     description = deviceDescription();
   }
   if (useDynamicScaling === initialState.useDynamicScaling) {
-    // Disable dynamic scaling on android because vmin is resized by software keyboard
-    useDynamicScaling = !(isCordova() && typeof device !== 'undefined' && device.platform === 'Android');
+    useDynamicScaling = shouldUseDynamicScaling();
   }
   return {
     ...state,

--- a/src/ducks/modules/deviceSettings.js
+++ b/src/ducks/modules/deviceSettings.js
@@ -5,18 +5,41 @@ import { isCordova } from '../../utils/Environment';
 const SET_DESCRIPTION = 'SETTINGS/SET_DESCRIPTION';
 const SET_INTERFACE_SCALE = 'SETTINGS/SET_INTERFACE_SCALE';
 const TOGGLE_SETTING = 'SETTINGS/TOGGLE_SETTING';
+const DEVICE_READY = 'DEVICE_READY';
 
+// getDeviceReadyState() may provide better defaults once more is known about the device.
+// Static defaults should be distinguishable from user choices (e.g., undefined instead of false).
 const initialState = {
-  description: deviceDescription(),
+  description: 'Unknown device',
+  useDynamicScaling: undefined,
   // useFullScrenForms should be false for most larger devices, and true for most tablets
   useFullScreenForms: !(window.matchMedia('screen and (min-device-aspect-ratio: 8/5), (min-device-height: 1800px)').matches),
-  // Disable dynamic scaling on android because vmin is resized by software keyboard
-  useDynamicScaling: !(isCordova() && typeof device !== 'undefined' && device.platform === 'Android'),
   interfaceScale: 100,
+};
+
+// This provides additional default state based on information unavailable before 'deviceready'.
+// Rehydration may occur before this, so only overwrite static default values.
+const getDeviceReadyState = (state) => {
+  let description = state.description;
+  let useDynamicScaling = state.useDynamicScaling;
+  if (description === initialState.description) {
+    description = deviceDescription();
+  }
+  if (useDynamicScaling === initialState.useDynamicScaling) {
+    // Disable dynamic scaling on android because vmin is resized by software keyboard
+    useDynamicScaling = !(isCordova() && typeof device !== 'undefined' && device.platform === 'Android');
+  }
+  return {
+    ...state,
+    description,
+    useDynamicScaling,
+  };
 };
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
+    case DEVICE_READY:
+      return getDeviceReadyState(state);
     case SET_DESCRIPTION:
       return {
         ...state,
@@ -37,6 +60,10 @@ export default function reducer(state = initialState, action = {}) {
   }
 }
 
+const deviceReady = () => ({
+  type: DEVICE_READY,
+});
+
 const setDescription = description => ({
   type: SET_DESCRIPTION,
   description,
@@ -53,6 +80,7 @@ const toggleSetting = item => ({
 });
 
 const actionCreators = {
+  deviceReady,
   setDescription,
   setInterfaceScale,
   toggleSetting,

--- a/src/ducks/modules/reset.js
+++ b/src/ducks/modules/reset.js
@@ -30,6 +30,9 @@ const resetEdgesOfType = edgeType =>
 
 const resetAppState = () => (dispatch) => {
   dispatch({ type: RESET_STATE });
+  // Dispatch deviceReady to re-populate any device defaults.
+  // On Cordova, reset is guaranteed to happen after 'deviceready';
+  // on other platforms, it's safe to call at any time (even after page load).
   dispatch(deviceActions.deviceReady());
 };
 

--- a/src/ducks/modules/reset.js
+++ b/src/ducks/modules/reset.js
@@ -1,8 +1,9 @@
 import { omit } from 'lodash';
 import { actionCreators as sessionsActions } from './sessions';
 import { nodeAttributesProperty } from './network';
+import { actionCreators as deviceActions } from './deviceSettings';
 
-
+const RESET_STATE = 'RESET_STATE';
 const RESET_EDGES_OF_TYPE = 'RESET/EDGES_OF_TYPE';
 const RESET_PROPERTY_FOR_ALL_NODES = 'RESET/PROPERTY_FOR_ALL_NODES';
 
@@ -27,12 +28,19 @@ const resetEdgesOfType = edgeType =>
     });
   };
 
+const resetAppState = () => (dispatch) => {
+  dispatch({ type: RESET_STATE });
+  dispatch(deviceActions.deviceReady());
+};
+
 const actionCreators = {
+  resetAppState,
   resetEdgesOfType,
   resetPropertyForAllNodes,
 };
 
 const actionTypes = {
+  RESET_STATE,
   RESET_EDGES_OF_TYPE,
   RESET_PROPERTY_FOR_ALL_NODES,
 };

--- a/src/ducks/modules/rootReducer.js
+++ b/src/ducks/modules/rootReducer.js
@@ -12,12 +12,7 @@ import dialogs from './dialogs';
 import search from './search';
 import ui from './ui';
 import pairedServer from './pairedServer';
-
-const RESET_STATE = 'RESET_STATE';
-
-const resetState = () => ({
-  type: RESET_STATE,
-});
+import { actionTypes as resetActionTypes } from './reset';
 
 const appReducer = combineReducers({
   router: routerReducer,
@@ -37,19 +32,11 @@ const appReducer = combineReducers({
 const rootReducer = (state, action) => {
   let currentState = state;
 
-  if (action.type === RESET_STATE) {
+  if (action.type === resetActionTypes.RESET_STATE) {
     currentState = undefined;
   }
 
   return appReducer(currentState, action);
-};
-
-export const actionCreators = {
-  resetState,
-};
-
-export const actionTypes = {
-  RESET_STATE,
 };
 
 export default rootReducer;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'react-router-redux';
 
 import { history, store } from './ducks/store';
+import { actionCreators } from './ducks/modules/deviceSettings';
 import App from './containers/App';
 import { isCordova, isElectron } from './utils/Environment';
 import AppRouter from './routes';
@@ -20,6 +21,8 @@ document.addEventListener('dragover', (e) => {
 });
 
 const startApp = () => {
+  store.dispatch(actionCreators.deviceReady());
+
   ReactDOM.render(
     <Provider store={store}>
       <ConnectedRouter history={history}>

--- a/src/utils/DeviceInfo.js
+++ b/src/utils/DeviceInfo.js
@@ -59,13 +59,11 @@ const iosDescription = () => {
 };
 
 const deviceDescription = () => {
-  if (isCordova() && typeof device !== 'undefined') {
-    if (device.platform === 'iOS') {
-      return iosDescription();
-    }
-    if (device.platform === 'Android') {
-      return androidDescription();
-    }
+  if (isCordova() && device.platform === 'iOS') {
+    return iosDescription();
+  }
+  if (isCordova() && device.platform === 'Android') {
+    return androidDescription();
   }
   if (isElectron()) {
     return electronDescription();
@@ -73,4 +71,12 @@ const deviceDescription = () => {
   return 'Unknown device';
 };
 
+// Disable dynamic scaling on android because vmin is resized by software keyboard
+const shouldUseDynamicScaling = () => !(isCordova() && device.platform === 'Android');
+
 export default deviceDescription;
+
+export {
+  deviceDescription,
+  shouldUseDynamicScaling,
+};


### PR DESCRIPTION
Fixes #787. This is a follow-up to #788. Rather than creating the store & reducers lazily, I've taken the second approach described in 788.

- initialState is statically determined
- a `deviceReady` action is dispatched prior to `ReactDOM.render` to set better defaults based on runtime info
- Does not interfere with rehydration or user settings

The lazy creation approach should work fine, but this seemed slightly preferable to me.