### PR TITLE
missing highlight and zero value ordinal

### DIFF
--- a/src/containers/Canvas/PresetSwitcher.js
+++ b/src/containers/Canvas/PresetSwitcher.js
@@ -33,6 +33,7 @@ class PresetSwitcher extends PureComponent {
       toggleConvex,
       toggleEdges,
       highlightIndex,
+      highlights,
       toggleHighlights,
       toggleHighlightIndex,
       showResetButton,
@@ -40,8 +41,6 @@ class PresetSwitcher extends PureComponent {
       resetInteractions,
       toggleFreeze,
     } = this.props;
-
-    const currentPreset = presets[presetIndex];
 
     const navigationClasses = cx(
       'preset-switcher__navigation ',
@@ -57,7 +56,7 @@ class PresetSwitcher extends PureComponent {
       <div className="preset-switcher">
         <PresetSwitcherKey
           subject={subject}
-          highlights={currentPreset.highlight}
+          highlights={highlights}
           highlightIndex={highlightIndex}
           toggleHighlights={toggleHighlights}
           toggleHighlightIndex={toggleHighlightIndex}
@@ -112,6 +111,7 @@ PresetSwitcher.propTypes = {
   toggleConvex: PropTypes.func.isRequired,
   toggleEdges: PropTypes.func.isRequired,
   highlightIndex: PropTypes.number.isRequired,
+  highlights: PropTypes.array,
   toggleHighlights: PropTypes.func.isRequired,
   toggleHighlightIndex: PropTypes.func.isRequired,
   showResetButton: PropTypes.bool.isRequired,
@@ -123,6 +123,7 @@ PresetSwitcher.propTypes = {
 PresetSwitcher.defaultProps = {
   displayEdges: null,
   convexHulls: null,
+  highlights: [],
   isFreeze: false,
   showFreezeButton: true,
   toggleFreeze: () => {},

--- a/src/containers/Interfaces/Narrative.js
+++ b/src/containers/Interfaces/Narrative.js
@@ -98,7 +98,7 @@ class Narrative extends Component {
     const presets = stage.presets;
     const currentPreset = presets[this.state.presetIndex];
     const layoutVariable = currentPreset.layoutVariable;
-    const highlight = currentPreset.highlight;
+    const highlight = currentPreset.highlight || [];
     const displayEdges = (currentPreset.edges && currentPreset.edges.display) || [];
     const convexHulls = currentPreset.groupVariable;
 
@@ -143,7 +143,7 @@ class Narrative extends Component {
             updatePreset={this.updatePreset}
             presetIndex={this.state.presetIndex}
             subject={subject}
-            highlights={currentPreset.highlight}
+            highlights={highlight}
             highlightIndex={this.state.highlightIndex}
             toggleHighlightIndex={this.toggleHighlightIndex}
             toggleHighlights={this.toggleHighlights}

--- a/src/containers/Interfaces/OrdinalBin.js
+++ b/src/containers/Interfaces/OrdinalBin.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { isNil } from 'lodash';
+
 import withPrompt from '../../behaviours/withPrompt';
 import { PromptSwiper, OrdinalBins } from '../';
 import { makeGetPromptVariable, makeNetworkNodesForType } from '../../selectors/interface';
@@ -65,7 +67,7 @@ function makeMapStateToProps() {
 
     return {
       nodesForPrompt: stageNodes.filter(
-        node => !node[entityAttributesProperty][activePromptVariable],
+        node => isNil(node[entityAttributesProperty][activePromptVariable]),
       ),
     };
   };

--- a/src/containers/OrdinalBins.js
+++ b/src/containers/OrdinalBins.js
@@ -2,7 +2,9 @@ import React, { PureComponent } from 'react';
 import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { isNil } from 'lodash';
 import color from 'color';
+
 import { makeNetworkNodesForType, makeGetVariableOptions, makeGetPromptVariable } from '../selectors/interface';
 import { actionCreators as sessionsActions } from '../ducks/modules/sessions';
 import { NodeList } from '../components/';
@@ -115,7 +117,7 @@ function makeMapStateToProps() {
         .map((bin) => {
           const nodes = stageNodes.filter(
             node =>
-              node[entityAttributesProperty][activePromptVariable] &&
+              !isNil(node[entityAttributesProperty][activePromptVariable]) &&
               node[entityAttributesProperty][activePromptVariable] === bin.value,
           );
 


### PR DESCRIPTION
This fixes the narrative error when highlight variable is not provided, defaulting to an empty array.

Also fixes ordinal bin issue when a value is set to `0`. The value was being set correctly, but the bins were just not displaying it because `0` is `false`. Checks for null or undefined to test whether a value is filled in or not when filtering nodes for ordinal bins.