### PR TITLE
fix touch/mouse issue

### DIFF
--- a/src/containers/Interfaces/AlterEdgeForm.js
+++ b/src/containers/Interfaces/AlterEdgeForm.js
@@ -83,12 +83,12 @@ class AlterEdgeForm extends Component {
       stageEdges,
       updateEdge,
     } = this.props;
+
     const swiperParams = {
       containerClass: 'alter-form__swiper swiper-container',
       direction: 'vertical',
       speed: getCSSVariableAsNumber('--animation-duration-slow-ms'),
       effect: 'coverflow',
-      allowTouchMove: false,
       coverflowEffect: {
         rotate: 30,
         slideShadows: false,
@@ -105,7 +105,7 @@ class AlterEdgeForm extends Component {
     );
 
     return (
-      <div className="alter-form alter-edge-form">
+      <div className="alter-form alter-edge-form swiper-no-swiping">
         <Swiper {...swiperParams} ref={this.swipeRef} >
           <div>
             <div key="alter-form__introduction" className="slide-content alter-form__introduction">

--- a/src/containers/Interfaces/AlterForm.js
+++ b/src/containers/Interfaces/AlterForm.js
@@ -90,7 +90,6 @@ class AlterForm extends Component {
       direction: 'vertical',
       speed: getCSSVariableAsNumber('--animation-duration-slow-ms'),
       effect: 'coverflow',
-      allowTouchMove: false,
       coverflowEffect: {
         rotate: 30,
         slideShadows: false,
@@ -107,7 +106,7 @@ class AlterForm extends Component {
     );
 
     return (
-      <div className="alter-form">
+      <div className="alter-form swiper-no-swiping">
         <Swiper {...swiperParams} ref={this.swipeRef} >
           <div>
             <div key="alter-form__introduction" className="slide-content alter-form__introduction">


### PR DESCRIPTION
Removes `allowTouchMove` option from swiper, and instead uses the `swiper-no-swiping` class so our mouse/touch events still register as expected for forms.