### PR TITLE
Fix for #899

### DIFF
--- a/src/containers/Interfaces/EgoForm.js
+++ b/src/containers/Interfaces/EgoForm.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { clamp } from 'lodash';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { isValid, isSubmitting, submit } from 'redux-form';
 import ReactMarkdown from 'react-markdown';
-
+import { isIOS } from '../../utils/Environment';
 import { ProgressBar, Scroller } from '../../components';
 import { Form } from '../../containers';
 import { actionCreators as sessionsActions } from '../../ducks/modules/sessions';
@@ -60,7 +61,12 @@ class EgoForm extends Component {
   }
 
   handleScroll = (scrollTop, scrollProgress) => {
-    this.setState({ scrollProgress });
+    // iOS inertial scrolling takes values out of range
+    const clampedScrollProgress = clamp(scrollProgress, 0, 1);
+
+    if (this.state.scrollProgress !== clampedScrollProgress) {
+      this.setState({ scrollProgress: clampedScrollProgress });
+    }
   }
 
   render() {
@@ -73,7 +79,7 @@ class EgoForm extends Component {
     const progressClasses = cx(
       'progress-container',
       {
-        'progress-container--show': this.state.scrollProgress > 0,
+        'progress-container--show': isIOS() || this.state.scrollProgress > 0,
       },
     );
 
@@ -99,7 +105,7 @@ class EgoForm extends Component {
           </Scroller>
         </div>
         <div className={progressClasses}>
-          { this.state.scrollProgress === 1 && (<span className="progress-container__status-text">Click next to continue</span>)}
+          { (!isIOS() && this.state.scrollProgress === 1) && (<span className="progress-container__status-text">Click next to continue</span>)}
           <ProgressBar
             orientation="horizontal"
             percentProgress={this.state.scrollProgress * 100}

--- a/src/styles/containers/_alter-form-interface.scss
+++ b/src/styles/containers/_alter-form-interface.scss
@@ -92,7 +92,7 @@
     position: absolute;
     z-index: var(--z-panel);
     left: 50%;
-    transform: translate(-50%, 5rem);
+    transform: translateX(-50%);
     opacity: 0;
     text-align: center;
     display: flex;
@@ -105,7 +105,6 @@
 
     &--show {
       opacity: 1;
-      transform: translate(-50%, 0);
     }
 
     .progress {
@@ -114,6 +113,8 @@
     }
 
   }
+
+
 
 }
 

--- a/src/styles/containers/_ego-form-interface.scss
+++ b/src/styles/containers/_ego-form-interface.scss
@@ -1,6 +1,6 @@
 .ego-form {
   height: 100%;
-  padding: 1rem 2rem 4rem;
+  padding: 2rem 8rem 5rem 4rem;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -13,6 +13,10 @@ export const isLinux = () => isElectron() && window.require('os').platform() ===
 
 export const isCordova = () => !!window.cordova;
 
+export const isIOS = () => isCordova() && (/iOS/i).test(window.device.platform);
+
+export const isAndroid = () => isCordova() && (/Android/i).test(window.device.platform);
+
 export const isWeb = () => (!isCordova() && !isElectron());
 
 const getEnvironment = () => {


### PR DESCRIPTION
Root cause was that changing the DOM while momentum scrolling (which is enabled by `-webkit-overflow-scrolling: touch;`) caused momentum to be lost, appearing to the user as scrolling getting "stuck". We change the DOM to toggle the appearance of the progress-bar, and to toggle some text when scrolled to the bottom.

This PR adds environment detection for Android and iOS, and uses it to disable these two actions. iOS users will not see the progress bar animate in, nor will they see "click next to continue" appear when they get to the bottom of the screen.

Fixes #899.