### PR TITLE
fix blank narrative attribute label

### DIFF
--- a/src/selectors/network.js
+++ b/src/selectors/network.js
@@ -128,7 +128,7 @@ export const makeGetNodeAttributeLabel = () => createDeepEqualSelector(
   (codebook, nodeType, variableId) => {
     const nodeInfo = codebook.node;
     const variables = (nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].variables) || {};
-    return (variables && variables[variableId] && variables[variableId].name) || [];
+    return (variables && variables[variableId] && variables[variableId].name) || variableId;
   },
 );
 

--- a/src/selectors/network.js
+++ b/src/selectors/network.js
@@ -128,7 +128,7 @@ export const makeGetNodeAttributeLabel = () => createDeepEqualSelector(
   (codebook, nodeType, variableId) => {
     const nodeInfo = codebook.node;
     const variables = (nodeInfo && nodeInfo[nodeType] && nodeInfo[nodeType].variables) || {};
-    return (variables && variables[variableId] && variables[variableId].label) || [];
+    return (variables && variables[variableId] && variables[variableId].name) || [];
   },
 );
 


### PR DESCRIPTION
Very small change for narrative preset key, which was expecting a `label` for variable attributes. It should look for a `name` now.