### PR TITLE
allow cancel for load screen

### DIFF
--- a/src/containers/LoadScreen.js
+++ b/src/containers/LoadScreen.js
@@ -54,7 +54,7 @@ class LoadScreen extends Component {
     return (
       <Fade in={this.props.isWorking || !this.state.minimumTimeMet}>
         <div className="load-screen">
-          <Icon name="close" onClick={this.handleClose} />
+          <Icon className="load-screen__close" name="close" onClick={this.handleClose} />
           <Spinner large />
         </div>
       </Fade>

--- a/src/containers/LoadScreen.js
+++ b/src/containers/LoadScreen.js
@@ -1,9 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import { compose } from 'redux';
-import { Spinner } from '../ui/components';
+
+import { Icon, Spinner } from '../ui/components';
 import Fade from '../ui/components/Transitions/Fade';
+import { actionCreators as sessionActions } from '../ducks/modules/session';
 
 const minimumTimeToDisplaySpinner = 1000;
 
@@ -18,6 +21,7 @@ class LoadScreen extends Component {
 
   constructor(props) {
     super(props);
+    this.timer = () => this.setState({ minimumTimeMet: true });
     this.state = {
       minimumTimeMet: true,
     };
@@ -33,14 +37,24 @@ class LoadScreen extends Component {
 
   scheduleSpinnerExpiration() {
     if (this.props.isWorking) {
-      setTimeout(() => this.setState({ minimumTimeMet: true }), minimumTimeToDisplaySpinner);
+      setTimeout(this.timer, minimumTimeToDisplaySpinner);
     }
+  }
+
+  handleClose = () => {
+    this.state = {
+      minimumTimeMet: true,
+    };
+    this.props.endSession();
+    clearTimeout(this.timer);
+    this.timer();
   }
 
   render() {
     return (
       <Fade in={this.props.isWorking || !this.state.minimumTimeMet}>
         <div className="load-screen">
+          <Icon name="close" onClick={this.handleClose} />
           <Spinner large />
         </div>
       </Fade>
@@ -50,6 +64,7 @@ class LoadScreen extends Component {
 
 LoadScreen.propTypes = {
   isWorking: PropTypes.bool,
+  endSession: PropTypes.func.isRequired,
 };
 
 LoadScreen.defaultProps = {
@@ -60,6 +75,13 @@ const mapStateToProps = state => ({
   isWorking: state.protocol.isLoading,
 });
 
+const mapDispatchToProps = dispatch => ({
+  endSession: () => {
+    dispatch(sessionActions.endSession());
+    dispatch(push('/'));
+  },
+});
+
 export default compose(
-  connect(mapStateToProps),
+  connect(mapStateToProps, mapDispatchToProps),
 )(LoadScreen);

--- a/src/styles/components/_load-screen.scss
+++ b/src/styles/components/_load-screen.scss
@@ -9,4 +9,10 @@
   background-color: palette('background');
   width: 100%;
   height: 100%;
+
+  & .icon[name='close'] {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+  }
 }

--- a/src/styles/components/_load-screen.scss
+++ b/src/styles/components/_load-screen.scss
@@ -10,7 +10,7 @@
   width: 100%;
   height: 100%;
 
-  & .icon[name='close'] {
+  &__close {
     position: absolute;
     top: 1.5rem;
     right: 1.5rem;


### PR DESCRIPTION
Resolves #356, resolves #727. This adds a "close" button to the loading screen, to give the user an "out" if the protocol hangs (which I haven't seen in awhile, but...) or if they change their mind while waiting for a session to load.