### PR TITLE
rename start screen screen labels

### DIFF
--- a/src/containers/Setup/SetupScreen.js
+++ b/src/containers/Setup/SetupScreen.js
@@ -67,8 +67,8 @@ class Setup extends Component {
             <img className="toggle-image" src={downArrow} alt="Resume interview" />
             <h4>
               { !this.state.showSessionOverlay ?
-                ('Resume session') :
-                ('Start new interview')
+                ('Manage Interview Sessions') :
+                ('Start New Session')
               }
             </h4>
           </div>

--- a/src/styles/components/_session-list.scss
+++ b/src/styles/components/_session-list.scss
@@ -108,7 +108,7 @@
     width: 90vw;
     height: calc(80vh);
     margin: 0 auto;
-    background: var(--light-background);
+    background: var(--session-management-screen-bg);
     border-radius: var(--border-radius);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Feedback response: rename the start screen labels to "Manage Interview Sessions", and "Start New Session".

Also creates transparent background color for manage sessions screen in UI.

Also updates UI ref.