### PR TITLE
Transpose node type for Server export

### DIFF
--- a/src/utils/__tests__/networkFormat.test.js
+++ b/src/utils/__tests__/networkFormat.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import {
+  asExportableNode,
   asWorkerAgentEdge,
   asWorkerAgentNode,
 } from '../networkFormat';
@@ -69,5 +70,28 @@ describe('asWorkerAgentEdge', () => {
 
   it('returns a user-friendly edge type', () => {
     expect(asWorkerAgentEdge(edgeInNetwork, edgeTypeDefinition).type).toEqual('friend');
+  });
+});
+
+describe('asExportableNode', () => {
+  const nodeInNetwork = {
+    attributes: {
+      1234: 'userProp1value',
+    },
+    [nodePrimaryKeyProperty]: 'node1',
+    stageId: 42,
+  };
+
+  const nodeTypeDefinition = {
+    name: 'person',
+    variables: {
+      1234: { name: 'userProp1' },
+    },
+  };
+
+  it('transposes type and attributes', () => {
+    const exportNode = asExportableNode(nodeInNetwork, nodeTypeDefinition);
+    expect(exportNode.attributes.userProp1).toEqual('userProp1value');
+    expect(exportNode.type).toEqual('person');
   });
 });

--- a/src/utils/networkFormat.js
+++ b/src/utils/networkFormat.js
@@ -63,8 +63,13 @@ export const getNodeWithIdAttributes = (node, nodeVariables) => {
   };
 };
 
+/**
+ * Transposes attribute and type IDs to names for export.
+ * Unlike `asWorkerAgentNode()`, this does not flatten attributes.
+ */
 export const asExportableNode = (node, nodeTypeDefinition) => ({
   ...node,
+  type: nodeTypeDefinition.name,
   attributes: getNodeAttributesWithNamesResolved(node, (nodeTypeDefinition || {}).variables),
 });
 


### PR DESCRIPTION
#783 handled transposing node attributes, but I missed the node `type` there. `type` will required for filtering & querying.

This supports https://github.com/codaco/Server/issues/209.
