### PR TITLE
remove android-maxSdkVersion from config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -67,6 +67,6 @@
     <plugin name="cordova-plugin-zeroconf" spec="^1.3.3" />
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
     <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
-    <engine name="android" spec="^7.1.1" />
     <engine name="ios" spec="^4.5.5" />
+    <engine name="android" spec="^7.1.4" />
 </widget>

--- a/config.xml
+++ b/config.xml
@@ -58,7 +58,6 @@
     <preference name="AllowInlineMediaPlayback" value="true" />
     <preference name="android-minSdkVersion" value="25" />
     <preference name="android-targetSdkVersion" value="27" />
-    <preference name="android-maxSdkVersion" value="27" />
     <plugin name="cordova-plugin-app-version" spec="^0.1.9" />
     <plugin name="cordova-plugin-file" spec="^5.0.0" />
     <plugin name="cordova-plugin-file-transfer" spec="^1.7.1" />

--- a/config.xml
+++ b/config.xml
@@ -68,5 +68,5 @@
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
     <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
     <engine name="ios" spec="^4.5.5" />
-    <engine name="android" spec="^7.1.4" />
+    <engine name="android" spec="^7.1.2" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,16 +3389,16 @@
             "dev": true
         },
         "cordova-android": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.1.4.tgz",
-            "integrity": "sha512-Rtvu002I83uzfVyCsE6p2krFKVHt9TSAqZUATes+zH+o9cdxYGrLHY+PKCQo4SLCdSMdrkIHCDnQPTYTp/d7+g==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.1.2.tgz",
+            "integrity": "sha512-w28HJGtfAZCT96hVH9BMppWMnmDTZplKu2NRQZN2dCr5e9r7aHpay41MYy9IBkh8+7E7lMo/jZkRwBDNr4VnEg==",
             "requires": {
                 "abbrev": "*",
-                "android-versions": "1.4.0",
+                "android-versions": "1.3.0",
                 "ansi": "*",
                 "balanced-match": "*",
                 "base64-js": "1.2.0",
-                "big-integer": "1.6.32",
+                "big-integer": "*",
                 "bplist-parser": "*",
                 "brace-expansion": "*",
                 "concat-map": "*",
@@ -3411,12 +3411,12 @@
                 "minimatch": "*",
                 "nopt": "3.0.1",
                 "once": "*",
-                "path-is-absolute": "1.0.1",
+                "path-is-absolute": "*",
                 "plist": "2.1.0",
                 "properties-parser": "0.2.3",
                 "q": "1.4.1",
                 "sax": "0.3.5",
-                "semver": "5.5.0",
+                "semver": "*",
                 "shelljs": "0.5.3",
                 "underscore": "*",
                 "unorm": "*",
@@ -3430,7 +3430,7 @@
                     "bundled": true
                 },
                 "android-versions": {
-                    "version": "1.4.0",
+                    "version": "1.3.0",
                     "bundled": true,
                     "requires": {
                         "semver": "^5.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "network-canvas",
-    "version": "4.0.0-alpha.9",
+    "version": "4.0.0-alpha.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3389,16 +3389,16 @@
             "dev": true
         },
         "cordova-android": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.1.1.tgz",
-            "integrity": "sha512-MAOwEMT3TuGjKw4McNzzYyHmxkWY3ozafbIgdMAvPzqSBVGIcn+H3SmWfaHtUXfmIPFliT171ICsSm6W5lZXEA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.1.4.tgz",
+            "integrity": "sha512-Rtvu002I83uzfVyCsE6p2krFKVHt9TSAqZUATes+zH+o9cdxYGrLHY+PKCQo4SLCdSMdrkIHCDnQPTYTp/d7+g==",
             "requires": {
                 "abbrev": "*",
-                "android-versions": "1.3.0",
+                "android-versions": "1.4.0",
                 "ansi": "*",
                 "balanced-match": "*",
                 "base64-js": "1.2.0",
-                "big-integer": "*",
+                "big-integer": "1.6.32",
                 "bplist-parser": "*",
                 "brace-expansion": "*",
                 "concat-map": "*",
@@ -3411,12 +3411,12 @@
                 "minimatch": "*",
                 "nopt": "3.0.1",
                 "once": "*",
-                "path-is-absolute": "*",
+                "path-is-absolute": "1.0.1",
                 "plist": "2.1.0",
                 "properties-parser": "0.2.3",
                 "q": "1.4.1",
                 "sax": "0.3.5",
-                "semver": "*",
+                "semver": "5.5.0",
                 "shelljs": "0.5.3",
                 "underscore": "*",
                 "unorm": "*",
@@ -3430,7 +3430,7 @@
                     "bundled": true
                 },
                 "android-versions": {
-                    "version": "1.3.0",
+                    "version": "1.4.0",
                     "bundled": true,
                     "requires": {
                         "semver": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "xss": "^0.3.4"
   },
   "dependencies": {
-    "cordova-android": "^7.1.1",
+    "cordova-android": "^7.1.4",
     "cordova-ios": "^4.5.5",
     "cordova-plugin-app-version": "^0.1.9",
     "cordova-plugin-device": "^2.0.2",
@@ -230,8 +230,8 @@
   },
   "cordova": {
     "platforms": [
-      "android",
-      "ios"
+      "ios",
+      "android"
     ],
     "plugins": {
       "cordova-plugin-app-version": {},

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "xss": "^0.3.4"
   },
   "dependencies": {
-    "cordova-android": "^7.1.4",
+    "cordova-android": "^7.1.2",
     "cordova-ios": "^4.5.5",
     "cordova-plugin-app-version": "^0.1.9",
     "cordova-plugin-device": "^2.0.2",


### PR DESCRIPTION
The `maxSdkVersion` property is causing the app to not be installable on API level 28 devices. As per [the documentation](https://developer.android.com/guide/topics/manifest/uses-sdk-element), there is no need to set this property (and in fact it is a bad idea).

In classic Cordova fashion, there was a bug in both our previous and the current version of the android platform, which has required updating to a specific version in order to make this property be correctly built into our compiled APK.