### PR TITLE
Feature/per alter form

### DIFF
--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1660,7 +1660,7 @@
       "form": "myAlterFormID",
       "introductionPanel": {
         "title": "Introduction to this task",
-        "text": "This is some markdown that explains this interface."
+        "text": "This is some **markdown** that \n* explains this interface and \n* is *marked down*."
       }
     },
     {

--- a/public/protocols/development.netcanvas/protocol.json
+++ b/public/protocols/development.netcanvas/protocol.json
@@ -1058,6 +1058,33 @@
           "value": "network-canvas"
         }
       ]
+    },
+    "myAlterFormID": {
+      "title": "Modify a Person",
+      "entity": "node",
+      "type": "4aebf73e-95e3-4fd1-95e7-237dcc4a4466",
+      "fields": [
+        {
+          "variable": "6be95f85-c2d9-4daf-9de1-3939418af888",
+          "component": "Text",
+          "label": "What is this person's name?"
+        },
+        {
+          "variable": "23c5a7b9-b553-4ff1-b515-6a81999773d2",
+          "component": "RadioGroup",
+          "label": "How much do you like likert scales?"
+        },
+        {
+          "variable": "4ccba4e2-a246-46ee-a3ff-1c70fb4c449c",
+          "component": "ToggleButtonGroup",
+          "label": "Which of these other things do you like?"
+        },
+        {
+          "variable": "57fefac9-561f-454a-8f78-81bd9470efaa",
+          "component": "Toggle",
+          "label": "Is the switch below not turned on?"
+        }
+      ]
     }
   },
   "stages": [
@@ -1625,6 +1652,16 @@
           "variable": "4ccba4e2-a246-46ee-a3ff-1c70fb4c449c"
         }
       ]
+    },
+    {
+      "id": "alter-form-1",
+      "type": "AlterForm",
+      "label": "Alter Form",
+      "form": "myAlterFormID",
+      "introductionPanel": {
+        "title": "Introduction to this task",
+        "text": "This is some markdown that explains this interface."
+      }
     },
     {
       "id": "rubberduck",

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -10,12 +10,16 @@ import { nodeAttributesProperty, nodePrimaryKeyProperty } from '../../ducks/modu
 import { getDefaultFormValues } from '../../selectors/forms';
 import { makeNetworkNodesForType } from '../../selectors/interface';
 import { protocolForms } from '../../selectors/protocol';
+import { Progress } from '../../ui/components';
 import { Form } from '../';
 
 class AlterForm extends Component {
   constructor(props) {
     super(props);
     this.swipeRef = React.createRef();
+    this.state = {
+      activeIndex: 0,
+    };
   }
 
   formSubmitAllowed = index => (
@@ -54,7 +58,7 @@ class AlterForm extends Component {
     } = this.props;
 
     const params = {
-      containerClass: 'alter-form swiper-container',
+      containerClass: 'alter-form__swiper swiper-container',
       direction: 'vertical',
       slidesPerView: 'auto',
       centeredSlides: true,
@@ -69,8 +73,13 @@ class AlterForm extends Component {
             const submitIndex = this.swipeRef.current.swiper.previousIndex;
             if (!this.formSubmitAllowed(submitIndex)) {
               this.swipeRef.current.swiper.slideTo(submitIndex);
-            } else if (this.props.formDirty(`NODE_FORM_${submitIndex - 1}`)) {
-              this.props.submitForm(`NODE_FORM_${submitIndex - 1}`);
+            } else {
+              if (this.props.formDirty(`NODE_FORM_${submitIndex - 1}`)) {
+                this.props.submitForm(`NODE_FORM_${submitIndex - 1}`);
+              }
+              this.setState({
+                activeIndex: this.swipeRef.current.swiper.activeIndex,
+              });
             }
           }
         },
@@ -78,37 +87,44 @@ class AlterForm extends Component {
     };
 
     return (
-      <Swiper {...params} ref={this.swipeRef} >
-        <div key="alter-form__introduction">
-          <div>{stage.introductionPanel.title}</div>
-          <div>{stage.introductionPanel.text}</div>
-        </div>
-        {stageNodes.map((node, index) => {
-          const nodeAttributes = node ? node[nodeAttributesProperty] : {};
+      <div className="alter-form">
+        <Swiper {...params} ref={this.swipeRef} >
+          <div key="alter-form__introduction">
+            <div>{stage.introductionPanel.title}</div>
+            <div>{stage.introductionPanel.text}</div>
+          </div>
+          {stageNodes.map((node, index) => {
+            const nodeAttributes = node ? node[nodeAttributesProperty] : {};
 
-          const initialValues = {
-            ...defaultFormValues[stage.form],
-            ...nodeAttributes,
-          };
+            const initialValues = {
+              ...defaultFormValues[stage.form],
+              ...nodeAttributes,
+            };
 
-          return (
-            <div className="swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
-              <Scroller>
-                <Form
-                  key={node[nodePrimaryKeyProperty]}
-                  {...form}
-                  className="alter-form__form"
-                  initialValues={initialValues}
-                  controls={[]}
-                  autoFocus={false}
-                  form={`NODE_FORM_${index}`}
-                  onSubmit={formData => this.props.updateNode(node, formData)}
-                />
-              </Scroller>
-            </div>
-          );
-        })}
-      </Swiper>
+            return (
+              <div className="swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
+                <Scroller>
+                  <Form
+                    key={node[nodePrimaryKeyProperty]}
+                    {...form}
+                    className="alter-form__form"
+                    initialValues={initialValues}
+                    controls={[]}
+                    autoFocus={false}
+                    form={`NODE_FORM_${index}`}
+                    onSubmit={formData => this.props.updateNode(node, formData)}
+                  />
+                </Scroller>
+              </div>
+            );
+          })}
+        </Swiper>
+        <Progress
+          max={stageNodes.length + 1}
+          value={this.state.activeIndex + 1}
+          className="alter-form__progress"
+        />
+      </div>
     );
   }
 }

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -23,13 +23,23 @@ class AlterForm extends Component {
       this.props.formEnabled(`NODE_FORM_${index - 1}`)
   );
 
-  goNext = () => {
+  isStageBeginning = () => (
+    this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex) &&
+    this.swipeRef.current.swiper.activeIndex === 0
+  );
+
+  isStageEnding = () => (
+    this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex) &&
+    this.swipeRef.current.swiper.activeIndex === this.props.stageNodes.length
+  );
+
+  clickNext = () => {
     if (this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex)) {
       this.swipeRef.current.swiper.slideNext();
     }
   };
 
-  goPrev = () => {
+  clickPrevious = () => {
     if (this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex)) {
       this.swipeRef.current.swiper.slidePrev();
     }
@@ -65,12 +75,6 @@ class AlterForm extends Component {
           }
         },
       },
-      navigation: {
-        nextEl: '.swiper-button-next',
-        prevEl: '.swiper-button-prev',
-      },
-      renderPrevButton: () => (<button className="swiper-button-prev">Prev</button>),
-      renderNextButton: () => (<button className="swiper-button-next">Next</button>),
     };
 
     return (
@@ -88,12 +92,14 @@ class AlterForm extends Component {
           };
 
           return (
-            <div className="alter-form__form swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
+            <div className="swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
               <Scroller>
                 <Form
                   key={node[nodePrimaryKeyProperty]}
                   {...form}
+                  className="alter-form__form"
                   initialValues={initialValues}
+                  controls={[]}
                   autoFocus={false}
                   form={`NODE_FORM_${index}`}
                   onSubmit={formData => this.props.updateNode(node, formData)}
@@ -138,5 +144,5 @@ const mapDispatchToProps = dispatch => ({
 export { AlterForm };
 
 export default compose(
-  connect(makeMapStateToProps, mapDispatchToProps),
+  connect(makeMapStateToProps, mapDispatchToProps, null, { withRef: true }),
 )(AlterForm);

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -5,6 +5,7 @@ import { isDirty, isValid, isSubmitting, reset, submit } from 'redux-form';
 import Swiper from 'react-id-swiper';
 
 import { Scroller } from '../../components';
+import Node from '../Node';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
 import { nodeAttributesProperty, nodePrimaryKeyProperty } from '../../ducks/modules/network';
 import { getDefaultFormValues } from '../../selectors/forms';
@@ -49,6 +50,14 @@ class AlterForm extends Component {
     }
   };
 
+  clickLast = () => {
+    if (this.formSubmitAllowed(this.state.activeIndex)) {
+      if (this.props.formDirty(`NODE_FORM_${this.state.activeIndex - 1}`)) {
+        this.props.submitForm(`NODE_FORM_${this.state.activeIndex - 1}`);
+      }
+    }
+  }
+
   render() {
     const {
       defaultFormValues,
@@ -89,7 +98,7 @@ class AlterForm extends Component {
     return (
       <div className="alter-form">
         <Swiper {...params} ref={this.swipeRef} >
-          <div key="alter-form__introduction">
+          <div key="alter-form__introduction" className="alter-form__introduction">
             <div>{stage.introductionPanel.title}</div>
             <div>{stage.introductionPanel.text}</div>
           </div>
@@ -103,18 +112,21 @@ class AlterForm extends Component {
 
             return (
               <div className="swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
-                <Scroller>
-                  <Form
-                    key={node[nodePrimaryKeyProperty]}
-                    {...form}
-                    className="alter-form__form"
-                    initialValues={initialValues}
-                    controls={[]}
-                    autoFocus={false}
-                    form={`NODE_FORM_${index}`}
-                    onSubmit={formData => this.props.updateNode(node, formData)}
-                  />
-                </Scroller>
+                <Node {...node} />
+                <div className="alter-form__form-container">
+                  <Scroller>
+                    <Form
+                      key={node[nodePrimaryKeyProperty]}
+                      {...form}
+                      className="alter-form__form"
+                      initialValues={initialValues}
+                      controls={[]}
+                      autoFocus={false}
+                      form={`NODE_FORM_${index}`}
+                      onSubmit={formData => this.props.updateNode(node, formData)}
+                    />
+                  </Scroller>
+                </div>
               </div>
             );
           })}

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -1,0 +1,142 @@
+import React, { Component } from 'react';
+import { bindActionCreators, compose } from 'redux';
+import { connect } from 'react-redux';
+import { isDirty, isValid, isSubmitting, reset, submit } from 'redux-form';
+import Swiper from 'react-id-swiper';
+
+import { Scroller } from '../../components';
+import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
+import { nodeAttributesProperty, nodePrimaryKeyProperty } from '../../ducks/modules/network';
+import { getDefaultFormValues } from '../../selectors/forms';
+import { makeNetworkNodesForType } from '../../selectors/interface';
+import { protocolForms } from '../../selectors/protocol';
+import { Form } from '../';
+
+class AlterForm extends Component {
+  constructor(props) {
+    super(props);
+    this.swipeRef = React.createRef();
+  }
+
+  formSubmitAllowed = index => (
+    this.swipeRef && this.swipeRef.current.swiper &&
+      this.props.formEnabled(`NODE_FORM_${index - 1}`)
+  );
+
+  goNext = () => {
+    if (this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex)) {
+      this.swipeRef.current.swiper.slideNext();
+    }
+  };
+
+  goPrev = () => {
+    if (this.swipeRef && this.formSubmitAllowed(this.swipeRef.current.swiper.activeIndex)) {
+      this.swipeRef.current.swiper.slidePrev();
+    }
+  };
+
+  render() {
+    const {
+      defaultFormValues,
+      form,
+      stage,
+      stageNodes,
+    } = this.props;
+
+    const params = {
+      containerClass: 'alter-form swiper-container',
+      direction: 'vertical',
+      slidesPerView: 'auto',
+      centeredSlides: true,
+      on: {
+        touchStart: () => {
+          if (this.swipeRef.current && this.swipeRef.current.swiper) {
+            this.swipeRef.current.swiper.allowTouchMove = this.formSubmitAllowed();
+          }
+        },
+        slideChangeTransitionStart: () => {
+          if (this.swipeRef.current && this.swipeRef.current.swiper) {
+            const submitIndex = this.swipeRef.current.swiper.previousIndex;
+            if (!this.formSubmitAllowed(submitIndex)) {
+              this.swipeRef.current.swiper.slideTo(submitIndex);
+            } else if (this.props.formDirty(`NODE_FORM_${submitIndex - 1}`)) {
+              this.props.submitForm(`NODE_FORM_${submitIndex - 1}`);
+            }
+          }
+        },
+      },
+      navigation: {
+        nextEl: '.swiper-button-next',
+        prevEl: '.swiper-button-prev',
+      },
+      renderPrevButton: () => (<button className="swiper-button-prev">Prev</button>),
+      renderNextButton: () => (<button className="swiper-button-next">Next</button>),
+    };
+
+    return (
+      <Swiper {...params} ref={this.swipeRef} >
+        <div key="alter-form__introduction">
+          <div>{stage.introductionPanel.title}</div>
+          <div>{stage.introductionPanel.text}</div>
+        </div>
+        {stageNodes.map((node, index) => {
+          const nodeAttributes = node ? node[nodeAttributesProperty] : {};
+
+          const initialValues = {
+            ...defaultFormValues[stage.form],
+            ...nodeAttributes,
+          };
+
+          return (
+            <div className="alter-form__form swiper-no-swiping" key={node[nodePrimaryKeyProperty]}>
+              <Scroller>
+                <Form
+                  key={node[nodePrimaryKeyProperty]}
+                  {...form}
+                  initialValues={initialValues}
+                  autoFocus={false}
+                  form={`NODE_FORM_${index}`}
+                  onSubmit={formData => this.props.updateNode(node, formData)}
+                />
+              </Scroller>
+            </div>
+          );
+        })}
+      </Swiper>
+    );
+  }
+}
+
+function makeMapStateToProps() {
+  const getStageNodes = makeNetworkNodesForType();
+
+  return function mapStateToProps(state, props) {
+    const forms = protocolForms(state);
+    const defaultFormValues = getDefaultFormValues(state);
+    const currentForm = forms[props.stage.form];
+    const stageNodes = getStageNodes(state, {
+      ...props,
+      stage: { ...props.stage, subject: { entity: currentForm.entity, type: currentForm.type } },
+    });
+
+    return {
+      form: currentForm,
+      formEnabled: formName => isValid(formName)(state) && !isSubmitting(formName)(state),
+      formDirty: formName => isDirty(formName)(state),
+      defaultFormValues,
+      stageNodes,
+    };
+  };
+}
+
+const mapDispatchToProps = dispatch => ({
+  resetValues: bindActionCreators(reset, dispatch),
+  updateNode: bindActionCreators(sessionsActions.updateNode, dispatch),
+  submitForm: bindActionCreators(formName => submit(formName), dispatch),
+});
+
+export { AlterForm };
+
+export default compose(
+  connect(makeMapStateToProps, mapDispatchToProps),
+)(AlterForm);

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -13,6 +13,7 @@ import { makeNetworkNodesForType } from '../../selectors/interface';
 import { protocolForms } from '../../selectors/protocol';
 import { Progress } from '../../ui/components';
 import { Form } from '../';
+import { getItemComponent } from './Information';
 
 class AlterForm extends Component {
   constructor(props) {
@@ -52,9 +53,7 @@ class AlterForm extends Component {
 
   clickLast = () => {
     if (this.formSubmitAllowed(this.state.activeIndex)) {
-      if (this.props.formDirty(`NODE_FORM_${this.state.activeIndex - 1}`)) {
-        this.props.submitForm(`NODE_FORM_${this.state.activeIndex - 1}`);
-      }
+      this.props.submitForm(`NODE_FORM_${this.state.activeIndex - 1}`);
     }
   }
 
@@ -83,9 +82,7 @@ class AlterForm extends Component {
             if (!this.formSubmitAllowed(submitIndex)) {
               this.swipeRef.current.swiper.slideTo(submitIndex);
             } else {
-              if (this.props.formDirty(`NODE_FORM_${submitIndex - 1}`)) {
-                this.props.submitForm(`NODE_FORM_${submitIndex - 1}`);
-              }
+              this.props.submitForm(`NODE_FORM_${submitIndex - 1}`);
               this.setState({
                 activeIndex: this.swipeRef.current.swiper.activeIndex,
               });
@@ -99,8 +96,8 @@ class AlterForm extends Component {
       <div className="alter-form">
         <Swiper {...params} ref={this.swipeRef} >
           <div key="alter-form__introduction" className="alter-form__introduction">
-            <div>{stage.introductionPanel.title}</div>
-            <div>{stage.introductionPanel.text}</div>
+            <h1>{stage.introductionPanel.title}</h1>
+            <div>{getItemComponent({ content: stage.introductionPanel.text, type: 'text' })}</div>
           </div>
           {stageNodes.map((node, index) => {
             const nodeAttributes = node ? node[nodeAttributesProperty] : {};

--- a/src/containers/Interfaces/Information.js
+++ b/src/containers/Interfaces/Information.js
@@ -18,7 +18,7 @@ const TAGS = [
   'thematicBreak',
 ];
 
-const getItemComponent = (item) => {
+export const getItemComponent = (item) => {
   switch (item.type) {
     case InformationContentType.text:
       return (

--- a/src/containers/Interfaces/index.js
+++ b/src/containers/Interfaces/index.js
@@ -11,6 +11,7 @@ import Quiz from './Quiz';
 import Information from './Information';
 import CategoricalBin from './CategoricalBin';
 import Narrative from './Narrative';
+import AlterForm from './AlterForm';
 import FinishSession from './FinishSession';
 
 import { StageType } from '../../protocol-consts';
@@ -25,6 +26,7 @@ const interfaces = {
   [StageType.OrdinalBin]: OrdinalBin,
   [StageType.CategoricalBin]: CategoricalBin,
   [StageType.Narrative]: Narrative,
+  [StageType.AlterForm]: AlterForm,
   FinishSession,
 };
 
@@ -50,6 +52,7 @@ export {
   CategoricalBin,
   OrdinalBin,
   Narrative,
+  AlterForm,
 };
 
 export default getInterface;

--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -34,6 +34,9 @@ class Protocol extends Component {
     if (this.getInterfaceRef() && !this.getInterfaceRef().isStageEnding()) {
       this.getInterfaceRef().clickNext();
     } else if (!this.props.stage.prompts || this.props.isLastPrompt()) {
+      if (this.getInterfaceRef()) {
+        this.getInterfaceRef().clickLast();
+      }
       this.props.changeStage(`${this.props.pathPrefix}/${this.props.nextIndex}`);
     } else {
       this.props.promptForward();

--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -17,9 +17,23 @@ import { getCSSVariableAsNumber } from '../ui/utils/CSSVariables';
   * Check protocol is loaded, and render the stage
   */
 class Protocol extends Component {
+  constructor(props) {
+    super(props);
+    this.interfaceRef = React.createRef();
+  }
+
+  componentDidUpdate(previousProps) {
+    if (previousProps.stage.id !== this.props.stage.id) {
+      this.interfaceRef = React.createRef();
+      this.forceUpdate();
+    }
+  }
+
   // change the stage to the next
   onClickNext = () => {
-    if (!this.props.stage.prompts || this.props.isLastPrompt()) {
+    if (this.getInterfaceRef() && !this.getInterfaceRef().isStageEnding()) {
+      this.getInterfaceRef().clickNext();
+    } else if (!this.props.stage.prompts || this.props.isLastPrompt()) {
       this.props.changeStage(`${this.props.pathPrefix}/${this.props.nextIndex}`);
     } else {
       this.props.promptForward();
@@ -28,10 +42,21 @@ class Protocol extends Component {
 
   // change the stage to the previous
   onClickBack = () => {
-    if (!this.props.stage.prompts || this.props.isFirstPrompt()) {
+    if (this.getInterfaceRef() && !this.getInterfaceRef().isStageBeginning()) {
+      this.getInterfaceRef().clickPrevious();
+    } else if (!this.props.stage.prompts || this.props.isFirstPrompt()) {
       this.props.changeStage(`${this.props.pathPrefix}/${this.props.previousIndex}?back`);
     } else {
       this.props.promptBackward();
+    }
+  }
+
+  getInterfaceRef = () => {
+    try {
+      return (this.interfaceRef && this.interfaceRef.current &&
+        this.interfaceRef.current.getWrappedInstance());
+    } catch (e) {
+      return false;
     }
   }
 
@@ -77,6 +102,7 @@ class Protocol extends Component {
               promptId={promptId}
               pathPrefix={pathPrefix}
               stageIndex={stageIndex}
+              ref={this.interfaceRef}
             />
           </StageTransition>
         </TransitionGroup>

--- a/src/containers/Stage.js
+++ b/src/containers/Stage.js
@@ -8,21 +8,27 @@ import StageErrorBoundary from '../components/StageErrorBoundary';
   * Render a protocol interface based on protocol info and id
   * @extends Component
   */
-const Stage = ({ stage, promptId }) => {
+const Stage = React.forwardRef(({ stage, promptId }, ref) => {
   const CurrentInterface = getInterface(stage.type);
+
+  let interfaceRef = ref;
+  // can't pass a ref to a stateless component
+  if (!CurrentInterface.prototype.render) {
+    interfaceRef = null;
+  }
 
   return (
     <div className="stage">
       <div className="stage__interface">
         <StageErrorBoundary>
           { CurrentInterface &&
-            <CurrentInterface stage={stage} promptId={promptId} />
+            <CurrentInterface stage={stage} promptId={promptId} ref={interfaceRef} />
           }
         </StageErrorBoundary>
       </div>
     </div>
   );
-};
+});
 
 Stage.propTypes = {
   stage: PropTypes.object.isRequired,

--- a/src/protocol-consts.js
+++ b/src/protocol-consts.js
@@ -84,6 +84,7 @@ const StageType = Object.freeze({
   OrdinalBin: 'OrdinalBin',
   CategoricalBin: 'CategoricalBin',
   Narrative: 'Narrative',
+  AlterForm: 'AlterForm',
 });
 
 // Docs: https://github.com/codaco/Network-Canvas/wiki/Variable-Types

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -133,6 +133,7 @@
           "type": "string",
           "enum": [
             "Narrative",
+            "AlterForm",
             "NameGenerator",
             "NameGeneratorList",
             "NameGeneratorAutoComplete",

--- a/src/styles/containers/_all.scss
+++ b/src/styles/containers/_all.scss
@@ -14,3 +14,4 @@
 @import 'session-list';
 @import 'sociogram-interface';
 @import 'narrative-interface';
+@import 'alter-form-interface';

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -1,0 +1,38 @@
+.alter-form {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .swiper-wrapper {
+    box-sizing: border-box;
+    width: 80%;
+
+    .scrollable {
+      height: 100%;
+    }
+  }
+
+  .swiper-slide {
+    height: 50vh;
+    border-radius: var(--border-radius);
+    background: var(--light-background);
+    padding: 1.5rem;
+    overflow: hidden;
+    transition: opacity var(--animation-duration-slow) var(--animation-easing);
+    margin-top: 4rem;
+
+    &.swiper-slide-active {
+      height: 50vh;
+      pointer-events: initial;
+      opacity: 1;
+    }
+
+    &:not(.swiper-slide-active) {
+      height: 25vh;
+      pointer-events: none;
+      opacity: .3;
+    }
+  }
+}

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -1,3 +1,5 @@
+$slide-padding: 1.5rem;
+
 .alter-form {
   &__swiper {
     height: 100vh;
@@ -20,22 +22,34 @@
     height: 50vh;
     border-radius: var(--border-radius);
     background: var(--light-background);
-    padding: 1.5rem;
-    overflow: hidden;
     transition: opacity var(--animation-duration-slow) var(--animation-easing);
-    margin-top: 4rem;
+    margin-top: 5rem;
 
     &.swiper-slide-active {
-      height: 50vh;
+      height: 60vh;
       pointer-events: initial;
       opacity: 1;
     }
 
     &:not(.swiper-slide-active) {
-      height: 25vh;
       pointer-events: none;
       opacity: .3;
     }
+  }
+
+  &__introduction {
+    padding: $slide-padding;
+  }
+
+  .node {
+    margin-top: calc((var(--base-node-size) / -2));
+    margin-left: calc(50% - (var(--base-node-size) / 2));
+  }
+
+  &__form-container {
+    height: calc(100% - (var(--base-node-size) / 2));
+    overflow: hidden;
+    padding: $slide-padding;
   }
 
   &__form {

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -11,7 +11,7 @@ $slide-padding: 1.5rem;
 
   .swiper-wrapper {
     box-sizing: border-box;
-    width: 80%;
+    width: 75%;
 
     .scrollable {
       height: 100%;

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -1,9 +1,11 @@
 .alter-form {
-  height: 100vh;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  &__swiper {
+    height: 100vh;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   .swiper-wrapper {
     box-sizing: border-box;
@@ -44,5 +46,13 @@
       flex: calc(50% - 2rem);
       margin: 1rem;
     }
+  }
+
+  &__progress {
+    bottom: 1rem;
+    left: 37.5%;
+    position: absolute;
+    width: 25%;
+    z-index: var(--z-panel);
   }
 }

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -35,4 +35,14 @@
       opacity: .3;
     }
   }
+
+  &__form {
+    display: flex;
+    flex-wrap: wrap;
+
+    .form-field-container {
+      flex: calc(50% - 2rem);
+      margin: 1rem;
+    }
+  }
 }


### PR DESCRIPTION
Resolves #585, adding a per-alter form interface: 

![per alter form](https://user-images.githubusercontent.com/16093053/51218368-0ec20e00-18fa-11e9-8af7-badf40bf3e46.png)

This updates each node on swipe or when clicking next/previous on the stage buttons. It does not allow switching nodes when the form is in an invalid state.