### PR TITLE
Feature/quick node add

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,7 +10,7 @@
     <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/supports-screens">
         <supports-screens android:anyDensity="false" android:largeScreens="true" android:normalScreens="false" android:requiresSmallestWidthDp="600" android:resizeable="false" android:smallScreens="false" android:xlargeScreens="true" />
     </edit-config>
-    <content src="http://192.168.1.66:3000/" />
+    <content src="index.html" />
     <access origin="*" />
     <access origin="cdvfile://*" />
     <allow-intent href="http://*/*" />

--- a/config.xml
+++ b/config.xml
@@ -30,7 +30,6 @@
     </platform>
     <platform name="ios">
         <allow-navigation href="*" />
-        <allow-navigation href="*" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <icon height="40" src="www/icons/ios/NC-Square-40.png" width="40" />

--- a/public/protocols/development.netcanvas/nodeLabelWorker.js
+++ b/public/protocols/development.netcanvas/nodeLabelWorker.js
@@ -71,7 +71,7 @@ function nodeLabelWorker({ node, network }) {
 
 
   // For our example worker we will return a different label dependant on the node type.
-  let label = node.name;
+  let label = node.nickname || node.name;
 
   switch (node.networkCanvasType) {
     case 'person':

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1066,6 +1066,7 @@
       "type": "NameGenerator",
       "label": "NG Closeness",
       "form": "person",
+      "quickAdd": true,
       "subject": {
         "entity": "node",
         "type": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466"

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1066,7 +1066,6 @@
       "type": "NameGenerator",
       "label": "NG Closeness",
       "form": "person",
-      "quickAdd": true,
       "subject": {
         "entity": "node",
         "type": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466"
@@ -1143,6 +1142,33 @@
       ]
     },
     {
+      "id": "namegen2",
+      "type": "NameGenerator",
+      "label": "NG Quick add",
+      "quickAdd": true,
+      "subject": {
+        "entity": "node",
+        "type": "eda5e3bb-8e1c-4216-9e06-adc0ff6b7f73"
+      },
+      "panels": [
+        {
+          "id": "cab85e8a-0a9e-4d5f-9242-930b5d9ce3e4",
+          "title": "Other Venues",
+          "dataSource": "existing"
+        }
+      ],
+      "prompts": [
+        {
+          "id": "6cl",
+          "text": "This name generator creates venue nodes using the quick add form"
+        },
+        {
+          "id": "6su",
+          "text": "Another venue prompt"
+        }
+      ]
+    },
+    {
       "id": "ordinalBin1",
       "type": "OrdinalBin",
       "label": "Contact Freq.",
@@ -1193,7 +1219,7 @@
           "id": "visitFreq",
           "text": "Showing an ordinalbin interface with a node type other than person.",
           "variable": "a39a86ef-18c7-4545-8fbc-d0e5894565d0",
-          "color": "ord-color-seq-4"
+          "color": "ord-color-seq-7"
         }
       ]
     },

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -283,7 +283,7 @@
             "label": "Special category",
             "description": "A special category",
             "type": "ordinal",
-            "options": [46,56]
+            "options": [46,56,54]
           },
           "04298634-eb5f-450a-84dd-95d2708e10c1": {
             "name": "dataSource",
@@ -1145,7 +1145,7 @@
           "id": "6cl",
           "text": "This name generator creates venue nodes using the quick add form",
           "additionalAttributes": {
-            "b6f2c4b9-e42f-459b-8f59-a11a685f460d": 54
+            "55f1fbbe-2fe5-42a7-88fb-9a8e5e659d2f": true
           }
         },
         {

--- a/src/containers/Interfaces/NameGenerator.js
+++ b/src/containers/Interfaces/NameGenerator.js
@@ -151,6 +151,7 @@ class NameGenerator extends Component {
           <QuickNodeForm
             stage={this.props.stage}
             addNodes={this.props.addNodes}
+            nodeIconName={nodeIconName}
           />
         }
         <NodeBin id="NODE_BIN" />

--- a/src/containers/Node.js
+++ b/src/containers/Node.js
@@ -64,7 +64,6 @@ class Node extends PureComponent {
       color,
       workerUrl,
     } = this.props;
-    console.log(this.props);
     const useWorkerLabel = workerUrl !== false && !this.state.workerError;
     const label = useWorkerLabel ? (this.state.label || '') : this.props.getLabel(this.props);
     return (

--- a/src/containers/Node.js
+++ b/src/containers/Node.js
@@ -64,7 +64,7 @@ class Node extends PureComponent {
       color,
       workerUrl,
     } = this.props;
-
+    console.log(this.props);
     const useWorkerLabel = workerUrl !== false && !this.state.workerError;
     const label = useWorkerLabel ? (this.state.label || '') : this.props.getLabel(this.props);
     return (

--- a/src/containers/QuickNodeForm.js
+++ b/src/containers/QuickNodeForm.js
@@ -1,0 +1,124 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { bindActionCreators, compose } from 'redux';
+import { connect } from 'react-redux';
+import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
+import withPrompt from '../behaviours/withPrompt';
+import { makeGetNodeDisplayVariable } from '../selectors/interface';
+import { makeGetPromptNodeAttributes } from '../selectors/name-generator';
+import { nodeAttributesProperty } from '../ducks/modules/network';
+import { Icon } from '../ui/components/';
+import { Node } from './';
+
+class QuickNodeForm extends PureComponent {
+  static propTypes = {
+    addNodes: PropTypes.func.isRequired.isRequired,
+    activePromptAttributes: PropTypes.object.isRequired,
+    newNodeAttributes: PropTypes.object.isRequired,
+    displayVariable: PropTypes.string.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      nodeLabel: '',
+      show: false,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmitForm = this.handleSubmitForm.bind(this);
+    this.handleCloseForm = this.handleCloseForm.bind(this);
+    this.handleOpenForm = this.handleOpenForm.bind(this);
+  }
+
+  handleOpenForm = () => {
+    console.log('open');
+    this.setState({
+      show: true,
+    });
+  }
+
+  handleCloseForm = () => {
+    this.setState({
+      show: false,
+      nodeLabel: '',
+    });
+  }
+
+  handleChange(e) {
+    this.setState({
+      nodeLabel: e.target.value,
+    });
+  }
+
+  handleSubmitForm = (e) => {
+    e.preventDefault();
+    this.props.addNodes({
+      [nodeAttributesProperty]: {
+        ...this.props.activePromptAttributes,
+        [this.props.displayVariable]: this.state.nodeLabel,
+      },
+    }, this.props.newNodeAttributes);
+    this.setState({
+      nodeLabel: '',
+    });
+  }
+
+  render() {
+    return (
+      <div className="quick-add">
+        <div className={cx('quick-add-container', { 'quick-add-container--show': this.state.show })}>
+          <form autoComplete="off" onSubmit={this.handleSubmitForm}>
+            {this.state.show &&
+            <input
+              className="quick-add-container__label-input"
+              key="label"
+              autoFocus
+              onChange={this.handleChange}
+              onBlur={this.handleCloseForm}
+              placeholder="Type a name and press enter"
+              value={this.state.nodeLabel}
+              type="text"
+            />
+            }
+          </form>
+        </div>
+        <div className={cx('flip-box', { 'flip-box--flip': this.state.nodeLabel.length > 0 })}>
+          <div className="flip-box-inner">
+            <div className="flip-box-front" onClick={this.handleOpenForm}>
+              <Icon name="add-a-place" />
+            </div>
+            <div className="flip-box-back">
+              <Node
+                type={this.props.stage.subject.type}
+                attributes={{
+                  [this.props.displayVariable]: this.state.nodeLabel,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => {
+  const getNodeDisplayVariable = makeGetNodeDisplayVariable();
+  const getPromptNodeAttributes = makeGetPromptNodeAttributes();
+
+  return {
+    displayVariable: getNodeDisplayVariable(state, props),
+    activePromptAttributes: props.prompt.additionalAttributes,
+    newNodeAttributes: getPromptNodeAttributes(state, props),
+  };
+};
+
+export { QuickNodeForm };
+
+export default compose(
+  withPrompt,
+  connect(mapStateToProps, null),
+)(QuickNodeForm);

--- a/src/containers/QuickNodeForm.js
+++ b/src/containers/QuickNodeForm.js
@@ -1,9 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { bindActionCreators, compose } from 'redux';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
 import withPrompt from '../behaviours/withPrompt';
 import { makeGetNodeDisplayVariable } from '../selectors/interface';
 import { makeGetPromptNodeAttributes } from '../selectors/name-generator';
@@ -16,7 +15,9 @@ class QuickNodeForm extends PureComponent {
     addNodes: PropTypes.func.isRequired.isRequired,
     activePromptAttributes: PropTypes.object.isRequired,
     newNodeAttributes: PropTypes.object.isRequired,
+    stage: PropTypes.object.isRequired,
     displayVariable: PropTypes.string.isRequired,
+    nodeIconName: PropTypes.string.isRequired,
   };
 
   constructor(props) {
@@ -34,7 +35,6 @@ class QuickNodeForm extends PureComponent {
   }
 
   handleOpenForm = () => {
-    console.log('open');
     this.setState({
       show: true,
     });
@@ -67,34 +67,45 @@ class QuickNodeForm extends PureComponent {
   }
 
   render() {
+    const {
+      nodeIconName,
+      displayVariable,
+      stage,
+    } = this.props;
+
+    const {
+      show,
+      nodeLabel,
+    } = this.state;
+
     return (
       <div className="quick-add">
-        <div className={cx('quick-add-container', { 'quick-add-container--show': this.state.show })}>
+        <div className={cx('quick-add-container', { 'quick-add-container--show': show })}>
           <form autoComplete="off" onSubmit={this.handleSubmitForm}>
-            {this.state.show &&
+            {show &&
             <input
               className="quick-add-container__label-input"
               key="label"
-              autoFocus
+              autoFocus // eslint-disable-line
               onChange={this.handleChange}
               onBlur={this.handleCloseForm}
-              placeholder="Type a name and press enter"
-              value={this.state.nodeLabel}
+              placeholder="Type a name and press enter..."
+              value={nodeLabel}
               type="text"
             />
             }
           </form>
         </div>
-        <div className={cx('flip-box', { 'flip-box--flip': this.state.nodeLabel.length > 0 })}>
+        <div className={cx('flip-box', { 'flip-box--flip': nodeLabel.length > 0 })}>
           <div className="flip-box-inner">
             <div className="flip-box-front" onClick={this.handleOpenForm}>
-              <Icon name="add-a-place" />
+              <Icon name={nodeIconName} />
             </div>
             <div className="flip-box-back">
               <Node
-                type={this.props.stage.subject.type}
+                type={stage.subject.type}
                 attributes={{
-                  [this.props.displayVariable]: this.state.nodeLabel,
+                  [displayVariable]: this.state.nodeLabel,
                 }}
               />
             </div>

--- a/src/containers/QuickNodeForm.js
+++ b/src/containers/QuickNodeForm.js
@@ -80,11 +80,11 @@ class QuickNodeForm extends PureComponent {
 
     return (
       <div className="quick-add">
-        <div className={cx('quick-add-container', { 'quick-add-container--show': show })}>
+        <div className={cx('quick-add-form', { 'quick-add-form--show': show })}>
           <form autoComplete="off" onSubmit={this.handleSubmitForm}>
             {show &&
             <input
-              className="quick-add-container__label-input"
+              className="quick-add-form__label-input"
               key="label"
               autoFocus // eslint-disable-line
               onChange={this.handleChange}
@@ -96,12 +96,12 @@ class QuickNodeForm extends PureComponent {
             }
           </form>
         </div>
-        <div className={cx('flip-box', { 'flip-box--flip': nodeLabel.length > 0 })}>
-          <div className="flip-box-inner">
-            <div className="flip-box-front" onClick={this.handleOpenForm}>
+        <div className={cx('flip-button', { 'flip-button--flip': nodeLabel.length > 0 })}>
+          <div className="flip-button-inner">
+            <div className="flip-button-front" onClick={this.handleOpenForm}>
               <Icon name={nodeIconName} />
             </div>
-            <div className="flip-box-back">
+            <div className="flip-button-back">
               <Node
                 type={stage.subject.type}
                 attributes={{

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -8,6 +8,7 @@ export { default as NodePanels } from './NodePanels';
 export { default as Field } from './Field';
 export { default as Node } from './Node';
 export { default as NodeForm } from './NodeForm';
+export { default as QuickNodeForm } from './QuickNodeForm';
 export { default as FormWizard } from './FormWizard';
 export { default as LoadScreen } from './LoadScreen';
 export { default as LoadParamsRoute } from './LoadParamsRoute';

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -151,6 +151,9 @@
             "null"
           ]
         },
+        "quickAdd": {
+          "type": "boolean"
+        },
         "subject": {
           "$ref": "#/definitions/Subject"
         },

--- a/src/styles/components/_all.scss
+++ b/src/styles/components/_all.scss
@@ -50,3 +50,4 @@
 @import 'overlay';
 @import 'accordion';
 @import 'annotations';
+@import 'quick-add';

--- a/src/styles/components/_node-bin.scss
+++ b/src/styles/components/_node-bin.scss
@@ -4,18 +4,21 @@
   background-image: url('../images/node-bin.svg');
   background-repeat: no-repeat;
   background-size: contain;
-  width: 60px;
-  height: 80px;
-  transform: translate3d(0, 200px, 0);
+  width: 5rem;
+  height: 7rem;
+  transform: translateY(1.8rem);
   opacity: 0;
+  position: absolute;
+  bottom: 1.8rem;
+  left: 50%;
+  overflow: hidden;
 
   &--active {
-    transform: translate3d(0, 0, 0);
+    transform: translateY(0);
     opacity: 1;
   }
 
   &--hover {
-    width: 120px;
-    height: 160px;
+    transform: scale(2);
   }
 }

--- a/src/styles/components/_preset-switcher.scss
+++ b/src/styles/components/_preset-switcher.scss
@@ -13,7 +13,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: width var(--animation-duration-standard) var(--animation-duration-standard) var(--animation-easing);
+    transition: width var(--animation-duration-standard) var(--animation-easing);
 
     .icon {
       height: 1.5rem;

--- a/src/styles/components/_quick-add.scss
+++ b/src/styles/components/_quick-add.scss
@@ -4,83 +4,83 @@
   right: 2.8rem;
   display: flex;
   align-items: center;
-}
 
-.quick-add-container {
-  @include transition-properties((opacity transform), var(--animation-easing), var(--animation-duration-fast));
-  width: 20rem;
-  opacity: 0;
-  transform-origin: center right;
-  transform: scaleX(0);
-  z-index: var(--z-global-ui);
-  margin-right: unit(1);
+  .quick-add-form {
+    @include transition-properties((opacity transform), var(--animation-easing), var(--animation-duration-fast));
+    width: 20rem;
+    opacity: 0;
+    transform-origin: center right;
+    transform: scaleX(0);
+    z-index: var(--z-global-ui);
+    margin-right: unit(1);
 
-  &--show {
-    opacity: 1;
-    transform: scaleX(1);
-  }
+    &--show {
+      opacity: 1;
+      transform: scaleX(1);
+    }
 
-  &__label-input {
-    width: 100%;
-    padding: unit(2) unit(4);
-    border-radius: 5rem;
-    border: 0;
-    background: var(--text);
-    color: var(--text-dark);
-    font-size: 1.2rem;
-    font-weight: bold;
+    &__label-input {
+      width: 100%;
+      padding: unit(2) unit(4);
+      border-radius: 5rem;
+      border: 0;
+      background: var(--text);
+      color: var(--text-dark);
+      font-size: 1.2rem;
+      font-weight: bold;
 
-    &::placeholder {
-      font-style: italic;
-      font-weight: 100;
+      &::placeholder {
+        font-style: italic;
+        font-weight: 100;
+      }
     }
   }
-}
 
-/* The flip box container - set the width and height to whatever you want. We have added the border property to demonstrate that the flip itself goes out of the box on hover (remove perspective if you don't want the 3D effect */
-.flip-box {
-  width: 7rem;
-  height: 7rem;
-  perspective: 1000px;
-}
+  .flip-button {
+    width: 7rem;
+    height: 7rem;
+    perspective: 1000px;
+  }
 
-/* This container is needed to position the front and back side */
-.flip-box-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  text-align: center;
-  transition: transform var(--animation-duration-fast);
-  transform-style: preserve-3d;
-}
-
-/* Do an horizontal flip when you move the mouse over the flip box container */
-.flip-box--flip .flip-box-inner {
-  transform: rotateY(180deg);
-}
-
-/* Position the front and back side */
-.flip-box-front, .flip-box-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
-
-  .node, .icon {
-    font-size: 9rem;
+  /* This container is needed to position the front and back side */
+  .flip-button-inner {
+    position: relative;
     width: 100%;
     height: 100%;
+    text-align: center;
+    transition: transform var(--animation-duration-fast);
+    transform-style: preserve-3d;
   }
-}
 
-/* Style the front side */
-.flip-box-front {
-  transform-origin: 1rem 0;
-  margin: 0 0 0 0.7rem;
-  padding-bottom: 0.3rem;
-}
+  .flip-button--flip {
+    .flip-button-inner {
+      transform: rotateY(180deg);
+    }
+  }
 
-/* Style the back side */
-.flip-box-back {
-  transform: rotateY(180deg);
+  .flip-button-front,
+  .flip-button-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+
+    .node,
+    .icon {
+      font-size: 9rem;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .flip-button-front {
+    transform-origin: 1rem 0;
+    margin: 0 0 0 0.7rem;
+    padding-bottom: 0.3rem;
+  }
+
+  .flip-button-back {
+    transform: rotateY(180deg);
+  }
+
 }

--- a/src/styles/components/_quick-add.scss
+++ b/src/styles/components/_quick-add.scss
@@ -7,7 +7,7 @@
 
   .quick-add-form {
     @include transition-properties((opacity transform), var(--animation-easing), var(--animation-duration-fast));
-    width: 20rem;
+    width: 25rem;
     opacity: 0;
     transform-origin: center right;
     transform: scaleX(0);

--- a/src/styles/components/_quick-add.scss
+++ b/src/styles/components/_quick-add.scss
@@ -1,18 +1,19 @@
 .quick-add {
   position: absolute;
   bottom: 1.8rem;
-  right: 1.8rem;
+  right: 2.8rem;
   display: flex;
   align-items: center;
 }
 
 .quick-add-container {
   @include transition-properties((opacity transform), var(--animation-easing), var(--animation-duration-fast));
-  width: 25rem;
+  width: 20rem;
   opacity: 0;
   transform-origin: center right;
   transform: scaleX(0);
   z-index: var(--z-global-ui);
+  margin-right: unit(1);
 
   &--show {
     opacity: 1;
@@ -26,7 +27,7 @@
     border: 0;
     background: var(--text);
     color: var(--text-dark);
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     font-weight: bold;
 
     &::placeholder {
@@ -74,6 +75,9 @@
 
 /* Style the front side */
 .flip-box-front {
+  transform-origin: 1rem 0;
+  margin: 0 0 0 0.7rem;
+  padding-bottom: 0.3rem;
 }
 
 /* Style the back side */

--- a/src/styles/components/_quick-add.scss
+++ b/src/styles/components/_quick-add.scss
@@ -1,0 +1,82 @@
+.quick-add {
+  position: absolute;
+  bottom: 1.8rem;
+  right: 1.8rem;
+  display: flex;
+  align-items: center;
+}
+
+.quick-add-container {
+  @include transition-properties((opacity transform), var(--animation-easing), var(--animation-duration-fast));
+  width: 25rem;
+  opacity: 0;
+  transform-origin: center right;
+  transform: scaleX(0);
+  z-index: var(--z-global-ui);
+
+  &--show {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  &__label-input {
+    width: 100%;
+    padding: unit(2) unit(4);
+    border-radius: 5rem;
+    border: 0;
+    background: var(--text);
+    color: var(--text-dark);
+    font-size: 1.5rem;
+    font-weight: bold;
+
+    &::placeholder {
+      font-style: italic;
+      font-weight: 100;
+    }
+  }
+}
+
+/* The flip box container - set the width and height to whatever you want. We have added the border property to demonstrate that the flip itself goes out of the box on hover (remove perspective if you don't want the 3D effect */
+.flip-box {
+  width: 7rem;
+  height: 7rem;
+  perspective: 1000px;
+}
+
+/* This container is needed to position the front and back side */
+.flip-box-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform var(--animation-duration-fast);
+  transform-style: preserve-3d;
+}
+
+/* Do an horizontal flip when you move the mouse over the flip box container */
+.flip-box--flip .flip-box-inner {
+  transform: rotateY(180deg);
+}
+
+/* Position the front and back side */
+.flip-box-front, .flip-box-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+
+  .node, .icon {
+    font-size: 9rem;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+/* Style the front side */
+.flip-box-front {
+}
+
+/* Style the back side */
+.flip-box-back {
+  transform: rotateY(180deg);
+}

--- a/src/styles/containers/_name-generator-interface.scss
+++ b/src/styles/containers/_name-generator-interface.scss
@@ -39,12 +39,4 @@
       @include floating-action-button;
     }
   }
-
-  &__node-bin {
-    position: absolute;
-    bottom: spacing(large);
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: var(--z-tooltip);
-  }
 }


### PR DESCRIPTION
This PR adds a new experimental feature: a "quick add node form".

## Concept

We developed the node form concept to allow researchers to customise the attributes collected about an alter as they are elicited. This allows the flexibility to choose to collect one or more variables right from the start, thereby balancing the response burden associated with naming an alter against more efficient data collection.

However, this system is sub optimal if the researcher desires extremely low response burden for naming alters. It would require a node form with a single field. Such a form would be slow to show, would obscure existing nodes (which may spur faster recall if visible), and requires additional clicking (unless using add another mode).

## Implementation

This feature implements a new property, `quickAdd`, which is a boolean attribute on the name generator interface. If enabled, clicking the add a node button will not show a node form. Instead the user will see a single input box containing placeholder instructions ("Type a name and press enter..."). This form will remain open as long as the input is focused, allow the user to rapidly create new nodes by typing a label and pressing the enter key.

The form uses the name generator's subject, and looks up the `displayLabel` property of the stage subject. It creates a new node with only this property set.

`quickAdd` is not a required property, and defaults to false. If present, it takes precedent over the `form` property. Importantly, this means that editing of nodes created via a quick node form is not possible. Instead the intention is for the node to be erased and recreated.