### PR TITLE
add cordova keyboard plugin, switch iOS to px font sizing

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -72,4 +72,5 @@
     <plugin name="cordova-plugin-zeroconf" spec="^1.4.0" />
     <engine name="ios" spec="^5.0.0" />
     <engine name="android" spec="^8.0.0" />
+    <plugin name="cordova-plugin-keyboard" spec="^1.2.0" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3599,6 +3599,11 @@
             "resolved": "https://registry.npmjs.org/cordova-plugin-file-transfer/-/cordova-plugin-file-transfer-1.7.1.tgz",
             "integrity": "sha1-p12L4uvDu5sjxbG70ZkhTsJnWGs="
         },
+        "cordova-plugin-keyboard": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cordova-plugin-keyboard/-/cordova-plugin-keyboard-1.2.0.tgz",
+            "integrity": "sha512-Zng4SgDQQ2BCqeDOvrsgNlM9tcjnxmJoh0Qhex0KltMsoR0g/ONbMTpaVvI8EhNKVO8HJPnhFxxzHxrCPLQ7sQ=="
+        },
         "cordova-plugin-network-canvas-client": {
             "version": "file:cordova-plugin-network-canvas-client"
         },

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-file": "^5.0.0",
     "cordova-plugin-file-transfer": "^1.7.1",
+    "cordova-plugin-keyboard": "^1.2.0",
     "cordova-plugin-network-canvas-client": "./cordova-plugin-network-canvas-client",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-plugin-wkwebview-engine": "^1.1.4",
@@ -246,7 +247,8 @@
       "cordova-plugin-device": {},
       "cordova-plugin-network-canvas-client": {},
       "cordova-plugin-chooser": {},
-      "cordova-plugin-zeroconf": {}
+      "cordova-plugin-zeroconf": {},
+      "cordova-plugin-keyboard": {}
     }
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
       worker-src 'self' blob:;
       "
     />
-    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width viewport-fit=cover"  />
     <title>Network Canvas</title>
   </head>
   <body>

--- a/src/components/MainMenu/SettingsMenu.js
+++ b/src/components/MainMenu/SettingsMenu.js
@@ -5,6 +5,7 @@ import { Icon, Button } from '../../ui/components';
 import Scroller from '../Scroller';
 import { Toggle, Text } from '../../ui/components/Fields';
 import MenuPanel from './MenuPanel';
+import { isCordova } from '../../utils/protocol/protocol-validation/utils/Environment';
 
 class SettingsMenu extends PureComponent {
   constructor(props) {
@@ -151,7 +152,7 @@ class SettingsMenu extends PureComponent {
                     visible on each screen.
                   </p>
                 </section>
-                <section>
+                {!isCordova() && <section>
                   <Toggle
                     input={{
                       checked: true,
@@ -166,6 +167,7 @@ class SettingsMenu extends PureComponent {
                     the size of the window. Turning it off will use a fixed size.
                   </p>
                 </section>
+                }
                 {isElectron() && <section>
                   <Toggle
                     input={{

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -11,6 +11,7 @@ import DialogManager from '../components/DialogManager';
 
 import MainMenu from '../containers/MainMenu';
 import SettingsMenuButton from '../components/MainMenu/SettingsMenuButton';
+import { isCordova } from '../utils/protocol/protocol-validation/utils/Environment';
 
 /**
   * Main app container.
@@ -19,6 +20,11 @@ import SettingsMenuButton from '../components/MainMenu/SettingsMenuButton';
 class App extends PureComponent {
   componentDidMount() {
     this.setFontSize();
+
+    if (isCordova()) {
+      // Enable viewport shrinking on iOS to mirror behaviour on android.
+      window.Keyboard.shrinkView(true);
+    }
   }
 
   componentDidUpdate() {
@@ -28,8 +34,8 @@ class App extends PureComponent {
   setFontSize = () => {
     const root = document.documentElement;
     const newFontSize = this.props.useDynamicScaling ?
-      `${(1.75 * this.props.interfaceScale) / 100}vmin` :
-      `${(18 * this.props.interfaceScale) / 100}px`;
+      `${(1.65 * this.props.interfaceScale) / 100}vmin` :
+      `${(16 * this.props.interfaceScale) / 100}px`;
 
     root.style.setProperty('--base-font-size', newFontSize);
   }

--- a/src/ducks/modules/__tests__/deviceSettings.test.js
+++ b/src/ducks/modules/__tests__/deviceSettings.test.js
@@ -32,7 +32,7 @@ describe('deviceSettings reducer', () => {
       global.device = { platform: 'iOS', isVirtual: true };
       const newState = reducer(initialState, { type: actionTypes.DEVICE_READY });
       expect(newState.description).toMatch('iOS');
-      expect(newState.useDynamicScaling).toBe(true);
+      expect(newState.useDynamicScaling).toBe(false);
     });
   });
 

--- a/src/utils/DeviceInfo.js
+++ b/src/utils/DeviceInfo.js
@@ -72,7 +72,7 @@ const deviceDescription = () => {
 };
 
 // Disable dynamic scaling on android because vmin is resized by software keyboard
-const shouldUseDynamicScaling = () => !(isCordova() && device.platform === 'Android');
+const shouldUseDynamicScaling = () => !(isCordova());
 
 export default deviceDescription;
 

--- a/src/utils/DeviceInfo.js
+++ b/src/utils/DeviceInfo.js
@@ -72,7 +72,7 @@ const deviceDescription = () => {
 };
 
 // Disable dynamic scaling on android because vmin is resized by software keyboard
-const shouldUseDynamicScaling = () => !(isCordova());
+const shouldUseDynamicScaling = () => !isCordova();
 
 export default deviceDescription;
 


### PR DESCRIPTION
Fixes #900.

The behavior with iOS viewports is complicated, and we have changed it several times to address different issues. In #334 we removed a meta viewport property that makes iOS scroll to a focused input because it was causing content to be pushed off of the screen.

In this PR I add a Cordova plugin that makes iOS behave the same way as Android, which is to shrink the viewport when an input is focused. This means the above issue no longer occurs, and the property can be reinstated.

As a consequence, iOS can no longer use viewport units for font sizing. I updated the default device setting to reflect this. I also removed the ability to set dynamic font sizing on Cordova entirely, since it will break the app. I actually think having all mobile on PX sizing, and all electron on dynamic by default (with the option for px) is better.

This has numerous other benefits, including making the quick add input visible. However, it is a big change for this late in the day, and so some testing would be welcome.

Small note: I also reduced the overall font size to match the defaults in UI (16px and 1.675vmin). 