### PR TITLE
Feature/check existing protocol

### DIFF
--- a/src/containers/Setup/ImportProgressOverlay.js
+++ b/src/containers/Setup/ImportProgressOverlay.js
@@ -15,7 +15,7 @@ class ImportProgressOverlay extends Component {
   }
 
   componentWillUpdate(newProps) {
-    if (newProps.progress.step === 5) {
+    if (newProps.progress.step === 6) {
       this.handleImportFinished();
     }
   }
@@ -32,19 +32,19 @@ class ImportProgressOverlay extends Component {
   render() {
     const { show, progress, resetImportProtocol } = this.props;
 
-    const percentProgress = progress.step / 5;
+    const percentProgress = progress.step / 6;
 
     return (
       <Modal show={show}>
         <div className="import-protocol-overlay">
           <div className="overlay__content import-protocol-overlay__content" ref={this.contentRef}>
-            { progress.step === 5 ? (
+            { progress.step === 6 ? (
               <Icon name="protocol-card" />
             ) : (
               <Spinner large />
             )}
             <h4>{progress.statusText}</h4>
-            { progress.step === 5 ? (
+            { progress.step === 6 ? (
               <Button onClick={resetImportProtocol}>Continue</Button>
             ) : (
               <React.Fragment>

--- a/src/utils/protocol/checkExistingProtocol.js
+++ b/src/utils/protocol/checkExistingProtocol.js
@@ -1,0 +1,48 @@
+import { CancellationError } from 'builder-util-runtime';
+import { findKey } from 'lodash';
+
+import { actionCreators as dialogActions } from '../../ducks/modules/dialogs';
+import {
+  removeDirectory,
+  rename,
+} from '../filesystem';
+import protocolPath from './protocolPath';
+
+const renameProtocol = (previousUuid, currentUuid) => {
+  // delete contents of previous uuid, and move current content directory to previous uuid location
+  const previousDir = protocolPath(previousUuid);
+  const currentDir = protocolPath(currentUuid);
+
+  return removeDirectory(previousDir)
+  .then(() => rename(currentDir, previousDir));
+}
+
+const checkExistingSession = (dispatch, state, protocolContent) => {
+  const existingIndex = findKey(state.installedProtocols,
+    protocol => protocol.name === protocolContent.name);
+  const unExportedSession = findKey(state.sessions,
+    session => session.protocolUID === existingIndex && !session.lastExportedAt);
+  if (unExportedSession) {
+    return Promise.reject(new Error('This protocol is already installed. In progress sessions for a previous version of this protocol have not yet been exported. Please export them before attempting to overwrite the protocol.'));
+  }
+
+  const existingSession = findKey(state.sessions,
+    session => session.protocolUID === existingIndex);
+  if (existingSession) {
+    return new Promise((resolve, reject) => dispatch(dialogActions.openDialog({
+      type: 'Warning',
+      title: 'Overwrite existing protocol?',
+      confirmLabel: 'Overwrite protocol',
+      onConfirm: () => {
+        renameProtocol(existingIndex, protocolContent.uid)
+        .then(() => resolve(protocolContent));
+      },
+      onCancel: () => reject(new CancellationError('Installation of this protocol cancelled.')),
+      message: 'This protocol is already installed; all in progress sessions have been exported. Overwriting the previous installation of this protocol may limit access to previously created sessions.',
+    })));
+  }
+  
+  return Promise.resolve(protocolContent);
+}
+
+export default checkExistingSession;

--- a/src/utils/protocol/checkExistingProtocol.js
+++ b/src/utils/protocol/checkExistingProtocol.js
@@ -23,7 +23,8 @@ const checkExistingSession = (dispatch, state, protocolContent) => {
   const unExportedSession = findKey(state.sessions,
     session => session.protocolUID === existingIndex && !session.lastExportedAt);
   if (unExportedSession) {
-    return Promise.reject(new Error('This protocol is already installed. In progress sessions for a previous version of this protocol have not yet been exported. Please export them before attempting to overwrite the protocol.'));
+    const message = 'This protocol is already installed. In progress sessions for a previous version of this protocol have not yet been exported. Please export them before attempting to overwrite the protocol.';
+    return Promise.reject(new Error(message));
   }
 
   const existingSession = findKey(state.sessions,
@@ -42,6 +43,12 @@ const checkExistingSession = (dispatch, state, protocolContent) => {
     })));
   }
   
+  if (existingIndex) {
+    // clean up protocol even if no sessions exist
+    return renameProtocol(existingIndex, protocolContent.uid)
+      .then(() => Promise.resolve(protocolContent));
+  }
+
   return Promise.resolve(protocolContent);
 }
 


### PR DESCRIPTION
Resolves #575. Resolves #567.

This disallows overwriting a protocol if there are in progress interviews that haven't yet been exported.

It allows overwriting a protocol if all existing sessions have been exported, but displays an additional confirmation during import.

This further fixes the issue that a protocol does not reset the node label worker (or any other assets), by moving the new protocol to the location of the old protocol version so assets and node label workers can be found.

Also, this addresses the issue that previous versions, or even attempted versions, shouldn't leave files around and makes an effort to clean up old files.

To test, you need two versions of a protocol with the same `name` (different file names are allowed since we use `name` as a basis for matching protocols). Tested with both the server and local file importing, with a mix of existing/exported/non-existing sessions, on android and electron. Cancelling an import should also clean up files. Opening a session that was exported and had the protocol updated is allowed here.

Note that the server needs to address the similar issue of overwriting protocols, but will be a separate issue.