### PR TITLE
remove top operator from skip logic

### DIFF
--- a/src/selectors/__tests__/skip-logic.test.js
+++ b/src/selectors/__tests__/skip-logic.test.js
@@ -30,8 +30,6 @@ const mockState = {
           id: 2,
           skipLogic: {
             action: 'SHOW',
-            operator: 'LESS_THAN_OR_EQUAL',
-            value: 3,
             filter: {
               rules: [
                 {
@@ -51,8 +49,6 @@ const mockState = {
           id: 3,
           skipLogic: {
             action: 'SHOW',
-            operator: 'EXACTLY',
-            value: 1,
             filter: {
               rules: [
                 {
@@ -71,8 +67,6 @@ const mockState = {
           id: 4,
           skipLogic: {
             action: 'SKIP',
-            operator: 'GREATER_THAN',
-            value: 2,
             filter: {
               rules: [
                 {
@@ -92,8 +86,6 @@ const mockState = {
           id: 5,
           skipLogic: {
             action: 'SKIP',
-            operator: 'NOT',
-            value: 1,
             filter: {
               rules: [
                 {
@@ -102,7 +94,7 @@ const mockState = {
                     type: 'person',
                     attribute: 'name',
                     operator: 'EXACTLY',
-                    value: 'soAndSo',
+                    value: 'somePerson',
                   },
                 },
               ],
@@ -113,8 +105,6 @@ const mockState = {
           id: 6,
           skipLogic: {
             action: 'SKIP',
-            operator: 'GREATER_THAN',
-            value: 1,
             filter: {
               join: 'AND',
               rules: [
@@ -144,8 +134,6 @@ const mockState = {
           id: 7,
           skipLogic: {
             action: 'SKIP',
-            operator: 'GREATER_THAN',
-            value: 1,
             filter: {
               join: 'OR',
               rules: [

--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -1,10 +1,9 @@
 import { createSelector } from 'reselect';
 
 import filter from '../utils/networkQuery/filter';
-import predicate from '../utils/networkQuery/predicate';
 import { getProtocolStages } from './protocol';
 import { getNetwork } from './network';
-import { SkipLogicAction, SkipLogicOperator } from '../protocol-consts';
+import { SkipLogicAction } from '../protocol-consts';
 
 const rotateIndex = (max, nextIndex) => (nextIndex + max) % max;
 const maxLength = state => getProtocolStages(state).length;
@@ -51,38 +50,14 @@ const isSkipAction = index => createSelector(
   logic => logic && logic.action === SkipLogicAction.SKIP,
 );
 
-const getSkipValue = index => createSelector(
-  getSkipLogic(index),
-  logic => logic && logic.value && Math.trunc(logic.value),
-);
-
-const getSkipOperator = index => createSelector(
-  getSkipLogic(index),
-  logic => logic && logic.operator,
-);
-
 export const isStageSkipped = index => createSelector(
   getSkipLogic(index),
   isSkipAction(index),
-  getSkipOperator(index),
-  getSkipValue(index),
   filterNetwork(index),
-  (logic, action, operator, comparisonValue, results) => {
+  (logic, action, results) => {
     if (!logic) return false;
 
-    let outerQuery = false;
-    switch (operator) {
-      case SkipLogicOperator.NONE:
-        outerQuery = !results.nodes.length;
-        break;
-      case SkipLogicOperator.ANY:
-        outerQuery = results.nodes.length > 0;
-        break;
-      default:
-        outerQuery = predicate(operator)(
-          { value: results.nodes.length, other: comparisonValue });
-    }
-
+    const outerQuery = results.nodes.length > 0;
     return !!logic && ((action && outerQuery) || (!action && !outerQuery));
   },
 );


### PR DESCRIPTION
Fixes skip logic to work without a top level operator expectation.