### PR TITLE
Fix hidden input values

### DIFF
--- a/src/containers/Field.js
+++ b/src/containers/Field.js
@@ -33,7 +33,7 @@ const fieldTypes = {
   [FormComponent.ToggleButtonGroup]: ToggleButtonGroup,
   // In the case of the hidden input component { value } isn't actually passed along, but since
   // this component is a placeholder, assume the interface for now.
-  [FormComponent.hidden]: ({ input, value }) => <input {...input} value={value} type="hidden" />,
+  [FormComponent.hidden]: ({ input }) => <input {...input} type="hidden" />,
 };
 
 const ComponentTypeNotFound = componentType =>

--- a/src/containers/__tests__/Field.test.js
+++ b/src/containers/__tests__/Field.test.js
@@ -56,3 +56,13 @@ describe('<Field />', () => {
 
   it('Loads options with optionsSelector');
 });
+
+describe('input', () => {
+  describe('[type="hidden"]', () => {
+    it('should populate a value from an input prop', () => {
+      const Input = getInputComponent('hidden');
+      const subject = shallow(<Input input={{ name: 'foo', value: 'bar' }} />);
+      expect(subject.find('input').prop('value')).toEqual('bar');
+    });
+  });
+});

--- a/src/selectors/__tests__/forms.test.js
+++ b/src/selectors/__tests__/forms.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { makeRehydrateForm } from '../forms';
+import { getDefaultFormValues, makeRehydrateForm } from '../forms';
 
 describe('forms selector', () => {
   describe('makeRehydrateForm', () => {
@@ -28,6 +28,17 @@ describe('forms selector', () => {
     it('returns form if defined', () => {
       const props = { stage: { form: 'person' } };
       expect(rehydrateForm(state, props)).toEqual(state.protocol.forms.person);
+    });
+  });
+
+  describe('getDefaultFormValues', () => {
+    const state = {
+      protocol: {
+        forms: { person: { fields: [] } },
+      },
+    };
+    it('returns an object keyed by form name', () => {
+      expect(getDefaultFormValues(state)).toHaveProperty('person');
     });
   });
 });

--- a/src/selectors/forms.js
+++ b/src/selectors/forms.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { map } from 'lodash';
+import { mapValues } from 'lodash';
 import { protocolRegistry, protocolForms } from './protocol';
 
 // Prop selectors
@@ -44,9 +44,12 @@ export const makeRehydrateForm = () =>
     (form, forms) => forms[form] || null,
   );
 
+/**
+ * @return {Object} keyed by form name
+ */
 export const getDefaultFormValues = createSelector(
   protocolForms,
-  forms => map(
+  forms => mapValues(
     forms,
     ({ fields }) =>
       fields.reduce(


### PR DESCRIPTION
Fixes #819.

This restores values to hidden inputs defined by a protocol. There are two parts to this:

- Change the return type of `getDefaultFormValues`. Based on the [`NodeForm` usage](https://github.com/codaco/Network-Canvas/blob/1aee497e17883e080fad714d9cf01ae9cb309ba4/src/containers/NodeForm.js#L89), I'm pretty sure this was the intent.
- Populate the value from the `input` prop. Based on [Redux Field docs](https://redux-form.com/6.0.0-alpha.4/docs/api/field.md/), I think this is what we'd expect, but I'm not very familiar with redux form, so I could be off here...

When using the app, I'm expecting that the form input contains the value, and that the generated node contains the corresponding attribute.