### PR TITLE
Fix/field types

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -997,6 +997,11 @@
         },
         {
           "variable": "57fefac9-561f-454a-8f78-81bd9470efaa",
+          "component": "ToggleButton",
+          "label": "Toggle button for something"
+        },
+        {
+          "variable": "57fefac9-561f-454a-8f78-81bd9470efaa",
           "component": "Toggle",
           "label": "Is the switch below not turned on?"
         }

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -951,7 +951,7 @@
         },
         {
           "variable": "c5fee926-855d-4419-b5bb-54e89010cea6",
-          "component": "Text"
+          "component": "Number"
         },
         {
           "variable": "04298634-eb5f-450a-84dd-95d2708e10c1",
@@ -973,7 +973,7 @@
         },
         {
           "variable": "e3eb5f0b-84ad-43f0-8db5-9f83cd3a56de",
-          "component": "Text",
+          "component": "Number",
           "label": "What is this person's age?"
         },
         {
@@ -1017,7 +1017,7 @@
         },
         {
           "variable": "c5fee926-855d-4419-b5bb-54e89010cea6",
-          "component": "Text"
+          "component": "Number"
         },
         {
           "variable": "04298634-eb5f-450a-84dd-95d2708e10c1",

--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -8,6 +8,7 @@ import {
   ToggleButtonGroup,
   RadioGroup,
   Text,
+  Number as NumberField,
   Toggle,
 } from '../ui/components/Fields';
 
@@ -25,6 +26,7 @@ const fieldTypes = {
   [FormComponent.CheckboxGroup]: CheckboxGroup,
   [FormComponent.RadioGroup]: RadioGroup,
   [FormComponent.Text]: Text,
+  [FormComponent.Number]: NumberField,
   [FormComponent.Toggle]: Toggle,
   [FormComponent.ToggleButtonGroup]: ToggleButtonGroup,
   [FormComponent.hidden]: props => <input {...props} type="hidden" />,

--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -31,7 +31,9 @@ const fieldTypes = {
   [FormComponent.ToggleButton]: ToggleButton,
   [FormComponent.Toggle]: Toggle,
   [FormComponent.ToggleButtonGroup]: ToggleButtonGroup,
-  [FormComponent.hidden]: props => <input {...props} type="hidden" />,
+  // In the case of the hidden input component { value } isn't actually passed along, but since
+  // this component is a placeholder, assume the interface for now.
+  [FormComponent.hidden]: ({ input, value }) => <input {...input} value={value} type="hidden" />,
 };
 
 const ComponentTypeNotFound = componentType =>
@@ -68,12 +70,13 @@ const getValidation = validation =>
 class Field extends PureComponent {
   constructor(props) {
     super(props);
-    this.component = (typeof props.component === 'string') ? getInputComponent(props.component) : props.component;
+    this.component = getInputComponent(props.component);
     this.validate = getValidation(props.validation);
   }
 
   render() {
     const { label, name, validation, ...rest } = this.props;
+
     return (
       <ReduxFormField
         {...rest}

--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -28,15 +28,16 @@ const fieldTypes = {
   [FormComponent.RadioGroup]: RadioGroup,
   [FormComponent.Text]: Text,
   [FormComponent.Number]: NumberField,
+  [FormComponent.ToggleButton]: ToggleButton,
   [FormComponent.Toggle]: Toggle,
   [FormComponent.ToggleButtonGroup]: ToggleButtonGroup,
   [FormComponent.hidden]: props => <input {...props} type="hidden" />,
 };
 
 const ComponentTypeNotFound = componentType =>
-  () => (<div>Input component {componentType} not found.</div>);
+  () => (<div>Input component &quot;{componentType}&quot; not found.</div>);
 
-export const getInputComponent = componentType =>
+export const getInputComponent = (componentType = 'Text') =>
   get(
     fieldTypes,
     componentType,

--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -6,6 +6,7 @@ import {
   Checkbox,
   CheckboxGroup,
   ToggleButtonGroup,
+  ToggleButton,
   RadioGroup,
   Text,
   Number as NumberField,
@@ -32,8 +33,15 @@ const fieldTypes = {
   [FormComponent.hidden]: props => <input {...props} type="hidden" />,
 };
 
+const ComponentTypeNotFound = componentType =>
+  () => (<div>Input component {componentType} not found.</div>);
+
 export const getInputComponent = componentType =>
-  get(fieldTypes, componentType, Text);
+  get(
+    fieldTypes,
+    componentType,
+    ComponentTypeNotFound(componentType),
+  );
 
 /**
 * Returns the named validation function, if no matching one is found it returns a validation

--- a/src/containers/Setup/ProtocolUrlForm.js
+++ b/src/containers/Setup/ProtocolUrlForm.js
@@ -15,7 +15,7 @@ const formConfig = {
     {
       label: 'Protocol URL',
       name: 'protocol_url',
-      component: 'TextInput',
+      component: 'Text',
       placeholder: 'Protocol URL',
       required: true,
     },

--- a/src/containers/Setup/__tests__/ProtocolUrlForm.test.js
+++ b/src/containers/Setup/__tests__/ProtocolUrlForm.test.js
@@ -26,4 +26,8 @@ describe('ProtocolUrlForm', () => {
     expect(submitButton).toHaveLength(1);
     expect(submitButton.text()).toMatch('Import');
   });
+
+  it('renders a text input', () => {
+    expect(component.find('input[type="text"]')).toHaveLength(1);
+  });
 });

--- a/src/containers/__tests__/Field.test.js
+++ b/src/containers/__tests__/Field.test.js
@@ -19,9 +19,21 @@ const reduxFormFieldProperties = { input: { name: 'foo', value: '' }, meta: { in
 
 describe('getInputComponent()', () => {
   it('should return a dom input', () => {
-    const Input = getInputComponent();
+    const Input = getInputComponent('Text');
     const subject = shallow(<Input {...reduxFormFieldProperties} />);
     expect(subject.find('input')).toHaveLength(1);
+  });
+
+  it('If field component is not found it returns an error component', () => {
+    const Input = getInputComponent('foobar');
+    const subject = shallow(<Input {...reduxFormFieldProperties} />);
+    expect(subject.text()).toEqual('Input component "foobar" not found.');
+  });
+
+  it('If no field component specified it returns a text input', () => {
+    const Input = getInputComponent();
+    const subject = shallow(<Input {...reduxFormFieldProperties} />);
+    expect(subject.find('input').prop('type')).toEqual('text');
   });
 });
 

--- a/src/containers/__tests__/Form.test.js
+++ b/src/containers/__tests__/Form.test.js
@@ -58,14 +58,14 @@ describe('<Form />', () => {
       {
         label: 'Name',
         name: 'name',
-        component: 'TextInput',
+        component: 'Text',
         placeholder: 'Name',
         validation: {},
       },
       {
         label: 'Nickname',
         name: 'nickname',
-        component: 'TextInput',
+        component: 'Text',
         placeholder: 'Nickname',
         validation: {},
       },

--- a/src/containers/__tests__/NodeForm.test.js
+++ b/src/containers/__tests__/NodeForm.test.js
@@ -11,7 +11,7 @@ const mockProps = {
   fields: [
     {
       variable: 'foo',
-      component: 'TextInput',
+      component: 'Text',
     },
   ],
   entity: 'node',

--- a/src/protocol-consts.js
+++ b/src/protocol-consts.js
@@ -34,6 +34,7 @@ const FormComponent = Object.freeze({
   RadioGroup: 'RadioGroup',
   Text: 'Text',
   Toggle: 'Toggle',
+  ToggleButton: 'ToggleButton',
   ToggleButtonGroup: 'ToggleButtonGroup',
   hidden: 'hidden',
 });

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -104,6 +104,7 @@
             "RadioGroup",
             "Text",
             "Toggle",
+            "ToggleButton",
             "ToggleButtonGroup",
             "hidden"
           ]

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -13,7 +13,11 @@ const propForm = (_, { entity, type }) => ({ entity, type });
 
 const rehydrateField = ({ registry, entity, type, field }) => {
   if (!field.variable) { return field; }
-  const entityVars = registry[entity][type] ? registry[entity][type].variables[field.variable] : {};
+
+  const entityVars = registry[entity][type] ?
+    registry[entity][type].variables[field.variable] :
+    {};
+
   const returnObject = {
     ...entityVars,
     name: field.variable,


### PR DESCRIPTION
Update Number input to return an integer
Update Field to define ToggleButton and Number field components, and also to show an error message if field component isn't found (rather than defaulting to a Text input).

Requires: https://github.com/codaco/Network-Canvas-UI/pull/92
Fixes: #764 