### PR TITLE
Add basic coverage for narrative interface

### DIFF
--- a/src/components/Canvas/__tests__/Canvas.test.js
+++ b/src/components/Canvas/__tests__/Canvas.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Canvas from '../Canvas';
+
+describe('<Canvas />', () => {
+  it('renders children in a canvas', () => {
+    const subject = shallow(<Canvas>foo</Canvas>);
+    expect(subject.find('.canvas')).toHaveLength(1);
+    expect(subject.childAt(0).text()).toEqual('foo');
+  });
+});

--- a/src/components/Canvas/__tests__/ConcentricCircles.test.js
+++ b/src/components/Canvas/__tests__/ConcentricCircles.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ConcentricCircles } from '../ConcentricCircles';
+
+jest.mock('../../../containers/Canvas/ConvexHulls', () => 'mockConvexHullsContainer');
+jest.mock('../../../containers/Canvas/EdgeLayout', () => 'mockEdgeLayoutContainer');
+
+describe('<ConcentricCircles />', () => {
+  let props;
+  beforeEach(() => {
+    props = { subject: {}, layoutVariable: '' };
+  });
+
+  it('renders a Canvas', () => {
+    expect(shallow(<ConcentricCircles {...props} />).find('Canvas')).toHaveLength(1);
+  });
+
+  it('renders a ConvexHulls container when hulls given', () => {
+    const subject = shallow(<ConcentricCircles {...props} convexHulls={[]} />);
+    expect(subject.find('mockConvexHullsContainer')).toHaveLength(1);
+  });
+
+  it('renders an EdgeLayout container when edges given', () => {
+    const subject = shallow(<ConcentricCircles {...props} displayEdges={[{}]} />);
+    expect(subject.find('mockEdgeLayoutContainer')).toHaveLength(1);
+  });
+});

--- a/src/components/Canvas/__tests__/ConvexHull.test.js
+++ b/src/components/Canvas/__tests__/ConvexHull.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ConvexHull from '../ConvexHull';
+
+describe('<ConvexHull />', () => {
+  it('renders a convex hull with a polygon', () => {
+    const props = { nodePoints: [{ attributes: { coords: { x: 0, y: 1 } } }], layoutVariable: 'coords', windowDimensions: {} };
+    expect(shallow(<ConvexHull {...props} />).find('polygon')).toHaveLength(1);
+  });
+});

--- a/src/components/Canvas/__tests__/ConvexHulls.test.js
+++ b/src/components/Canvas/__tests__/ConvexHulls.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ConvexHulls from '../ConvexHulls';
+
+describe('<ConvexHulls />', () => {
+  it('renders a ConvexHull for each group', () => {
+    const props = { nodesByGroup: { groupA: [], groupB: [] }, layoutVariable: '' };
+    expect(shallow(<ConvexHulls {...props} />).find('ConvexHull')).toHaveLength(2);
+  });
+});

--- a/src/components/Canvas/__tests__/NodeLayout.test.js
+++ b/src/components/Canvas/__tests__/NodeLayout.test.js
@@ -80,4 +80,26 @@ describe('<NodeLayout />', () => {
 
     expect(componentDidUpdate.mock.calls.length).toEqual(1);
   });
+
+  describe('isLinking', () => {
+    it('detects connecting state', () => {
+      const subject = shallow(<NodeLayout {...mockProps} connectFrom="1" />);
+      expect(subject.instance().isLinking({ _uid: '1' })).toBe(true);
+      expect(subject.instance().isLinking({ _uid: '2' })).toBe(false);
+    });
+  });
+
+  describe('highlighting', () => {
+    const subject = shallow(<NodeLayout highlightAttributes={[{ variable: 'isOn', color: 'neon' }]} />);
+
+    it('detects highlight state', () => {
+      expect(subject.instance().isHighlighted({ attributes: { isOn: true } })).toBe(true);
+      expect(subject.instance().isHighlighted({ attributes: {} })).toBe(false);
+    });
+
+    it('gets the highlight color', () => {
+      expect(subject.instance().getHighlightColor({ attributes: { isOn: true } })).toBe('neon');
+      expect(subject.instance().getHighlightColor({ attributes: {} })).toBe('');
+    });
+  });
 });

--- a/src/components/Canvas/__tests__/__snapshots__/NodeLayout.test.js.snap
+++ b/src/components/Canvas/__tests__/__snapshots__/NodeLayout.test.js.snap
@@ -14,7 +14,6 @@ ShallowWrapper {
     createEdge="bar"
     displayEdges={Array []}
     height={456}
-    highlightAttribute={null}
     highlightAttributes={Object {}}
     layoutVariable="foo"
     nodes={

--- a/src/containers/Canvas/PresetSwitcherKey.js
+++ b/src/containers/Canvas/PresetSwitcherKey.js
@@ -133,3 +133,7 @@ export default compose(
   window,
   connect(makeMapStateToProps),
 )(PresetSwitcherKey);
+
+export {
+  PresetSwitcherKey,
+};

--- a/src/containers/Canvas/__tests__/Accordion.test.js
+++ b/src/containers/Canvas/__tests__/Accordion.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Accordion from '../Accordion';
+
+describe('Accordion', () => {
+  it('calls a handler when anything clicked', () => {
+    // "Toggle" here has nothing to do with accordion open state
+    const handler = jest.fn();
+    const subject = shallow(<Accordion onAccordionToggle={handler} />);
+    subject.simulate('click');
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('toggles its own open state when header clicked', () => {
+    const onToggle = jest.fn();
+    const subject = shallow(<Accordion onAccordionToggle={onToggle} />);
+    const openState = subject.state('open');
+    subject.find('.accordion__toggle').simulate('click');
+    expect(subject.state('open')).not.toEqual(openState);
+  });
+});

--- a/src/containers/Canvas/__tests__/Annotations.test.js
+++ b/src/containers/Canvas/__tests__/Annotations.test.js
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Annotations from '../Annotations';
+
+describe('Annotations', () => {
+  it('renders lines drawn by user', () => {
+    const subject = shallow(<Annotations />);
+    subject.setState({ lines: [[{ x: 0, y: 0 }, { x: 1, y: 1 }]] });
+    const lines = subject.find('AnnotationLines').dive();
+    const firstLine = lines.find('AnnotationLine').dive();
+    expect(firstLine.find('path')).toHaveLength(1);
+  });
+});

--- a/src/containers/Canvas/__tests__/ButtonObstacle.test.js
+++ b/src/containers/Canvas/__tests__/ButtonObstacle.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ButtonObstacle from '../ButtonObstacle';
+
+describe('ButtonObstacle', () => {
+  it('renders a button obstacle', () => {
+    const subject = shallow(<ButtonObstacle />);
+    expect(subject.dive().find('Button')).toHaveLength(1);
+    expect(subject.instance().updateObstacle).toBeInstanceOf(Function);
+  });
+});

--- a/src/containers/Canvas/__tests__/ConvexHulls.test.js
+++ b/src/containers/Canvas/__tests__/ConvexHulls.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { createStore } from 'redux';
+
+import ConvexHulls from '../ConvexHulls';
+
+describe('Connect(ConvexHulls)', () => {
+  const mockState = {
+    sessions: {},
+    protocol: { variableRegistry: {} },
+  };
+  const mockProps = {
+    subject: {},
+  };
+  const subject = shallow(<ConvexHulls {...mockProps} store={createStore(() => mockState)} />);
+
+  it('provides a nodesByGroup prop', () => {
+    expect(subject.prop('nodesByGroup')).toBeDefined();
+  });
+
+  it('provides a categoricalOptions prop', () => {
+    expect(subject.prop('categoricalOptions')).toBeDefined();
+  });
+});

--- a/src/containers/Canvas/__tests__/NodeBucket.test.js
+++ b/src/containers/Canvas/__tests__/NodeBucket.test.js
@@ -10,9 +10,13 @@ const mockProps = {
 };
 
 describe('<NodeBucket />', () => {
+  it('displays content when positioning is not disabled', () => {
+    const component = shallow(<NodeBucket {...mockProps} />);
+    expect(component.children()).toHaveLength(1);
+  });
+
   it('does not display bucket when positioning is disabled', () => {
     const component = shallow(<NodeBucket {...mockProps} allowPositioning={false} />);
-
     expect(component.children()).toHaveLength(0);
   });
 });

--- a/src/containers/Canvas/__tests__/NodeLayout.test.js
+++ b/src/containers/Canvas/__tests__/NodeLayout.test.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+
+import NodeLayout from '../NodeLayout';
+
+describe('Connect(NodeLayout)', () => {
+  const mockState = {
+    sessions: {},
+  };
+  const mockProps = {};
+
+  it('provides a nodes prop', () => {
+    const subject = shallow(<NodeLayout {...mockProps} store={createStore(() => mockState)} />);
+    expect(subject.prop('nodes')).toBeDefined();
+  });
+
+  it('provides a drop target', () => {
+    const subject = mount(
+      <Provider store={createStore(() => mockState)}>
+        <NodeLayout {...mockProps} />
+      </Provider>);
+    expect(subject.find('DropTarget')).toHaveLength(1);
+  });
+});

--- a/src/containers/Canvas/__tests__/PresetSwitcher.test.js
+++ b/src/containers/Canvas/__tests__/PresetSwitcher.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PresetSwitcher from '../PresetSwitcher';
+
+describe('<PresetSwitcher />', () => {
+  const props = { presets: [{}, {}], presetIndex: 0 };
+
+  it('renders navigation', () => {
+    const subject = shallow(<PresetSwitcher {...props} />);
+    expect(subject.dive().find('.preset-switcher__navigation--next')).toHaveLength(1);
+  });
+
+  it('handles navigation', () => {
+    const handler = jest.fn();
+    const subject = shallow(<PresetSwitcher {...props} updatePreset={handler} />);
+    const next = subject.dive().find('.preset-switcher__navigation--next');
+    next.simulate('click');
+    expect(handler).toHaveBeenCalled();
+  });
+});

--- a/src/containers/Canvas/__tests__/PresetSwitcherKey.test.js
+++ b/src/containers/Canvas/__tests__/PresetSwitcherKey.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { createStore } from 'redux';
+
+import ConnectedPresetSwitcherKey, { PresetSwitcherKey } from '../PresetSwitcherKey';
+
+describe('<PresetSwitcherKey />', () => {
+  const props = { open: true };
+
+  it('renders accordions of preset options', () => {
+    const subject = shallow(<PresetSwitcherKey {...props} />);
+    expect(subject.find('Accordion').length).toBeGreaterThan(1);
+  });
+});
+
+describe('Connect(PresetSwitcherKey)', () => {
+  const mockState = {
+    protocol: { variableRegistry: {} },
+  };
+  const mockProps = {
+    displayEdges: [],
+    highlights: [],
+    subject: {},
+  };
+  let subject;
+
+  beforeEach(() => {
+    const portal = shallow(
+      <ConnectedPresetSwitcherKey {...mockProps} store={createStore(() => mockState)} />);
+    subject = portal.dive().find('Connect(PresetSwitcherKey)').dive();
+  });
+
+  it('provides a convexOptions prop', () => {
+    expect(subject.prop('convexOptions')).toBeDefined();
+  });
+
+  it('provides an edges prop', () => {
+    expect(subject.prop('edges')).toBeDefined();
+  });
+
+  it('provides a highlightLabels prop', () => {
+    expect(subject.prop('highlightLabels')).toBeDefined();
+  });
+});

--- a/src/containers/Canvas/__tests__/PromptObstacle.test.js
+++ b/src/containers/Canvas/__tests__/PromptObstacle.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PromptObstacle from '../PromptObstacle';
+
+describe('PromptObstacle', () => {
+  it('renders a prompt obstacle', () => {
+    const subject = shallow(<PromptObstacle />);
+    expect(subject.dive().find('Connect(PromptSwiper)')).toHaveLength(1);
+    expect(subject.instance().updateObstacle).toBeInstanceOf(Function);
+  });
+});

--- a/src/containers/Canvas/__tests__/__snapshots__/LayoutNode.test.js.snap
+++ b/src/containers/Canvas/__tests__/__snapshots__/LayoutNode.test.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
     onDropped={[Function]}
     onSelected={[Function]}
     selected={false}
+    selectedColor=""
     updateNode={[Function]}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -59,6 +60,7 @@ ShallowWrapper {
         onSelected={[Function]}
         scrollDirection="NO_SCROLL"
         selected={false}
+        selectedColor=""
       />,
       "className": "node-layout__node",
       "style": Object {
@@ -88,6 +90,7 @@ ShallowWrapper {
         "onSelected": [Function],
         "scrollDirection": "NO_SCROLL",
         "selected": false,
+        "selectedColor": "",
       },
       "ref": null,
       "rendered": null,
@@ -119,6 +122,7 @@ ShallowWrapper {
           onSelected={[Function]}
           scrollDirection="NO_SCROLL"
           selected={false}
+          selectedColor=""
         />,
         "className": "node-layout__node",
         "style": Object {
@@ -148,6 +152,7 @@ ShallowWrapper {
           "onSelected": [Function],
           "scrollDirection": "NO_SCROLL",
           "selected": false,
+          "selectedColor": "",
         },
         "ref": null,
         "rendered": null,

--- a/src/selectors/__tests__/canvas.test.js
+++ b/src/selectors/__tests__/canvas.test.js
@@ -1,23 +1,24 @@
 /* eslint-env jest */
 
 import {
+  makeGetNodesByCategorical,
   makeGetNextUnplacedNode,
   makeGetPlacedNodes,
   makeGetDisplayEdges,
 } from '../canvas';
+
+const node1 = { _uid: 1, type: 'person', attributes: { role: ['a'], name: 'alpha', closeness: [1, 1] } };
+const node2 = { _uid: 2, type: 'person', attributes: { role: ['a'], name: 'foxtrot' } };
+const node3 = { _uid: 3, type: 'person', attributes: { role: ['a'], name: 'bravo' } };
+const node4 = { _uid: 4, type: 'person', attributes: { role: ['a'], name: 'echo', closeness: [1, 1] } };
+const node5 = { _uid: 5, type: 'person', attributes: { role: ['b'], name: 'charlie', closeness: [1, 1] } };
 
 const mockState = {
   session: 'testSession',
   sessions: {
     testSession: {
       network: {
-        nodes: [
-          { _uid: 1, type: 'person', attributes: { name: 'alpha', closeness: [1, 1] } },
-          { _uid: 2, type: 'person', attributes: { name: 'foxtrot' } },
-          { _uid: 3, type: 'person', attributes: { name: 'bravo' } },
-          { _uid: 4, type: 'person', attributes: { name: 'echo', closeness: [1, 1] } },
-          { _uid: 5, type: 'person', attributes: { name: 'charlie', closeness: [1, 1] } },
-        ],
+        nodes: [node1, node2, node3, node4, node5],
         edges: [
           { type: 'friend', from: 1, to: 4 },
           { type: 'friend', from: 4, to: 5 },
@@ -43,10 +44,27 @@ describe('canvas selectors', () => {
       const subject = getPlacedNodes(mockState, props);
 
       expect(subject).toEqual([
-        { _uid: 1, type: 'person', attributes: { name: 'alpha', closeness: [1, 1] } },
-        { _uid: 4, type: 'person', attributes: { name: 'echo', closeness: [1, 1] } },
-        { _uid: 5, type: 'person', attributes: { name: 'charlie', closeness: [1, 1] } },
+        node1,
+        node4,
+        node5,
       ]);
+    });
+  });
+
+  describe('makeGetNodesByCategorical()', () => {
+    const getNodesByCategorical = makeGetNodesByCategorical();
+    const props = {
+      subject: {
+        entity: 'node',
+        type: 'person',
+      },
+      layoutVariable: 'closeness',
+      groupVariable: 'role',
+    };
+    it('groups placed nodes based on groupVariable', () => {
+      const groups = getNodesByCategorical(mockState, props);
+      expect(groups.a).toEqual([node1, node4]);
+      expect(groups.b).toEqual([node5]);
     });
   });
 


### PR DESCRIPTION
This fixes two snapshots and adds some tests for the new canvas/narrative-related components, containers and selectors.