### PR TITLE
default for options

### DIFF
--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -948,7 +948,7 @@
           "items": {
             "$ref": "#/definitions/OptionElement"
           },
-          "minItems": 1
+          "minItems": 2
         }
       },
       "required": [

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -947,7 +947,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/OptionElement"
-          }
+          },
+          "minItems": 1
         }
       },
       "required": [

--- a/src/schemas/protocol.schema.v1.json
+++ b/src/schemas/protocol.schema.v1.json
@@ -954,7 +954,26 @@
       "required": [
         "type"
       ],
-      "title": "Variable"
+      "title": "Variable",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "ordinal",
+                  "categorical"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "options"
+            ]
+          }
+        }
+      ]
     },
     "OptionClass": {
       "type": "object",

--- a/src/selectors/__tests__/interface.test.js
+++ b/src/selectors/__tests__/interface.test.js
@@ -79,6 +79,13 @@ const mockProtocol = {
           nickname: {
             type: 'text',
           },
+          cat1: {
+            type: 'categorical',
+            options: [123, 456],
+          },
+          ord1: {
+            type: 'ordinal',
+          },
         },
       },
     },
@@ -155,6 +162,12 @@ describe('interface selector', () => {
     it('should get displayVariable', () => {
       const selected = Interface.makeGetNodeDisplayVariable();
       expect(selected(mockState, mockProps)).toEqual('name');
+    });
+
+    it('makeGetVariableOptions', () => {
+      const selected = Interface.makeGetVariableOptions();
+      expect(selected(mockState, { ...mockProps, prompt: { ...mockPrompt, variable: 'cat1' } })).toEqual([123, 456]);
+      expect(selected(mockState, { ...mockProps, prompt: { ...mockPrompt, variable: 'ord1' } })).toEqual([]);
     });
 
     it('should get node label function', () => {

--- a/src/selectors/interface.js
+++ b/src/selectors/interface.js
@@ -126,7 +126,7 @@ export const makeGetVariableOptions = () =>
     makeGetNodeVariables(), makeGetPromptVariable(),
     (nodeVariables, promptVariable) => {
       const optionValues = nodeVariables[promptVariable].options;
-      return optionValues;
+      return optionValues || [];
     },
   );
 


### PR DESCRIPTION
Fixes #870. This ensures that `null` categorical and ordinal `options` are handled gracefully, and adds a test for that. 

To check, remove options from the variable registry for a categorical or ordinal variable used in an interface, and see that the interface still loads.