### PR TITLE
Fix/categorical bin formatting

### DIFF
--- a/src/containers/CategoricalList.js
+++ b/src/containers/CategoricalList.js
@@ -102,6 +102,10 @@ class CategoricalList extends Component {
       'categorical-list__content',
       { 'categorical-list__content--expanded': this.state.expandedBinValue },
     );
+    const styleNames = { '--num-categorical-items': this.props.bins.length };
+    if (this.props.bins.length < 4) {
+      styleNames['--categorical-item-multiplier'] = 1.2;
+    }
 
     return (
       <Flipper flipKey={this.state.expandedBinValue} className="categorical-list">
@@ -118,7 +122,7 @@ class CategoricalList extends Component {
           </div>
           <div
             className={classNames}
-            style={{ '--num-categorical-items': this.props.bins.length }}
+            style={styleNames}
           >
             {this.props.bins.map(this.renderCategoricalBin).filter((bin, index) =>
               this.props.bins[index].value !== this.state.expandedBinValue,

--- a/src/containers/Interfaces/CategoricalBin.js
+++ b/src/containers/Interfaces/CategoricalBin.js
@@ -39,6 +39,7 @@ const CategoricalBin = ({
           sortOrder={prompt.bucketSortOrder}
         />
       </div>
+      <hr />
       <CategoricalList key={prompt.id} stage={stage} prompt={prompt} />
     </div>
   );

--- a/src/containers/Interfaces/__tests__/CategoricalBin.test.js
+++ b/src/containers/Interfaces/__tests__/CategoricalBin.test.js
@@ -15,7 +15,7 @@ describe('CategoricalBin', () => {
   it('renders CategoricalBin interface', () => {
     const component = shallow(<CategoricalBin {...requiredProps} />);
     expect(component.find('.categorical-bin-interface')).toHaveLength(1);
-    expect(component.find('.categorical-bin-interface').children()).toHaveLength(3);
+    expect(component.find('.categorical-bin-interface').children()).toHaveLength(4);
     expect(component.find('.categorical-bin-interface__prompt')).toHaveLength(1);
     expect(component.find('.categorical-bin-interface__bucket')).toHaveLength(1);
   });

--- a/src/containers/__tests__/__snapshots__/CategoricalList.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/CategoricalList.test.js.snap
@@ -68,6 +68,7 @@ ShallowWrapper {
           className="categorical-list__content"
           style={
             Object {
+              "--categorical-item-multiplier": 1.2,
               "--num-categorical-items": 2,
             }
           }
@@ -125,6 +126,7 @@ ShallowWrapper {
             className="categorical-list__content"
             style={
               Object {
+                "--categorical-item-multiplier": 1.2,
                 "--num-categorical-items": 2,
               }
             }
@@ -228,6 +230,7 @@ ShallowWrapper {
             ],
             "className": "categorical-list__content",
             "style": Object {
+              "--categorical-item-multiplier": 1.2,
               "--num-categorical-items": 2,
             },
           },
@@ -309,6 +312,7 @@ ShallowWrapper {
             className="categorical-list__content"
             style={
               Object {
+                "--categorical-item-multiplier": 1.2,
                 "--num-categorical-items": 2,
               }
             }
@@ -366,6 +370,7 @@ ShallowWrapper {
               className="categorical-list__content"
               style={
                 Object {
+                  "--categorical-item-multiplier": 1.2,
                   "--num-categorical-items": 2,
                 }
               }
@@ -469,6 +474,7 @@ ShallowWrapper {
               ],
               "className": "categorical-list__content",
               "style": Object {
+                "--categorical-item-multiplier": 1.2,
                 "--num-categorical-items": 2,
               },
             },

--- a/src/styles/components/_categorical-item.scss
+++ b/src/styles/components/_categorical-item.scss
@@ -1,7 +1,6 @@
 .categorical-item {
-  --categorical-item-margin: .5rem;
   --categorical-item-color: var(--primary);
-  --categorical-item-size: calc(.8 * var(--categorical-available-height) / var(--num-categorical-rows));
+  --categorical-item-size: calc(var(--categorical-item-multiplier) * var(--categorical-available-height) / var(--num-categorical-rows));
   @include transition-properties((background-color width height margin), var(--animation-easing), var(--animation-duration-standard));
 
   display: flex;
@@ -16,7 +15,6 @@
     &:not(.categorical-item--hover) {
       &:not(.categorical-item--expanded) {
         background-color: var(--categorical-item-color);
-        transition: background-color var(--animation-duration-standard) var(--animation-easing);
       }
     }
   }
@@ -24,9 +22,9 @@
   &--hover {
     @include transition-properties((background-color width height margin), var(--animation-easing), var(--animation-duration-standard));
     background-color: var(--categorical-item-color);
-    height: calc((var(--categorical-available-height) / var(--num-categorical-rows)) + (var(--categorical-item-margin) * 2));
+    height: calc(var(--categorical-item-size) + (var(--categorical-item-margin) * 2));
     margin: 0;
-    width: calc((var(--categorical-available-height) / var(--num-categorical-rows)) + (var(--categorical-item-margin) * 2));
+    width: calc(var(--categorical-item-size) + (var(--categorical-item-margin) * 2));
   }
 
   &__title {
@@ -68,6 +66,11 @@
       height: calc(var(--categorical-available-height) + (var(--categorical-item-margin) * 2));
       margin: 0;
       width: calc(var(--categorical-available-height) + (var(--categorical-item-margin) * 2));
+      
+      .categorical-item__content {
+        padding: 1rem 2rem;
+        transition: padding var(--animation-duration-standard) var(--animation-easing);
+      }
     }
 
     .categorical-item__title,
@@ -80,6 +83,8 @@
       clip-path: circle();
       shape-outside: circle();
       width: 100%;
+      padding: 1rem;
+      transition: padding var(--animation-duration-standard) var(--animation-easing);
     }
   }
 
@@ -89,6 +94,10 @@
     .scrollable {
       @include scroller-mask($scroller-top-padding-small);
       height: 100%;
+    }
+
+    .node {
+      font-size: calc(var(--base-node-size) * .66);
     }
   }
 }

--- a/src/styles/components/_categorical-list.scss
+++ b/src/styles/components/_categorical-list.scss
@@ -1,4 +1,7 @@
 .categorical-list {
+  --categorical-item-margin: .6rem;
+  --categorical-item-multiplier: 1;
+  
   display: flex;
   height: 100%;
   justify-content: center;
@@ -19,7 +22,8 @@
   &__content {
     --categorical-available-height: calc(100vh - var(--categorical-bucket-basis) -
       var(--interface-prompt-flex-basis) - var(--categorical-padding-top) -
-      var(--categorical-padding-bottom));
+      var(--categorical-padding-bottom) - 
+      (var(--categorical-item-margin) * 2 * var(--num-categorical-items) / var(--num-categorical-rows)));
     --num-categorical-items: 8;
     --num-categorical-rows: 2;
 
@@ -34,6 +38,12 @@
       align-items: center;
       justify-content: center;
       --num-categorical-rows: 3;
+      --categorical-item-multiplier: 1.1;
+
+      .categorical-item__title h3,
+      .categorical-item__title h5 {
+        font-size: 80%;
+      }
     }
 
     @media screen and (max-aspect-ratio: 7 / 5) {

--- a/src/styles/containers/_categorical-bin-interface.scss
+++ b/src/styles/containers/_categorical-bin-interface.scss
@@ -11,6 +11,11 @@
   display: flex;
   flex-direction: column;
 
+  hr {
+    border: solid 1px var(--light-background);
+    width: 75%;
+  }
+
   &__prompt {
     @include interface-prompt;
   }


### PR DESCRIPTION
Fixes #794.

* Adds animation for bins on node drop.
* Bins only expand on hover by the margin size so that node placement isn't affected.
* made bins larger for n<4
* reduced text size and increased bins for smaller, collapsed bins.
* smaller nodes in the expanded bin.