### PR TITLE
Do not require additionalProperties for cards

### DIFF
--- a/scripts/schema/generate-schema.js
+++ b/scripts/schema/generate-schema.js
@@ -202,6 +202,7 @@ const generateSchema = async () => {
       then: { required: ['value'] }, // in addition to props which are always required
     },
   ];
+
   // These need not be UUIDs
   delete defs.Options.properties.type.format;
   delete defs.Options.properties.attribute.format;
@@ -220,6 +221,7 @@ const generateSchema = async () => {
   // need actual review...
   pull(defs.Item.required, 'size');
   pull(defs.Highlight.required, 'allowHighlighting');
+  pull(defs.CardOptions.required, 'additionalProperties');
 
   fs.writeFileSync(schemaFile, JSON.stringify(schema, null, 2));
 

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -508,7 +508,6 @@
         }
       },
       "required": [
-        "additionalProperties",
         "displayLabel"
       ],
       "title": "CardOptions"


### PR DESCRIPTION
Subtask from #785. CardOptions [should not require additionalProperties](https://github.com/codaco/Network-Canvas/wiki/Name-Generator:-Roster-List#interface-specific-api). Architect behaves correctly in https://github.com/codaco/Architect/pull/338.