### PR TITLE
Remove protocol.name from Network Canvas

### DIFF
--- a/src/components/MainMenu/SettingsMenu.js
+++ b/src/components/MainMenu/SettingsMenu.js
@@ -122,7 +122,7 @@ class SettingsMenu extends PureComponent {
                 <section>
                   <Button
                     color="mustard"
-                    onClick={() => importProtocolFromURI('https://github.com/codaco/development-protocol/releases/download/20190520140749-4afad6a/development-protocol.netcanvas')}
+                    onClick={() => importProtocolFromURI('https://github.com/codaco/development-protocol/releases/download/20190529123247-7c1e58a/development-protocol.netcanvas')}
                   >
                     Import development protocol
                   </Button>

--- a/src/ducks/modules/importProtocol.js
+++ b/src/ducks/modules/importProtocol.js
@@ -4,7 +4,7 @@ import { removeDirectory } from '../../utils/filesystem';
 import downloadProtocol from '../../utils/protocol/downloadProtocol';
 import extractProtocol from '../../utils/protocol/extractProtocol';
 import parseProtocol from '../../utils/protocol/parseProtocol';
-import checkExistingProtocol from '../../utils/protocol/checkExistingProtocol';
+import checkExistingProtocol, { moveToExistingProtocol } from '../../utils/protocol/checkExistingProtocol';
 import protocolPath from '../../utils/protocol/protocolPath';
 
 const DOWNLOAD_PROTOCOL = 'DOWNLOAD_PROTOCOL';
@@ -26,29 +26,29 @@ export default function reducer(state = initialState, action = {}) {
     case IMPORT_PROTOCOL_FAILED:
     case RESET_IMPORT:
       return initialState;
+    case CHECK_EXISTING_PROTOCOL:
+      return {
+        statusText: 'Checking for previous installation...',
+        step: 1,
+      };
     case IMPORT_PROTOCOL_START:
       return {
         statusText: 'Initializing protocol import...',
-        step: 1,
+        step: 2,
       };
     case DOWNLOAD_PROTOCOL:
       return {
         statusText: 'Downloading protocol...',
-        step: 2,
+        step: 3,
       };
     case EXTRACT_PROTOCOL:
       return {
         statusText: 'Extracting protocol to temporary storage...',
-        step: 3,
+        step: 4,
       };
     case PARSE_PROTOCOL:
       return {
         statusText: 'Parsing and validating protocol...',
-        step: 4,
-      };
-    case CHECK_EXISTING_PROTOCOL:
-      return {
-        statusText: 'Checking for previous installation...',
         step: 5,
       };
     case IMPORT_PROTOCOL_COMPLETE:
@@ -135,6 +135,7 @@ const catchError = error => Promise.reject(error);
 const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => {
   let pairedServer;
   let protocolUid;
+  let previousUid;
   const filename = filenameFromURI(uri);
   const protocolName = protocolNameFromFilename(filename);
 
@@ -142,9 +143,14 @@ const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => 
     pairedServer = getState().pairedServer;
   }
 
-  dispatch(importProtocolStartAction());
-  dispatch(downloadProtocolAction());
-  return downloadProtocol(uri, pairedServer)
+  dispatch(checkExistingProtocolAction());
+  return checkExistingProtocol(dispatch, getState(), protocolName)
+    .then((existingUid) => {
+      previousUid = existingUid;
+      dispatch(importProtocolStartAction());
+      dispatch(downloadProtocolAction());
+      return downloadProtocol(uri, pairedServer);
+    })
     .then((tempLocation) => {
       if (getState().importProtocol.step === 0) return cancelledImport();
       dispatch(extractProtocolAction());
@@ -158,8 +164,10 @@ const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => 
     }, catchError)
     .then((protocolContent) => {
       if (getState().importProtocol.step === 0) return cancelledImport();
-      dispatch(checkExistingProtocolAction());
-      return checkExistingProtocol(dispatch, getState(), protocolContent);
+      if (previousUid) {
+        return moveToExistingProtocol(previousUid, protocolContent);
+      }
+      return protocolContent;
     })
     .then((protocolContent) => {
       if (getState().importProtocol.step === 0) return cancelledImport();
@@ -179,12 +187,18 @@ const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => 
 
 const importProtocolFromFile = filePath => (dispatch, getState) => {
   let protocolUid;
+  let previousUid;
   const filename = filenameFromPath(filePath);
   const protocolName = protocolNameFromFilename(filename);
 
-  dispatch(importProtocolStartAction());
-  dispatch(extractProtocolAction());
-  return extractProtocol(filePath)
+  dispatch(checkExistingProtocolAction());
+  return checkExistingProtocol(dispatch, getState(), protocolName)
+    .then((existingUid) => {
+      previousUid = existingUid;
+      dispatch(importProtocolStartAction());
+      dispatch(extractProtocolAction());
+      return extractProtocol(filePath);
+    })
     .then((protocolLocation) => {
       protocolUid = protocolLocation;
       if (getState().importProtocol.step === 0) return cancelledImport(protocolLocation);
@@ -193,8 +207,10 @@ const importProtocolFromFile = filePath => (dispatch, getState) => {
     }, catchError)
     .then((protocolContent) => {
       if (getState().importProtocol.step === 0) return cancelledImport(protocolContent.uid);
-      dispatch(checkExistingProtocolAction());
-      return checkExistingProtocol(dispatch, getState(), protocolContent);
+      if (previousUid) {
+        return moveToExistingProtocol(previousUid, protocolContent);
+      }
+      return protocolContent;
     })
     .then((protocolContent) => {
       if (getState().importProtocol.step === 0) return cancelledImport(protocolContent.uid);

--- a/src/ducks/modules/importProtocol.js
+++ b/src/ducks/modules/importProtocol.js
@@ -167,7 +167,7 @@ const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => 
     }, catchError)
     .catch(
       (error) => {
-        cleanUpProtocol(protocolUid); // attempt to clean up files
+        if (protocolUid) cleanUpProtocol(protocolUid); // attempt to clean up files
         if (error instanceof CancellationError) {
           dispatch(resetImportAction());
         } else {
@@ -178,6 +178,7 @@ const importProtocolFromURI = (uri, usePairedServer) => (dispatch, getState) => 
 };
 
 const importProtocolFromFile = filePath => (dispatch, getState) => {
+  let protocolUid;
   const filename = filenameFromPath(filePath);
   const protocolName = protocolNameFromFilename(filename);
 
@@ -185,6 +186,7 @@ const importProtocolFromFile = filePath => (dispatch, getState) => {
   dispatch(extractProtocolAction());
   return extractProtocol(filePath)
     .then((protocolLocation) => {
+      protocolUid = protocolLocation;
       if (getState().importProtocol.step === 0) return cancelledImport(protocolLocation);
       dispatch(parseProtocolAction());
       return parseProtocol(protocolLocation, protocolName);
@@ -200,6 +202,7 @@ const importProtocolFromFile = filePath => (dispatch, getState) => {
     }, catchError)
     .catch(
       (error) => {
+        if (protocolUid) cleanUpProtocol(protocolUid); // attempt to clean up files
         if (error instanceof CancellationError) {
           dispatch(resetImportAction());
         } else {

--- a/src/utils/protocol/checkExistingProtocol.js
+++ b/src/utils/protocol/checkExistingProtocol.js
@@ -17,9 +17,9 @@ const renameProtocol = (previousUuid, currentUuid) => {
   .then(() => rename(currentDir, previousDir));
 }
 
-const checkExistingSession = (dispatch, state, protocolContent) => {
+const checkExistingSession = (dispatch, state, currentName) => {
   const existingIndex = findKey(state.installedProtocols,
-    protocol => protocol.name === protocolContent.name);
+    protocol => protocol.name === currentName);
   const unExportedSession = findKey(state.sessions,
     session => session.protocolUID === existingIndex && !session.lastExportedAt);
   if (unExportedSession) {
@@ -34,22 +34,18 @@ const checkExistingSession = (dispatch, state, protocolContent) => {
       type: 'Warning',
       title: 'Overwrite existing protocol?',
       confirmLabel: 'Overwrite protocol',
-      onConfirm: () => {
-        renameProtocol(existingIndex, protocolContent.uid)
-        .then(() => resolve(protocolContent));
-      },
+      onConfirm: () => resolve(existingIndex),
       onCancel: () => reject(new CancellationError('Installation of this protocol cancelled.')),
       message: 'This protocol is already installed. Overwriting the previous installation of this protocol may prevent you from modifying previously created sessions.',
     })));
   }
 
-  if (existingIndex) {
-    // clean up protocol even if no sessions exist
-    return renameProtocol(existingIndex, protocolContent.uid)
-      .then(() => Promise.resolve(protocolContent));
-  }
+  return Promise.resolve(existingIndex);
+}
 
-  return Promise.resolve(protocolContent);
+export const moveToExistingProtocol = (existingIndex, protocolContent) => {
+  return renameProtocol(existingIndex, protocolContent.uid)
+    .then(() => protocolContent);
 }
 
 export default checkExistingSession;

--- a/src/utils/protocol/checkExistingProtocol.js
+++ b/src/utils/protocol/checkExistingProtocol.js
@@ -23,8 +23,8 @@ const checkExistingSession = (dispatch, state, protocolContent) => {
   const unExportedSession = findKey(state.sessions,
     session => session.protocolUID === existingIndex && !session.lastExportedAt);
   if (unExportedSession) {
-    const message = 'This protocol is already installed. In progress sessions for a previous version of this protocol have not yet been exported. Please export them before attempting to overwrite the protocol.';
-    return Promise.reject(new Error(message));
+    const message = 'This protocol is already installed, and in-progress sessions using it have not yet been exported. Please export or delete these sessions before attempting to overwrite the protocol.';
+    return Promise.reject(message);
   }
 
   const existingSession = findKey(state.sessions,
@@ -39,10 +39,10 @@ const checkExistingSession = (dispatch, state, protocolContent) => {
         .then(() => resolve(protocolContent));
       },
       onCancel: () => reject(new CancellationError('Installation of this protocol cancelled.')),
-      message: 'This protocol is already installed; all in progress sessions have been exported. Overwriting the previous installation of this protocol may limit access to previously created sessions.',
+      message: 'This protocol is already installed. Overwriting the previous installation of this protocol may prevent you from modifying previously created sessions.',
     })));
   }
-  
+
   if (existingIndex) {
     // clean up protocol even if no sessions exist
     return renameProtocol(existingIndex, protocolContent.uid)

--- a/src/utils/protocol/parseProtocol.js
+++ b/src/utils/protocol/parseProtocol.js
@@ -22,24 +22,18 @@ const validateProtocol = (protocol) => {
   return Promise.resolve(protocol);
 };
 
-const parseProtocol = (environment) => {
-  if (environment !== environments.WEB) {
-    // store.dispatch(importActions.parseProtocol());
-    return protocolUID =>
-      readFile(protocolPath(protocolUID, 'protocol.json'))
-        .then(json => JSON.parse(json))
-        .then(data => validateProtocol(data)).catch(validationError)
-        .then((protocol) => {
-          const withUID = {
-            ...protocol,
-            uid: protocolUID,
-          };
-          return withUID;
-        })
-        .catch(openError);
-  }
+const parseProtocol = (protocolUID, name) =>
+  readFile(protocolPath(protocolUID, 'protocol.json'))
+    .then(json => JSON.parse(json))
+    .then(data => validateProtocol(data)).catch(validationError)
+    .then((protocol) => {
+      const withFilename = {
+        ...protocol,
+        name,
+        uid: protocolUID,
+      };
+      return withFilename;
+    })
+    .catch(openError);
 
-  return () => Promise.reject(new Error('parseProtocol() not supported on this platform'));
-};
-
-export default inEnvironment(parseProtocol);
+export default parseProtocol;


### PR DESCRIPTION
This is a super low involvement implementation of this. Instead of refactoring and removing the UUID generation that is littered throughout the importProtocol thunks, I added two functions to identify the filename, and injected it into the protocol payload after it is parsed. 

Todo:

- [x] test on windows. in particular test filenames imported locally from file.
- [x] update protocol validation to remove name property from protocol