### PR TITLE
remove touch interaction from prompts, and remove hammerjs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8182,12 +8182,6 @@
                 "duplexer": "^0.1.1"
             }
         },
-        "hammerjs": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-            "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-            "dev": true
-        },
         "handle-thing": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
@@ -15289,15 +15283,6 @@
             "dev": true,
             "requires": {
                 "rematrix": "^0.2.2"
-            }
-        },
-        "react-hammerjs": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/react-hammerjs/-/react-hammerjs-1.0.1.tgz",
-            "integrity": "sha1-vB7Z6e99oFcWP7FpzhKRe21sp9g=",
-            "dev": true,
-            "requires": {
-                "hammerjs": "^2.0.8"
             }
         },
         "react-id-swiper": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "react-dom": "^16.5.2",
     "react-draggable": "^2.2.3",
     "react-flip-toolkit": "^5.0.5",
-    "react-hammerjs": "^1.0.1",
     "react-id-swiper": "^1.6.8",
     "react-markdown": "^3.6.0",
     "react-redux": "^5.0.7",

--- a/src/containers/PromptSwiper.js
+++ b/src/containers/PromptSwiper.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import Touch from 'react-hammerjs';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { findIndex } from 'lodash';
@@ -103,16 +102,14 @@ class PromptSwiper extends Component {
 
     return (
       <React.Fragment>
-        <Touch onTap={this.handleTap} onSwipe={this.handleSwipe} >
-          <div className={classes}>
-            <div className="prompts__pips">
-              <Pips count={prompts.length} currentIndex={promptIndex} />
-            </div>
-            {!this.state.minimized && (<div className="prompts__prompts">
-              {promptsRender}
-            </div>)}
+        <div className={classes}>
+          <div className="prompts__pips">
+            <Pips count={prompts.length} currentIndex={promptIndex} />
           </div>
-        </Touch>
+          {!this.state.minimized && (<div className="prompts__prompts">
+            {promptsRender}
+          </div>)}
+        </div>
         {minimizable && minimizeButton}
       </React.Fragment>
     );

--- a/src/containers/__tests__/__snapshots__/PromptSwiper.test.js.snap
+++ b/src/containers/__tests__/__snapshots__/PromptSwiper.test.js.snap
@@ -34,10 +34,164 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "children": Array [
-        <Hammer
-          onSwipe={[Function]}
-          onTap={[Function]}
+        <div
+          className="prompts"
         >
+          <div
+            className="prompts__pips"
+          >
+            <Pips
+              count={2}
+              currentIndex={0}
+              large={false}
+            />
+          </div>
+          <div
+            className="prompts__prompts"
+          >
+            <Prompt
+              isActive={true}
+              isLeaving={false}
+              label="bar"
+            />
+            <Prompt
+              isActive={false}
+              isLeaving={true}
+              label="foo"
+            />
+          </div>
+        </div>,
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <div
+              className="prompts__pips"
+            >
+              <Pips
+                count={2}
+                currentIndex={0}
+                large={false}
+              />
+            </div>,
+            <div
+              className="prompts__prompts"
+            >
+              <Prompt
+                isActive={true}
+                isLeaving={false}
+                label="bar"
+              />
+              <Prompt
+                isActive={false}
+                isLeaving={true}
+                label="foo"
+              />
+            </div>,
+          ],
+          "className": "prompts",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <Pips
+                count={2}
+                currentIndex={0}
+                large={false}
+              />,
+              "className": "prompts__pips",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "count": 2,
+                "currentIndex": 0,
+                "large": false,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <Prompt
+                  isActive={true}
+                  isLeaving={false}
+                  label="bar"
+                />,
+                <Prompt
+                  isActive={false}
+                  isLeaving={true}
+                  label="foo"
+                />,
+              ],
+              "className": "prompts__prompts",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "0",
+                "nodeType": "function",
+                "props": Object {
+                  "isActive": true,
+                  "isLeaving": false,
+                  "label": "bar",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": "1",
+                "nodeType": "function",
+                "props": Object {
+                  "isActive": false,
+                  "isLeaving": true,
+                  "label": "foo",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+            ],
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      false,
+    ],
+    "type": Symbol(react.fragment),
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
           <div
             className="prompts"
           >
@@ -64,50 +218,13 @@ ShallowWrapper {
                 label="foo"
               />
             </div>
-          </div>
-        </Hammer>,
-        false,
-      ],
-    },
-    "ref": null,
-    "rendered": Array [
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "children": <div
-            className="prompts"
-          >
-            <div
-              className="prompts__pips"
-            >
-              <Pips
-                count={2}
-                currentIndex={0}
-                large={false}
-              />
-            </div>
-            <div
-              className="prompts__prompts"
-            >
-              <Prompt
-                isActive={true}
-                isLeaving={false}
-                label="bar"
-              />
-              <Prompt
-                isActive={false}
-                isLeaving={true}
-                label="foo"
-              />
-            </div>
           </div>,
-          "onSwipe": [Function],
-          "onTap": [Function],
-        },
-        "ref": null,
-        "rendered": Object {
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
@@ -221,209 +338,6 @@ ShallowWrapper {
             },
           ],
           "type": "div",
-        },
-        "type": [Function],
-      },
-      false,
-    ],
-    "type": Symbol(react.fragment),
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "children": Array [
-          <Hammer
-            onSwipe={[Function]}
-            onTap={[Function]}
-          >
-            <div
-              className="prompts"
-            >
-              <div
-                className="prompts__pips"
-              >
-                <Pips
-                  count={2}
-                  currentIndex={0}
-                  large={false}
-                />
-              </div>
-              <div
-                className="prompts__prompts"
-              >
-                <Prompt
-                  isActive={true}
-                  isLeaving={false}
-                  label="bar"
-                />
-                <Prompt
-                  isActive={false}
-                  isLeaving={true}
-                  label="foo"
-                />
-              </div>
-            </div>
-          </Hammer>,
-          false,
-        ],
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": <div
-              className="prompts"
-            >
-              <div
-                className="prompts__pips"
-              >
-                <Pips
-                  count={2}
-                  currentIndex={0}
-                  large={false}
-                />
-              </div>
-              <div
-                className="prompts__prompts"
-              >
-                <Prompt
-                  isActive={true}
-                  isLeaving={false}
-                  label="bar"
-                />
-                <Prompt
-                  isActive={false}
-                  isLeaving={true}
-                  label="foo"
-                />
-              </div>
-            </div>,
-            "onSwipe": [Function],
-            "onTap": [Function],
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <div
-                  className="prompts__pips"
-                >
-                  <Pips
-                    count={2}
-                    currentIndex={0}
-                    large={false}
-                  />
-                </div>,
-                <div
-                  className="prompts__prompts"
-                >
-                  <Prompt
-                    isActive={true}
-                    isLeaving={false}
-                    label="bar"
-                  />
-                  <Prompt
-                    isActive={false}
-                    isLeaving={true}
-                    label="foo"
-                  />
-                </div>,
-              ],
-              "className": "prompts",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <Pips
-                    count={2}
-                    currentIndex={0}
-                    large={false}
-                  />,
-                  "className": "prompts__pips",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "count": 2,
-                    "currentIndex": 0,
-                    "large": false,
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Prompt
-                      isActive={true}
-                      isLeaving={false}
-                      label="bar"
-                    />,
-                    <Prompt
-                      isActive={false}
-                      isLeaving={true}
-                      label="foo"
-                    />,
-                  ],
-                  "className": "prompts__prompts",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": "0",
-                    "nodeType": "function",
-                    "props": Object {
-                      "isActive": true,
-                      "isLeaving": false,
-                      "label": "bar",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": "1",
-                    "nodeType": "function",
-                    "props": Object {
-                      "isActive": false,
-                      "isLeaving": true,
-                      "label": "foo",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-            ],
-            "type": "div",
-          },
-          "type": [Function],
         },
         false,
       ],


### PR DESCRIPTION
This PR removes touch interactivity from prompts, as a result of user feedback that two methods of navigation could be confusing.

As a bonus, I was able to remove the hammerJS dependency.