### PR TITLE
Fix cert errors with session export

### DIFF
--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -227,7 +227,8 @@ const sessionExportPromise = (pairedServer, action) => {
   const { remoteProtocolId, sessionUuid, sessionData } = action;
   if (pairedServer) {
     const client = new ApiClient(pairedServer);
-    return client.exportSession(remoteProtocolId, sessionUuid, sessionData);
+    return client.addTrustedCert().then(() =>
+      client.exportSession(remoteProtocolId, sessionUuid, sessionData));
   }
   return Promise.reject(new Error('No paired server available'));
 };


### PR DESCRIPTION
If a user attempts to export a session without having made other calls to
the API first, we need to ensure the main process is aware of the
pre-trusted certificate.