### PR TITLE
make sure highlight attribute updates the right attribute

### DIFF
--- a/src/containers/Canvas/NodeLayout.js
+++ b/src/containers/Canvas/NodeLayout.js
@@ -69,14 +69,16 @@ const withSelectHandlers = compose(
 
         updateLinkFrom(null);
       },
-    toggleHighlightAttribute: ({ allowHighlighting, highlightAttribute, toggleHighlight }) =>
+    toggleHighlightAttribute: ({ allowHighlighting, highlightAttributes, toggleHighlight }) =>
       (node) => {
         if (!allowHighlighting) { return; }
-        const newVal = !node[nodeAttributesProperty][highlightAttribute];
-        toggleHighlight(
-          node[nodePrimaryKeyProperty],
-          { [highlightAttribute]: newVal },
-        );
+        highlightAttributes.forEach((highlightAttribute) => {
+          const newVal = !node[nodeAttributesProperty][highlightAttribute.variable];
+          toggleHighlight(
+            node[nodePrimaryKeyProperty],
+            { [highlightAttribute.variable]: newVal },
+          );
+        });
       },
   }),
   withHandlers({


### PR DESCRIPTION
With the update to allow multiple highlight attributes to support Narrative interface, toggle highlight was not updated. This updates the toggle for highlighting attributes.

To test, in master you cannot toggle attributes on Sociogram prompts; it toggles "undefined" instead of a valid attribute. Here, you can toggle the correct attribute as expected.