### PR TITLE
Feature/narrative hulls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3276,6 +3276,19 @@
                 }
             }
         },
+        "concaveman": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
+            "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
+            "dev": true,
+            "requires": {
+                "monotone-convex-hull-2d": "^1.0.1",
+                "point-in-polygon": "^1.0.1",
+                "rbush": "^2.0.1",
+                "robust-orientation": "^1.1.3",
+                "tinyqueue": "^1.1.0"
+            }
+        },
         "configstore": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -5082,7 +5095,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 },
@@ -12118,6 +12131,15 @@
             "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
             "dev": true
         },
+        "monotone-convex-hull-2d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+            "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+            "dev": true,
+            "requires": {
+                "robust-orientation": "^1.1.3"
+            }
+        },
         "moo": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
@@ -13306,7 +13328,7 @@
         },
         "pegjs": {
             "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+            "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
             "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
         },
         "pend": {
@@ -13422,6 +13444,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/pngjs-nozlib/-/pngjs-nozlib-1.0.0.tgz",
             "integrity": "sha1-nmTWAs/pzOTZ1Zl9BodCmnPwt9c=",
+            "dev": true
+        },
+        "point-in-polygon": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+            "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc=",
             "dev": true
         },
         "portfinder": {
@@ -14933,6 +14961,12 @@
             "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
             "dev": true
         },
+        "quickselect": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+            "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+            "dev": true
+        },
         "quicktype": {
             "version": "15.0.137",
             "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-15.0.137.tgz",
@@ -15137,6 +15171,15 @@
                     "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
                     "dev": true
                 }
+            }
+        },
+        "rbush": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+            "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+            "dev": true,
+            "requires": {
+                "quickselect": "^1.0.1"
             }
         },
         "rc": {
@@ -18106,6 +18149,40 @@
                 "inherits": "^2.0.1"
             }
         },
+        "robust-orientation": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+            "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+            "dev": true,
+            "requires": {
+                "robust-scale": "^1.0.2",
+                "robust-subtract": "^1.0.0",
+                "robust-sum": "^1.0.0",
+                "two-product": "^1.0.2"
+            }
+        },
+        "robust-scale": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+            "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+            "dev": true,
+            "requires": {
+                "two-product": "^1.0.2",
+                "two-sum": "^1.0.0"
+            }
+        },
+        "robust-subtract": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+            "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo=",
+            "dev": true
+        },
+        "robust-sum": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+            "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=",
+            "dev": true
+        },
         "rst-selector-parser": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -19001,7 +19078,7 @@
                 },
                 "onetime": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
                     "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
                     "dev": true
                 },
@@ -20843,6 +20920,12 @@
             "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c=",
             "dev": true
         },
+        "tinyqueue": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+            "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
+            "dev": true
+        },
         "title-case": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
@@ -21059,6 +21142,18 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true,
             "optional": true
+        },
+        "two-product": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+            "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo=",
+            "dev": true
+        },
+        "two-sum": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+            "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q=",
+            "dev": true
         },
         "type-check": {
             "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-docs": "cross-env NODE_ENV=production jsdoc src -r -d docs-build -c ./jsdoc.conf.json --verbose",
     "electron": "electron ./www",
     "electron:dev": "cross-env NODE_ENV=development NC_DEVSERVER_FILE=\".devserver\" electron public/",
-    "ios:dev": "node scripts/check-dev-server.js && cross-env LIVE_RELOAD=1 cordova run ios",
+    "ios:dev": "node scripts/check-dev-server.js && cross-env LIVE_RELOAD=1 cordova run ios --buildFlag='-UseModernBuildSystem=0' --developmentTeam=85EZ69PQHJ --device",
     "android:dev": "node scripts/check-dev-server.js && cross-env LIVE_RELOAD=1 cordova run android",
     "generate-icons": "node scripts/generate-app-icons.js",
     "dist:android": "npm run build:android && cordova build android --release",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "change-case": "^3.0.1",
     "classnames": "^2.2.6",
     "color": "^2.0.0",
+    "concaveman": "^1.1.1",
     "connect-history-api-fallback": "1.3.0",
     "cross-env": "^5.2.0",
     "css-loader": "0.28.4",

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -304,6 +304,12 @@
               "maxLength": 10
             }
           },
+          "d1qwe2d-aefe-4f48-841d-09f020e0e988": {
+            "name": "closenessLayout",
+            "label": "Closeness layout",
+            "description": "Closeness layout",
+            "type": "layout"
+          },
           "e3eb5f0b-84ad-43f0-8db5-9f83cd3a56de": {
             "name": "numberVariable",
             "label": "Number Variable",
@@ -1392,14 +1398,14 @@
       "label": "Narrative",
       "subject": {
         "entity": "node",
-        "type": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466"
+        "type": "c93af3fe-9f84-4e85-acb5-5b15f30788c7"
       },
       "presets": [
         {
           "id": "preset1",
           "label": "My preset",
-          "layoutVariable": "d13ca72d-aefe-4f48-841d-09f020e0e988",
-          "groupVariable": "e343a91f-628d-4175-870c-957beffa0154",
+          "layoutVariable": "d1qwe2d-aefe-4f48-841d-09f020e0e988",
+          "groupVariable": "6c647977-f2d1-426f-b0c5-6d44c795c554",
           "edges": {
             "display": [
               "77199445-9d50-4646-b0bc-6d6b0c0e06bd",

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -304,12 +304,6 @@
               "maxLength": 10
             }
           },
-          "d1qwe2d-aefe-4f48-841d-09f020e0e988": {
-            "name": "closenessLayout",
-            "label": "Closeness layout",
-            "description": "Closeness layout",
-            "type": "layout"
-          },
           "e3eb5f0b-84ad-43f0-8db5-9f83cd3a56de": {
             "name": "numberVariable",
             "label": "Number Variable",
@@ -1398,14 +1392,14 @@
       "label": "Narrative",
       "subject": {
         "entity": "node",
-        "type": "c93af3fe-9f84-4e85-acb5-5b15f30788c7"
+        "type": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466"
       },
       "presets": [
         {
           "id": "preset1",
           "label": "My preset",
-          "layoutVariable": "d1qwe2d-aefe-4f48-841d-09f020e0e988",
-          "groupVariable": "6c647977-f2d1-426f-b0c5-6d44c795c554",
+          "layoutVariable": "d13ca72d-aefe-4f48-841d-09f020e0e988",
+          "groupVariable": "e343a91f-628d-4175-870c-957beffa0154",
           "edges": {
             "display": [
               "77199445-9d50-4646-b0bc-6d6b0c0e06bd",
@@ -1425,7 +1419,7 @@
         }
       ],
       "background": {
-        "concentricCircles": 3,
+        "concentricCircles": 4,
         "skewedTowardCenter": true
       },
       "behaviours": {

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1419,7 +1419,7 @@
         }
       ],
       "background": {
-        "concentricCircles": 4,
+        "concentricCircles": 3,
         "skewedTowardCenter": true
       },
       "behaviours": {

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -954,6 +954,11 @@
           "component": "Text"
         },
         {
+          "variable": "e343a91f-628d-4175-870c-957beffa0154",
+          "component": "ToggleButtonGroup",
+          "label": "Multiple categorical membership"
+        },
+        {
           "variable": "04298634-eb5f-450a-84dd-95d2708e10c1",
           "component": "hidden",
           "value": "network-canvas"
@@ -1387,7 +1392,7 @@
       ]
     },
     {
-      "id": "narrative",
+      "id": "narrative1",
       "type": "Narrative",
       "label": "Narrative",
       "subject": {

--- a/src/components/Canvas/ConcentricCircles.js
+++ b/src/components/Canvas/ConcentricCircles.js
@@ -58,7 +58,7 @@ const ConcentricCircles = ({
     />
     <NodeBucket
       id="NODE_BUCKET"
-      layout={layoutVariable}
+      layoutVariable={layoutVariable}
       subject={subject}
       sortOrder={sortOrder}
     />

--- a/src/components/Canvas/ConcentricCircles.js
+++ b/src/components/Canvas/ConcentricCircles.js
@@ -5,6 +5,7 @@ import NodeBucket from '../../containers/Canvas/NodeBucket';
 import NodeLayout from '../../containers/Canvas/NodeLayout';
 import EdgeLayout from '../../containers/Canvas/EdgeLayout';
 import Background from '../../containers/Canvas/Background';
+import ConvexHulls from '../../containers/Canvas/ConvexHulls';
 
 const ConcentricCircles = ({
   subject,
@@ -12,6 +13,7 @@ const ConcentricCircles = ({
   highlight,
   allowHighlight,
   createEdge,
+  convexHulls,
   allowPositioning,
   displayEdges,
   backgroundImage,
@@ -28,11 +30,19 @@ const ConcentricCircles = ({
       image={backgroundImage}
     />
     {
+      convexHulls &&
+      <ConvexHulls
+        groupVariable={convexHulls}
+        subject={subject}
+        layoutVariable={layoutVariable}
+      />
+    }
+    {
       displayEdges.length > 0 &&
       <EdgeLayout
         displayEdges={displayEdges}
         subject={subject}
-        layout={layoutVariable}
+        layoutVariable={layoutVariable}
       />
     }
     <NodeLayout
@@ -40,7 +50,7 @@ const ConcentricCircles = ({
       highlight={highlight}
       allowHighlight={allowHighlight && !createEdge}
       createEdge={createEdge}
-      layout={layoutVariable}
+      layoutVariable={layoutVariable}
       allowPositioning={allowPositioning}
       subject={subject}
       connectFrom={connectFrom}
@@ -63,6 +73,7 @@ ConcentricCircles.propTypes = {
   createEdge: PropTypes.string,
   allowPositioning: PropTypes.bool,
   displayEdges: PropTypes.array,
+  convexHulls: PropTypes.string,
   backgroundImage: PropTypes.string,
   concentricCircles: PropTypes.number,
   skewedTowardCenter: PropTypes.bool,
@@ -77,6 +88,7 @@ ConcentricCircles.defaultProps = {
   createEdge: null,
   allowPositioning: true,
   displayEdges: [],
+  convexHulls: null,
   backgroundImage: null,
   concentricCircles: null,
   skewedTowardCenter: null,

--- a/src/components/Canvas/ConvexHull.js
+++ b/src/components/Canvas/ConvexHull.js
@@ -4,11 +4,12 @@ import PropTypes from 'prop-types';
 export class ConvexHull extends PureComponent {
   render() {
     const { color, points } = this.props;
-    const hullColor = `var(--${color})`;
-    console.log(points);
+
+    const hullClasses = `convex-hull convex-hull__${color}`;
+
     return (
-      <svg style={{ background: color, position: 'absolute', top: 0, left: 0 }} width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-        <polygon points={points} style={{ strokeLinejoin: 'round', stroke: hullColor, strokeWidth: 'calc(var(--base-node-size) / 2)', mixBlendMode: 'screen', fill: hullColor }} />
+      <svg className={hullClasses} xmlns="http://www.w3.org/2000/svg">
+        <polygon points={points} />
       </svg>
     );
   }
@@ -16,7 +17,7 @@ export class ConvexHull extends PureComponent {
 
 ConvexHull.propTypes = {
   color: PropTypes.string,
-  points: PropTypes.array.isRequired,
+  points: PropTypes.string.isRequired,
 };
 
 ConvexHull.defaultProps = {

--- a/src/components/Canvas/ConvexHull.js
+++ b/src/components/Canvas/ConvexHull.js
@@ -8,7 +8,6 @@ import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 
 const windowDimensions = getAbsoluteBoundingRect(document.body);
 
-console.log(windowDimensions);
 export class ConvexHull extends Component {
   shouldComponentUpdate(nextProps) {
     if (!isEqual(this.props.nodePoints, nextProps.nodePoints)) {

--- a/src/components/Canvas/ConvexHull.js
+++ b/src/components/Canvas/ConvexHull.js
@@ -1,0 +1,29 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+export class ConvexHull extends PureComponent {
+  render() {
+    const { color, points } = this.props;
+
+    return (
+      <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" points={points}>
+        <path d="M10 10 H 90 V 90 H 10 L 10 10" />
+        <circle cx="10" cy="10" r="2" fill={color} />
+        <circle cx="90" cy="90" r="2" fill={color} />
+        <circle cx="90" cy="10" r="2" fill={color} />
+        <circle cx="10" cy="90" r="2" fill={color} />
+      </svg>
+    );
+  }
+}
+
+ConvexHull.propTypes = {
+  color: PropTypes.string,
+  points: PropTypes.array.isRequired,
+};
+
+ConvexHull.defaultProps = {
+  color: 'edge-color-seq-1',
+};
+
+export default ConvexHull;

--- a/src/components/Canvas/ConvexHull.js
+++ b/src/components/Canvas/ConvexHull.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { map, isEqual } from 'lodash';
 import ConcaveMan from 'concaveman';
 import { nodeAttributesProperty } from '../../ducks/modules/network';
+import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 
+
+const windowDimensions = getAbsoluteBoundingRect(document.body);
+
+console.log(windowDimensions);
 export class ConvexHull extends Component {
   shouldComponentUpdate(nextProps) {
     if (!isEqual(this.props.nodePoints, nextProps.nodePoints)) {
@@ -24,8 +29,8 @@ export class ConvexHull extends Component {
     // See: https://github.com/mapbox/concaveman
     ConcaveMan(groupAsCoords, 0.6, 0).forEach((item) => {
       // Scale each hull point from ratio to window coordinate.
-      const itemX = item[0] * window.innerWidth;
-      const itemY = item[1] * window.innerHeight;
+      const itemX = item[0] * windowDimensions.width;
+      const itemY = item[1] * windowDimensions.height;
 
       // SVG points structured as string: "value1,value2 value3,value4"
       hullPointsAsSVG += `${itemX}, ${itemY} `;

--- a/src/components/Canvas/ConvexHull.js
+++ b/src/components/Canvas/ConvexHull.js
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types';
 export class ConvexHull extends PureComponent {
   render() {
     const { color, points } = this.props;
-
+    const hullColor = `var(--${color})`;
+    console.log(points);
     return (
-      <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg" points={points}>
-        <path d="M10 10 H 90 V 90 H 10 L 10 10" />
-        <circle cx="10" cy="10" r="2" fill={color} />
-        <circle cx="90" cy="90" r="2" fill={color} />
-        <circle cx="90" cy="10" r="2" fill={color} />
-        <circle cx="10" cy="90" r="2" fill={color} />
+      <svg style={{ background: color, position: 'absolute', top: 0, left: 0 }} width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+        <polygon points={points} style={{ strokeLinejoin: 'round', stroke: hullColor, strokeWidth: 'calc(var(--base-node-size) / 2)', mixBlendMode: 'screen', fill: hullColor }} />
       </svg>
     );
   }
@@ -23,7 +20,7 @@ ConvexHull.propTypes = {
 };
 
 ConvexHull.defaultProps = {
-  color: 'edge-color-seq-1',
+  color: 'cat-color-seq-1',
 };
 
 export default ConvexHull;

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -27,10 +27,18 @@ class ConvexHulls extends React.PureComponent {
     console.log(hulls);
     return (
       hulls.map((hull, index) => {
-        const hullPoints = hull;
 
+        let hullPoints = '';
+        hull.forEach((item) => {
+          const itemX = item[0] * window.innerWidth;
+          const itemY = item[1] * window.innerHeight;
+          hullPoints += `${itemX}, ${itemY} `;
+        });
+
+        const color = `cat-color-seq-${index + 1}`;
+        console.log(hullPoints);
         return (
-          <ConvexHull points={hullPoints} key={index} />
+          <ConvexHull color={color} points={hullPoints} key={index} />
         );
       })
     );

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -6,7 +6,6 @@ import { ConvexHull } from './ConvexHull';
 import { nodeAttributesProperty } from '../../ducks/modules/network';
 
 class ConvexHulls extends React.PureComponent {
-
   /*
     * generateHulls - generate points that encompass a set of nodes
     *
@@ -14,7 +13,6 @@ class ConvexHulls extends React.PureComponent {
     * groupName:
     *   [ nodeList ]
   */
-
   generateHulls = nodesByGroup =>
     map(nodesByGroup, (group) => {
       const groupAsCoords = map(group, (node) => {

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -29,7 +29,6 @@ class ConvexHulls extends React.PureComponent {
     } = this.props;
 
     const hulls = this.generateHulls(nodesByGroup);
-
     return (
       hulls.map((hull, index) => {
         let hullPoints = '';

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -1,46 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { map } from 'lodash';
-import ConcaveMan from 'concaveman';
+
 import { ConvexHull } from './ConvexHull';
-import { nodeAttributesProperty } from '../../ducks/modules/network';
+
 
 class ConvexHulls extends React.PureComponent {
-  /*
-    * generateHulls - generate points that encompass a set of nodes
-    *
-    * takes an object structured as follows:
-    * groupName:
-    *   [ nodeList ]
-  */
-  generateHulls = nodesByGroup =>
-    map(nodesByGroup, (group) => {
-      const groupAsCoords = map(group, (node) => {
-        const coords = node[nodeAttributesProperty][this.props.layoutVariable];
-        return [coords.x, coords.y];
-      });
-      // See: https://github.com/mapbox/concaveman
-      return ConcaveMan(groupAsCoords, 0.6, 0);
-    });
-
   render() {
     const {
       nodesByGroup,
+      layoutVariable,
     } = this.props;
 
-    const hulls = this.generateHulls(nodesByGroup);
     return (
-      hulls.map((hull, index) => {
-        let hullPoints = '';
-        hull.forEach((item) => {
-          const itemX = item[0] * window.innerWidth;
-          const itemY = item[1] * window.innerHeight;
-          hullPoints += `${itemX}, ${itemY} `;
-        });
-
+      Object.keys(nodesByGroup).map((group, index) => {
         const color = `cat-color-seq-${index + 1}`;
         return (
-          <ConvexHull color={color} points={hullPoints} key={index} />
+          <ConvexHull
+            color={color}
+            nodePoints={nodesByGroup[group]}
+            key={index}
+            layoutVariable={layoutVariable}
+          />
         );
       })
     );

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { map } from 'lodash';
+import ConcaveMan from 'concaveman';
+import { ConvexHull } from './ConvexHull';
+import { nodeAttributesProperty } from '../../ducks/modules/network';
+
+class ConvexHulls extends React.PureComponent {
+  generateHulls = (nodesByGroup) => {
+    return map(nodesByGroup, (group) => {
+      const groupCoords = map(group, (node) => {
+        const coords = node[nodeAttributesProperty][this.props.layoutVariable];
+        return [coords.x, coords.y];
+      });
+      return ConcaveMan(groupCoords);
+    });
+  };
+
+  render() {
+    const {
+      nodesByGroup,
+    } = this.props;
+
+
+    const hulls = this.generateHulls(nodesByGroup);
+
+    console.log(hulls);
+    return (
+      hulls.map((hull, index) => {
+        const hullPoints = hull;
+
+        return (
+          <ConvexHull points={hullPoints} key={index} />
+        );
+      })
+    );
+  }
+}
+
+ConvexHulls.propTypes = {
+  layoutVariable: PropTypes.string.isRequired,
+  nodesByGroup: PropTypes.object.isRequired,
+};
+
+ConvexHulls.defaultProps = {
+};
+
+
+export default ConvexHulls;

--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -6,28 +6,34 @@ import { ConvexHull } from './ConvexHull';
 import { nodeAttributesProperty } from '../../ducks/modules/network';
 
 class ConvexHulls extends React.PureComponent {
-  generateHulls = (nodesByGroup) => {
-    return map(nodesByGroup, (group) => {
-      const groupCoords = map(group, (node) => {
+
+  /*
+    * generateHulls - generate points that encompass a set of nodes
+    *
+    * takes an object structured as follows:
+    * groupName:
+    *   [ nodeList ]
+  */
+
+  generateHulls = nodesByGroup =>
+    map(nodesByGroup, (group) => {
+      const groupAsCoords = map(group, (node) => {
         const coords = node[nodeAttributesProperty][this.props.layoutVariable];
         return [coords.x, coords.y];
       });
-      return ConcaveMan(groupCoords);
+      // See: https://github.com/mapbox/concaveman
+      return ConcaveMan(groupAsCoords, 0.6, 0);
     });
-  };
 
   render() {
     const {
       nodesByGroup,
     } = this.props;
 
-
     const hulls = this.generateHulls(nodesByGroup);
 
-    console.log(hulls);
     return (
       hulls.map((hull, index) => {
-
         let hullPoints = '';
         hull.forEach((item) => {
           const itemX = item[0] * window.innerWidth;
@@ -36,7 +42,6 @@ class ConvexHulls extends React.PureComponent {
         });
 
         const color = `cat-color-seq-${index + 1}`;
-        console.log(hullPoints);
         return (
           <ConvexHull color={color} points={hullPoints} key={index} />
         );

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -21,7 +21,7 @@ class NodeLayout extends Component {
     allowPositioning: PropTypes.bool,
     canCreateEdge: PropTypes.bool,
     allowSelect: PropTypes.bool,
-    layout: PropTypes.string,
+    layoutVariable: PropTypes.string,
     width: PropTypes.number,
     height: PropTypes.number,
   };
@@ -33,7 +33,7 @@ class NodeLayout extends Component {
     allowPositioning: true,
     allowSelect: true,
     canCreateEdge: true,
-    layout: null,
+    layoutVariable: null,
     width: null,
     height: null,
   };
@@ -60,7 +60,7 @@ class NodeLayout extends Component {
       nodes,
       allowPositioning,
       allowSelect,
-      layout,
+      layoutVariable,
       width,
       height,
     } = this.props;
@@ -69,13 +69,13 @@ class NodeLayout extends Component {
       <div className="node-layout">
         { nodes.map((node) => {
           const nodeAttributes = getNodeAttributes(node);
-          if (!has(nodeAttributes, layout)) { return null; }
+          if (!has(nodeAttributes, layoutVariable)) { return null; }
 
           return (
             <LayoutNode
               key={node[nodePrimaryKeyProperty]}
               node={node}
-              layoutVariable={layout}
+              layoutVariable={layoutVariable}
               onSelected={() => this.props.onSelected(node)}
               selected={this.isHighlighted(node)}
               linking={this.isLinking(node)}

--- a/src/components/Canvas/NodeLayout.js
+++ b/src/components/Canvas/NodeLayout.js
@@ -64,7 +64,6 @@ class NodeLayout extends Component {
       width,
       height,
     } = this.props;
-
     return (
       <div className="node-layout">
         { nodes.map((node) => {

--- a/src/components/Canvas/__tests__/__snapshots__/NodeLayout.test.js.snap
+++ b/src/components/Canvas/__tests__/__snapshots__/NodeLayout.test.js.snap
@@ -16,7 +16,6 @@ ShallowWrapper {
     height={456}
     highlightAttribute={null}
     highlightAttributes={Object {}}
-    layout={null}
     layoutVariable="foo"
     nodes={
       Array [

--- a/src/components/CategoricalItem.js
+++ b/src/components/CategoricalItem.js
@@ -20,6 +20,7 @@ const CategoricalItem = ({
   nodes,
   onClick,
   sortOrder,
+  style,
   willAccept,
 }) => {
   const classNames = cx(
@@ -30,7 +31,7 @@ const CategoricalItem = ({
 
   return (
     <Flipped flipId={id}>
-      <div className={classNames} style={{ '--categorical-item-color': accentColor }} onClick={onClick} >
+      <div className={classNames} style={{ '--categorical-item-color': accentColor, ...style }} onClick={onClick} >
         <Flipped inverseFlipId={id} scale>
           <div className="categorical-item__title">
             <h3>{label}</h3>
@@ -62,6 +63,7 @@ CategoricalItem.propTypes = {
   nodes: PropTypes.array,
   onClick: PropTypes.func,
   sortOrder: PropTypes.array,
+  style: PropTypes.object,
   willAccept: PropTypes.bool,
 };
 
@@ -74,6 +76,7 @@ CategoricalItem.defaultProps = {
   nodes: [],
   onClick: () => {},
   sortOrder: [],
+  style: {},
   willAccept: false,
 };
 

--- a/src/components/Transition/Stage.js
+++ b/src/components/Transition/Stage.js
@@ -24,7 +24,7 @@ const exitAnimation = (backward) => {
   const translateDistance = backward ? '200vh' : '-200vh';
   return {
     elasticity: 0,
-    translateY: [0, translateDistance],
+    translateY: ['-100vh', translateDistance],
     easing: getCSSVariableAsObject('--animation-easing-js'),
     duration: duration.exit,
   };

--- a/src/containers/Canvas/Annotations.js
+++ b/src/containers/Canvas/Annotations.js
@@ -75,12 +75,6 @@ class Annotations extends Component {
   }
 
   componentWillUnmount() {
-    const nodeListRoot = document.getElementsByClassName('node-layout').length > 0 ?
-      document.getElementsByClassName('node-layout')[0] :
-      document.getElementById('narrative-interface__canvas');
-    if (nodeListRoot) {
-      nodeListRoot.removeChild(this.portal);
-    }
     this.cleanupDragManager();
   }
 

--- a/src/containers/Canvas/ConvexHulls.js
+++ b/src/containers/Canvas/ConvexHulls.js
@@ -1,3 +1,20 @@
-const ConvexHulls = () => null;
+import { connect } from 'react-redux';
+import { compose } from 'recompose';
 
-export default ConvexHulls;
+import ConvexHulls from '../../components/Canvas/ConvexHulls';
+import { makeGetNodesByCategorical } from '../../selectors/canvas';
+
+function makeMapStateToProps() {
+  const getNodesByGroup = makeGetNodesByCategorical();
+
+  return function mapStateToProps(state, props) {
+    const nodesByGroup = getNodesByGroup(state, props);
+    return {
+      nodesByGroup,
+    };
+  };
+}
+
+export default compose(
+  connect(makeMapStateToProps),
+)(ConvexHulls);

--- a/src/containers/Canvas/ConvexHulls.js
+++ b/src/containers/Canvas/ConvexHulls.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
+import { withBounds } from '../../behaviours';
 
 import ConvexHulls from '../../components/Canvas/ConvexHulls';
 import { makeGetNodesByCategorical } from '../../selectors/canvas';
@@ -17,4 +18,5 @@ function makeMapStateToProps() {
 
 export default compose(
   connect(makeMapStateToProps),
+  withBounds,
 )(ConvexHulls);

--- a/src/containers/Canvas/EdgeLayout.js
+++ b/src/containers/Canvas/EdgeLayout.js
@@ -5,8 +5,8 @@ import { makeGetDisplayEdges } from '../../selectors/canvas';
 const makeMapStateToProps = () => {
   const getDisplayEdges = makeGetDisplayEdges();
 
-  const mapStateToProps = (state, { subject, displayEdges, layout }) => ({
-    edges: getDisplayEdges(state, { subject, displayEdges, layout }),
+  const mapStateToProps = (state, { subject, displayEdges, layoutVariable }) => ({
+    edges: getDisplayEdges(state, { subject, displayEdges, layoutVariable }),
   });
 
   return mapStateToProps;

--- a/src/containers/Canvas/NodeBucket.js
+++ b/src/containers/Canvas/NodeBucket.js
@@ -47,8 +47,8 @@ class NodeBucket extends PureComponent {
 const makeMapStateToProps = () => {
   const getNextUnplacedNode = makeGetNextUnplacedNode();
 
-  const mapStateToProps = (state, { layout, subject }) => {
-    const node = getNextUnplacedNode(state, { layout, subject });
+  const mapStateToProps = (state, { layoutVariable, subject }) => {
+    const node = getNextUnplacedNode(state, { layoutVariable, subject });
 
     return {
       node,

--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -18,30 +18,30 @@ const withRerenderCount = withState('rerenderCount', 'setRerenderCount', 0);
 
 const withDropHandlers = withHandlers({
   accepts: () => ({ meta }) => meta.itemType === 'POSITIONED_NODE',
-  onDrop: ({ updateNode, layout, setRerenderCount, rerenderCount, width, height, x, y }) =>
+  onDrop: ({ updateNode, layoutVariable, setRerenderCount, rerenderCount, width, height, x, y }) =>
     (item) => {
       updateNode(
         item.meta,
         {
-          [layout]: relativeCoords({ width, height, x, y }, item),
+          [layoutVariable]: relativeCoords({ width, height, x, y }, item),
         },
       );
 
       // Horrible hack for performance (only re-render nodes on drop, not on drag)
       setRerenderCount(rerenderCount + 1);
     },
-  onDrag: ({ layout, updateNode, width, height, x, y }) => (item) => {
-    if (!has(item.meta[nodeAttributesProperty], layout)) { return; }
+  onDrag: ({ layoutVariable, updateNode, width, height, x, y }) => (item) => {
+    if (!has(item.meta[nodeAttributesProperty], layoutVariable)) { return; }
 
     updateNode(
       item.meta,
       {
-        [layout]: relativeCoords({ width, height, x, y }, item),
+        [layoutVariable]: relativeCoords({ width, height, x, y }, item),
       },
     );
   },
-  onDragEnd: ({ layout, setRerenderCount, rerenderCount }) => (item) => {
-    if (!has(item.meta[nodeAttributesProperty], layout)) { return; }
+  onDragEnd: ({ layoutVariable, setRerenderCount, rerenderCount }) => (item) => {
+    if (!has(item.meta[nodeAttributesProperty], layoutVariable)) { return; }
 
     // make sure to also re-render nodes that were updated on drag end
     setRerenderCount(rerenderCount + 1);
@@ -99,11 +99,14 @@ const withSelectHandlers = compose(
 function makeMapStateToProps() {
   const getPlacedNodes = makeGetPlacedNodes();
 
-  return function mapStateToProps(state, { createEdge, allowHighlighting, subject, layout }) {
+  return function mapStateToProps(
+    state,
+    { createEdge, allowHighlighting, subject, layoutVariable },
+  ) {
     const allowSelect = createEdge || allowHighlighting;
 
     return {
-      nodes: getPlacedNodes(state, { subject, layout }),
+      nodes: getPlacedNodes(state, { subject, layoutVariable }),
       allowSelect,
     };
   };

--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -103,7 +103,7 @@ function makeMapStateToProps() {
     state,
     { createEdge, allowHighlighting, subject, layoutVariable },
   ) {
-    const allowSelect = createEdge || allowHighlighting;
+    const allowSelect = !!(createEdge || allowHighlighting);
 
     return {
       nodes: getPlacedNodes(state, { subject, layoutVariable }),

--- a/src/containers/CategoricalList.js
+++ b/src/containers/CategoricalList.js
@@ -71,12 +71,12 @@ class CategoricalList extends Component {
 
   renderCategoricalBin = (bin, index) => {
     const onDrop = ({ meta }) => {
-      if (getNodeAttributes(meta)[this.props.activePromptVariable] === bin.value) {
+      if (getNodeAttributes(meta)[this.props.activePromptVariable] === [bin.value]) {
         return;
       }
 
       this.props.toggleNodeAttributes(meta[nodePrimaryKeyProperty],
-        { [this.props.activePromptVariable]: bin.value });
+        { [this.props.activePromptVariable]: [bin.value] });
     };
 
     const binDetails = this.getDetails(bin.nodes);
@@ -165,7 +165,7 @@ function makeMapStateToProps() {
           const nodes = stageNodes.filter(
             node =>
               node[nodeAttributesProperty][activePromptVariable] &&
-              node[nodeAttributesProperty][activePromptVariable] === bin.value,
+              node[nodeAttributesProperty][activePromptVariable].includes(bin.value),
           );
 
           return {

--- a/src/containers/CategoricalList.js
+++ b/src/containers/CategoricalList.js
@@ -93,6 +93,7 @@ class CategoricalList extends Component {
         isExpanded={this.state.expandedBinValue === bin.value}
         nodes={bin.nodes}
         sortOrder={this.props.prompt.binSortOrder}
+        style={{ '--categorical-available-height': `${Math.floor(this.getAvailableHeight())}px` }}
       />
     );
   }

--- a/src/containers/Interfaces/CategoricalBin.js
+++ b/src/containers/Interfaces/CategoricalBin.js
@@ -21,7 +21,7 @@ const CategoricalBin = ({
   const {
     prompts,
   } = stage;
-
+  console.log(nodesForPrompt);
   return (
     <div className="categorical-bin-interface">
       <div className="categorical-bin-interface__prompt">
@@ -60,7 +60,8 @@ function makeMapStateToProps() {
   return function mapStateToProps(state, props) {
     const stageNodes = getStageNodes(state, props);
     const activePromptVariable = getPromptVariable(state, props);
-
+    console.log(activePromptVariable);
+    console.log(stageNodes);
     return {
       activePromptVariable,
       nodesForPrompt: stageNodes.filter(

--- a/src/containers/Interfaces/CategoricalBin.js
+++ b/src/containers/Interfaces/CategoricalBin.js
@@ -21,7 +21,6 @@ const CategoricalBin = ({
   const {
     prompts,
   } = stage;
-  console.log(nodesForPrompt);
   return (
     <div className="categorical-bin-interface">
       <div className="categorical-bin-interface__prompt">
@@ -60,8 +59,7 @@ function makeMapStateToProps() {
   return function mapStateToProps(state, props) {
     const stageNodes = getStageNodes(state, props);
     const activePromptVariable = getPromptVariable(state, props);
-    console.log(activePromptVariable);
-    console.log(stageNodes);
+
     return {
       activePromptVariable,
       nodesForPrompt: stageNodes.filter(

--- a/src/containers/Interfaces/Narrative.js
+++ b/src/containers/Interfaces/Narrative.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import {
   NarrativeControlPanel,
   Annotations,
-  ConvexHulls,
 } from '../Canvas';
 
 import {
@@ -37,23 +36,25 @@ class Narrative extends Component {
     const layoutVariable = currentPreset.layoutVariable;
     const highlight = currentPreset.highlight && currentPreset.highlight[0].variable;
     const displayEdges = (currentPreset.edges && currentPreset.edges.display) || [];
+    const convexHulls = currentPreset.groupVariable;
+
     const backgroundImage = stage.background && stage.background.image;
     const concentricCircles = stage.background && stage.background.concentricCircles;
     const skewedTowardCenter = stage.background && stage.background.skewedTowardCenter;
     const freeDraw = stage.behaviours && stage.behaviours.freeDraw;
-    
+
     return (
       <div className="narrative-interface">
         <div className="narrative-interface__canvas" id="narrative-interface__canvas">
           <Canvas>
             <NarrativeControlPanel />
             <Annotations freeDraw={freeDraw} />
-            <ConvexHulls />
             <ConcentricCircles
               subject={subject}
               layoutVariable={layoutVariable}
               highlight={highlight}
               displayEdges={displayEdges}
+              convexHulls={convexHulls}
               backgroundImage={backgroundImage}
               concentricCircles={concentricCircles}
               skewedTowardCenter={skewedTowardCenter}

--- a/src/containers/Interfaces/Sociogram.js
+++ b/src/containers/Interfaces/Sociogram.js
@@ -61,7 +61,6 @@ const Sociogram = ({
   const concentricCircles = prompt.background && prompt.background.concentricCircles;
   const skewedTowardCenter = prompt.background && prompt.background.skewedTowardCenter;
   const sortOrder = prompt.sortOrder;
-
   return (
     <div className="sociogram-interface">
       <PromptObstacle
@@ -110,8 +109,12 @@ Sociogram.propTypes = {
   promptForward: PropTypes.func.isRequired,
   promptBackward: PropTypes.func.isRequired,
   handleResetInterface: PropTypes.func.isRequired,
-  connectFrom: PropTypes.string.isRequired,
+  connectFrom: PropTypes.string,
   handleConnectFrom: PropTypes.func.isRequired,
+};
+
+Sociogram.defaultProps = {
+  connectFrom: null,
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/src/containers/Search/SearchResults.js
+++ b/src/containers/Search/SearchResults.js
@@ -10,7 +10,7 @@ function styleForSoftKeyboard() {
   const scrollTop = window.pageYOffset || window.scrollY || 0;
   if (scrollTop > 0) {
     style = {
-      height: `calc(100vh - 320px - ${scrollTop}px)`,
+      height: `calc(100% - 320px - ${scrollTop}px)`,
       minHeight: '10em',
     };
   }

--- a/src/ducks/modules/mock.js
+++ b/src/ducks/modules/mock.js
@@ -9,6 +9,8 @@ const MOCK_GENERATE_NODES = 'MOCK/GENERATE_NODES';
 
 const mockCoord = () => faker.random.number({ min: 0, max: 1, precision: 0.000001 });
 
+
+// Todo: make these mock values reflect validation
 const mockValue = (nodeVariable) => {
   switch (nodeVariable.type) {
     case 'boolean':
@@ -16,8 +18,9 @@ const mockValue = (nodeVariable) => {
     case 'number':
       return faker.random.number({ min: 20, max: 100 });
     case 'ordinal':
-    case 'categorical':
       return faker.random.arrayElement(nodeVariable.options).value;
+    case 'categorical':
+      return [faker.random.arrayElement(nodeVariable.options).value];
     case 'layout':
       return { x: mockCoord(), y: mockCoord() };
     default:

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -31,8 +31,6 @@ export const makeGetNextUnplacedNode = () =>
 
       const unplacedNodes = nodes.filter((node) => {
         const attributes = getNodeAttributes(node);
-        console.log(attributes, layout);
-        console.log(has(attributes, layout));
         return (
           node.type === type &&
           !has(attributes, layout)

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -1,4 +1,4 @@
-import { first, has, filter, groupBy } from 'lodash';
+import { first, has } from 'lodash';
 import { networkNodes, networkEdges } from './interface';
 import { createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
@@ -76,12 +76,29 @@ export const makeGetNodesByCategorical = () => {
     getPlacedNodes,
     getCategoricalVariable,
     (nodes, categoricalVariable) => {
-      // Exclude nodes with no set value for this variable.
-      const filteredNodes = filter(nodes, node =>
-        node[nodeAttributesProperty][categoricalVariable],
-      );
+      const groupedList = {};
 
-      return groupBy(filteredNodes, node => node[nodeAttributesProperty][categoricalVariable]);
+      nodes.forEach((node) => {
+        const categoricalValues = node[nodeAttributesProperty][categoricalVariable];
+
+        // Filter out nodes with no value for this variable.
+        if (!categoricalValues) {
+          return false;
+        }
+
+        categoricalValues.forEach((categoricalValue) => {
+          if (groupedList[categoricalValue]) {
+            groupedList[categoricalValue].push(node);
+          } else {
+            groupedList[categoricalValue] = [];
+            groupedList[categoricalValue].push(node);
+          }
+        });
+
+        return true;
+      });
+
+      return groupedList;
     },
   );
 };

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -1,4 +1,4 @@
-import { first, has, groupBy } from 'lodash';
+import { first, has, groupBy, filter } from 'lodash';
 import { networkNodes, networkEdges } from './interface';
 import { createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
@@ -70,7 +70,7 @@ export const makeGetPlacedNodes = () =>
   );
 
 /**
- * Selector for nodes by group.
+ * Selector for nodes by group (categorical) variable.
  */
 
 export const makeGetNodesByCategorical = () => {
@@ -78,8 +78,14 @@ export const makeGetNodesByCategorical = () => {
   return createDeepEqualSelector(
     getPlacedNodes,
     getCategoricalVariable,
-    (nodes, categoricalVariable) =>
-      groupBy(nodes, node => node[nodeAttributesProperty][categoricalVariable]),
+    (nodes, categoricalVariable) => {
+      // Exclude nodes with no set value for this variable.
+      const filteredNodes = filter(nodes, node =>
+        node[nodeAttributesProperty][categoricalVariable],
+      );
+
+      return groupBy(filteredNodes, node => node[nodeAttributesProperty][categoricalVariable]);
+    },
   );
 };
 

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -1,4 +1,4 @@
-import { first, has, groupBy, filter } from 'lodash';
+import { first, has, filter, groupBy } from 'lodash';
 import { networkNodes, networkEdges } from './interface';
 import { createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
@@ -9,8 +9,8 @@ import {
 } from '../ducks/modules/network';
 
 const getLayout = (_, props) => props.layoutVariable;
-const getCategoricalVariable = (_, props) => props.groupVariable;
 const getSubject = (_, props) => props.subject;
+const getCategoricalVariable = (_, props) => props.groupVariable;
 const getSortOptions = (_, props) => props.sortOrder;
 const getDisplayEdges = (_, props) => props.displayEdges;
 
@@ -31,7 +31,8 @@ export const makeGetNextUnplacedNode = () =>
 
       const unplacedNodes = nodes.filter((node) => {
         const attributes = getNodeAttributes(node);
-
+        console.log(attributes, layout);
+        console.log(has(attributes, layout));
         return (
           node.type === type &&
           !has(attributes, layout)
@@ -57,10 +58,8 @@ export const makeGetPlacedNodes = () =>
     getLayout,
     (nodes, subject, layout) => {
       const type = subject && subject.type;
-
       return nodes.filter((node) => {
         const attributes = getNodeAttributes(node);
-
         return (
           node.type === type &&
           has(attributes, layout)
@@ -88,6 +87,7 @@ export const makeGetNodesByCategorical = () => {
     },
   );
 };
+
 
 const edgeCoords = (edge, { nodes, layout }) => {
   const from = nodes.find(n => n[nodePrimaryKeyProperty] === edge.from);

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -1,4 +1,4 @@
-import { first, has } from 'lodash';
+import { first, has, groupBy } from 'lodash';
 import { networkNodes, networkEdges } from './interface';
 import { createDeepEqualSelector } from './utils';
 import sortOrder from '../utils/sortOrder';
@@ -8,7 +8,8 @@ import {
   nodeAttributesProperty,
 } from '../ducks/modules/network';
 
-const getLayout = (_, props) => props.layout;
+const getLayout = (_, props) => props.layoutVariable;
+const getCategoricalVariable = (_, props) => props.groupVariable;
 const getSubject = (_, props) => props.subject;
 const getSortOptions = (_, props) => props.sortOrder;
 const getDisplayEdges = (_, props) => props.displayEdges;
@@ -67,6 +68,20 @@ export const makeGetPlacedNodes = () =>
       });
     },
   );
+
+/**
+ * Selector for nodes by group.
+ */
+
+export const makeGetNodesByCategorical = () => {
+  const getPlacedNodes = makeGetPlacedNodes();
+  return createDeepEqualSelector(
+    getPlacedNodes,
+    getCategoricalVariable,
+    (nodes, categoricalVariable) =>
+      groupBy(nodes, node => node[nodeAttributesProperty][categoricalVariable]),
+  );
+};
 
 const edgeCoords = (edge, { nodes, layout }) => {
   const from = nodes.find(n => n[nodePrimaryKeyProperty] === edge.from);

--- a/src/selectors/protocol.js
+++ b/src/selectors/protocol.js
@@ -52,7 +52,6 @@ export const makeGetEdgeColor = () => createDeepEqualSelector(
     return edgeInfo && edgeInfo[edgeType] && edgeInfo[edgeType].color;
   },
 );
-
 export const getNodeLabelWorkerUrl = createSelector(
   // null if URLs haven't yet loaded; false if worker does not exist
   state => state.protocol.workerUrlMap &&

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -1,6 +1,7 @@
 @import '../containers/interfaces';
 
 @import 'add-count-button';
+@import 'convex-hull';
 @import 'input';
 @import 'node-list';
 @import 'prompts';

--- a/src/styles/components/_annotations.scss
+++ b/src/styles/components/_annotations.scss
@@ -15,6 +15,5 @@
     stroke-width: .25rem;
     stroke: palette('selected');
     stroke-linejoin: round;
-    stroke-linecap: round;
   }
 }

--- a/src/styles/components/_categorical-list.scss
+++ b/src/styles/components/_categorical-list.scss
@@ -1,7 +1,7 @@
 .categorical-list {
   --categorical-item-margin: .6rem;
   --categorical-item-multiplier: 1;
-  
+
   display: flex;
   height: 100%;
   justify-content: center;
@@ -20,9 +20,9 @@
   }
 
   &__content {
-    --categorical-available-height: calc(100vh - var(--categorical-bucket-basis) -
+    --categorical-available-height: calc(100% - var(--categorical-bucket-basis) -
       var(--interface-prompt-flex-basis) - var(--categorical-padding-top) -
-      var(--categorical-padding-bottom) - 
+      var(--categorical-padding-bottom) -
       (var(--categorical-item-margin) * 2 * var(--num-categorical-items) / var(--num-categorical-rows)));
     --num-categorical-items: 8;
     --num-categorical-rows: 2;

--- a/src/styles/components/_convex-hull.scss
+++ b/src/styles/components/_convex-hull.scss
@@ -1,0 +1,23 @@
+.convex-hull {
+  @include gpu;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  mix-blend-mode: lighten;
+
+  polygon {
+    stroke-linejoin: round;
+    stroke-width: calc(var(--base-node-size) / 2);
+  }
+}
+
+@for $i from 1 through 10 {
+  .convex-hull__cat-color-seq-#{$i} {
+    polygon {
+      stroke: var(--cat-color-seq-#{$i});
+      fill: var(--cat-color-seq-#{$i});
+    }
+  }
+}

--- a/src/styles/components/_error-boundary.scss
+++ b/src/styles/components/_error-boundary.scss
@@ -4,4 +4,5 @@
   flex-direction: column;
   height: 100%;
   justify-content: center;
+  padding: 0 10rem;
 }

--- a/src/styles/components/_information-interface.scss
+++ b/src/styles/components/_information-interface.scss
@@ -6,7 +6,7 @@ $asset-size-default: 16vh;
 .information-interface {
   @include interface-centering;
 
-  height: 100vh;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/styles/components/_overlay.scss
+++ b/src/styles/components/_overlay.scss
@@ -14,7 +14,7 @@ $close-button-size: 1rem;
   }
 
   &__content {
-    max-height: 80vh;
+    max-height: 80%;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0 .5rem; // to make scroll bar less jarring
@@ -43,7 +43,7 @@ $close-button-size: 1rem;
 
   &--fullscreen {
     display: block;
-    height: 100vh;
+    height: 100%;
     width: 100%;
     border-radius: 0;
     padding: 6rem;

--- a/src/styles/components/_overlay.scss
+++ b/src/styles/components/_overlay.scss
@@ -8,13 +8,16 @@ $close-button-size: 1rem;
   border-radius: .75rem;
   padding: 2rem;
   width: 50rem;
+  height: calc(100% - 4rem);
+  margin: 2rem;
+  display: flex;
+  flex-direction: column;
 
   &__title {
     text-align: center;
   }
 
   &__content {
-    max-height: 80%;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 0 .5rem; // to make scroll bar less jarring
@@ -47,6 +50,7 @@ $close-button-size: 1rem;
     width: 100%;
     border-radius: 0;
     padding: 6rem;
+    margin: 0;
 
     .input__container--hidden {
       position: absolute;

--- a/src/styles/components/_protocol.scss
+++ b/src/styles/components/_protocol.scss
@@ -6,6 +6,6 @@
   &__content {
     background-color: palette('background');
     flex: 1 1 auto;
-    height: 100vh;
+    height: 100%;
   }
 }

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -1,6 +1,6 @@
 $content-padding: 1rem;
 $module-name: search;
-$results-height: calc(100vh - 23rem);
+$results-height: calc(100% - 23rem);
 
 // Base input on global styling; override as needed below.
 @include text-input('#{$module-name}__input');
@@ -11,7 +11,7 @@ $results-height: calc(100vh - 23rem);
 
   background-color: color('cyber-grape');
   border-radius: var(--border-radius);
-  max-height: 100vh;
+  max-height: 100%;
   position: absolute;
   transform-origin: right bottom;
 

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -1,6 +1,6 @@
 $content-padding: 1rem;
 $module-name: search;
-$results-height: calc(100% - 23rem);
+$results-height: calc(100vh - 23rem);
 
 // Base input on global styling; override as needed below.
 @include text-input('#{$module-name}__input');

--- a/src/styles/components/_stage.scss
+++ b/src/styles/components/_stage.scss
@@ -1,10 +1,9 @@
 .stage {
-  background-color: palette('background');
-  height: 0;
+  height: 100%;
 
   &__interface {
     flex: 1 auto;
-    height: 100vh;
+    height: 100%;
     position: relative;
   }
 

--- a/src/styles/containers/_categorical-bin-interface.scss
+++ b/src/styles/containers/_categorical-bin-interface.scss
@@ -4,7 +4,7 @@
   --categorical-padding-top: 1rem;
   --categorical-padding-bottom: 4rem;
 
-  height: 100vh;
+  height: 100%;
   //sass-lint:disable shorthand-values
   padding: var(--categorical-padding-top) 0 var(--categorical-padding-bottom);
   overflow: hidden;

--- a/src/styles/containers/_finish-session-interface.scss
+++ b/src/styles/containers/_finish-session-interface.scss
@@ -3,7 +3,7 @@
 
   align-items: center;
   display: flex;
-  height: 100vh;
+  height: 100%;
   justify-content: center;
 
   &__frame {

--- a/src/styles/containers/_name-generator-interface.scss
+++ b/src/styles/containers/_name-generator-interface.scss
@@ -1,7 +1,7 @@
 .name-generator-interface {
   @include interface-centering;
 
-  height: 100vh;
+  height: 100%;
   padding: 1rem 0 4rem;
   overflow: hidden;
   display: flex;

--- a/src/styles/containers/_name-generator-list-interface.scss
+++ b/src/styles/containers/_name-generator-list-interface.scss
@@ -1,7 +1,7 @@
 .name-generator-list-interface {
   @include interface-centering;
 
-  height: 100vh;
+  height: 100%;
   padding: 1rem 0 4rem;
   overflow: hidden;
   display: flex;

--- a/src/styles/containers/_ordinal-bin-interface.scss
+++ b/src/styles/containers/_ordinal-bin-interface.scss
@@ -1,7 +1,7 @@
 .ordinal-bin-interface {
   @include interface-centering;
 
-  height: 100vh;
+  height: 100%;
   padding: 1rem 0 4rem;
   overflow: hidden;
   display: flex;

--- a/src/styles/containers/_setupScreen.scss
+++ b/src/styles/containers/_setupScreen.scss
@@ -58,7 +58,7 @@
 
   &__main {
     flex: 1 1 auto;
-    height: calc(100vh - var(--setup-header-height));
+    height: calc(100% - var(--setup-header-height));
     display: flex;
     align-items: center;
 

--- a/src/styles/helpers/_gpu.scss
+++ b/src/styles/helpers/_gpu.scss
@@ -1,7 +1,3 @@
 @mixin gpu {
-  backface-visibility: hidden;
-  perspective: 1000;
   transform: translate3d(0, 0, 0);
-  background-color: transparent;
-  transition: background-color ease var(--animation-duration-fast);
 }

--- a/src/utils/getAbsoluteBoundingRect.js
+++ b/src/utils/getAbsoluteBoundingRect.js
@@ -20,6 +20,10 @@ canvas, regardless of scrolling.
 **/
 
 export default function getAbsoluteBoundingRect(el) {
+    if (!el) {
+      return 0;
+    }
+
     var doc  = document,
         win  = window,
         body = doc.body,


### PR DESCRIPTION
Adds the ability to use a categorical variable to render convex hulls around nodes.

Remaining issues:

- [x] undefined group should not render as a group
- [x] drag and drop is broken
- [x] resize window should redraw hulls
- [x] performance should be reviewed
- [x] overlapping group membership should work. not tested.

To test: in development mode, generate test alters, or add nodes and set the categorical variable in the new node form to one or more values. Visit the narrative screen.