### PR TITLE
Feature/scrollbars

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="40022" id="org.codaco.networkCanvas" ios-CFBundleIdentifier="networkCanvas" ios-CFBundleVersion="40022" version="4.0.0-beta.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="40023" id="org.codaco.networkCanvas" ios-CFBundleIdentifier="networkCanvas" ios-CFBundleVersion="40023" version="4.0.0-beta.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>NetworkCanvas</name>
     <description>
         Simplifying complex network data collection.
@@ -71,6 +71,6 @@
     <plugin name="cordova-plugin-network-canvas-client" spec="./cordova-plugin-network-canvas-client" />
     <plugin name="cordova-plugin-zeroconf" spec="^1.4.0" />
     <plugin name="cordova-plugin-keyboard" spec="^1.2.0" />
-    <engine name="android" spec="^8.0.0" />
     <engine name="ios" spec="^5.0.1" />
+    <engine name="android" spec="^8.0.0" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13725,7 +13725,7 @@
             "version": "1.9.4",
             "resolved": "https://registry.npmjs.org/ios-deploy/-/ios-deploy-1.9.4.tgz",
             "integrity": "sha512-pgyc19zgtwGrfx3GL8yV0c0dAPucTpJ0VZkuS3DcqxIZYC48+UW+tBTxI43u1ZDk17mop0ABLs1SkAy5SUQ6pQ==",
-            "dev": true
+            "optional": true
         },
         "ios-sim": {
             "version": "8.0.1",

--- a/src/behaviours/scrollable.js
+++ b/src/behaviours/scrollable.js
@@ -1,12 +1,23 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 
-const scrollable = (WrappedComponent) => {
+export const scrollable = (WrappedComponent) => {
   const Scrollable = props => (
-    <div className="scrollable" onScroll={props.onScroll}>
+    <div className={`scrollable ${(props.showScollbars && 'scrollable--show-scrollbars')}`} onScroll={props.onScroll}>
       <WrappedComponent {...props} />
     </div>
   );
   return Scrollable;
 };
 
-export default scrollable;
+const mapStateToProps = state => ({
+  showScollbars: state.deviceSettings.showScrollbars,
+});
+
+const composedScrollable = compose(
+  connect(mapStateToProps, null),
+  scrollable,
+);
+
+export default composedScrollable;

--- a/src/components/MainMenu/SettingsMenu.js
+++ b/src/components/MainMenu/SettingsMenu.js
@@ -1,11 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { isElectron } from '../../utils/Environment';
+import { isElectron, isCordova, isIOS } from '../../utils/Environment';
 import { Icon, Button } from '../../ui/components';
 import Scroller from '../Scroller';
 import { Toggle, Text } from '../../ui/components/Fields';
 import MenuPanel from './MenuPanel';
-import { isCordova } from '../../utils/protocol/protocol-validation/utils/Environment';
 
 class SettingsMenu extends PureComponent {
   constructor(props) {
@@ -55,6 +54,8 @@ class SettingsMenu extends PureComponent {
       toggleUseDynamicScaling,
       useDynamicScaling,
       setDeviceDescription,
+      showScrollbars,
+      toggleShowScrollbars,
       deviceDescription,
       setInterfaceScale,
       interfaceScale,
@@ -168,6 +169,24 @@ class SettingsMenu extends PureComponent {
                   </p>
                 </section>
                 }
+                {!isIOS() && <section>
+                  <Toggle
+                    input={{
+                      checked: false,
+                      value: showScrollbars,
+                      onChange: toggleShowScrollbars,
+                    }}
+                    label="Show scrollbars on scrollable elements?"
+                    fieldLabel=" "
+                  />
+                  <p>
+                    By default, Network Canvas does not show scrollbars in order to provide
+                    a more streamlined visual experience. If you encounter difficulties with
+                    discoverability or with scrolling behavior, you may enable showing scrollbars
+                    here.
+                  </p>
+                </section>
+                }
                 {isElectron() && <section>
                   <Toggle
                     input={{
@@ -175,7 +194,7 @@ class SettingsMenu extends PureComponent {
                       value: this.state.fullScreenApp,
                       onChange: this.handleToggleUseFullScreenApp,
                     }}
-                    label="Run in full screen?"
+                    label="Run in full screen mode?"
                     fieldLabel=" "
                   />
                   <p>
@@ -219,9 +238,11 @@ SettingsMenu.propTypes = {
   handleAddMockNodes: PropTypes.func.isRequired,
   shouldShowMocksItem: PropTypes.bool,
   toggleUseFullScreenForms: PropTypes.func.isRequired,
+  toggleShowScrollbars: PropTypes.func.isRequired,
   useFullScreenForms: PropTypes.bool.isRequired,
   toggleUseDynamicScaling: PropTypes.func.isRequired,
   useDynamicScaling: PropTypes.bool.isRequired,
+  showScrollbars: PropTypes.bool.isRequired,
   setDeviceDescription: PropTypes.func.isRequired,
   deviceDescription: PropTypes.string.isRequired,
   setInterfaceScale: PropTypes.func.isRequired,

--- a/src/components/MainMenu/SettingsMenu.js
+++ b/src/components/MainMenu/SettingsMenu.js
@@ -77,66 +77,8 @@ class SettingsMenu extends PureComponent {
           <Scroller>
             <div className="main-menu-settings-menu__form">
               <fieldset>
-                <legend>Device Options</legend>
-                <section>
-                  <label htmlFor="deviceName">Device Name</label>
-                  <Text
-                    input={{
-                      value: deviceDescription,
-                      onChange: e => setDeviceDescription(e.target.value),
-                    }}
-                    name="deviceName"
-                    label="Device name"
-                    fieldLabel=" "
-                  />
-                  <p>The device name determines how your device appears to Server.</p>
-                </section>
-                <section>
-                  <Button
-                    color="neon-coral"
-                    onClick={handleResetAppData}
-                  >
-                    Reset Network Canvas data
-                  </Button>
-                  <p>
-                    Click the button above to reset all Network Canvas data. This will erase any
-                    in-progress interviews, and all application settings.
-                  </p>
-                </section>
-              </fieldset>
-              <fieldset>
-                <legend>Developer Options</legend>
-                {
-                  shouldShowMocksItem &&
-                  <section>
-                    <Button
-                      color="mustard"
-                      onClick={handleAddMockNodes}
-                    >
-                      Add mock nodes
-                    </Button>
-                    <p>
-                      During an active interview session, clicking this button will create
-                      mock nodes for testing purposes.
-                    </p>
-                  </section>
-                }
-                <section>
-                  <Button
-                    color="mustard"
-                    onClick={() => importProtocolFromURI('https://github.com/codaco/development-protocol/releases/download/20190529123247-7c1e58a/development-protocol.netcanvas')}
-                  >
-                    Import development protocol
-                  </Button>
-                  <p>
-                    Clicking this button will import the latest development protocol for this
-                    version of Network Canvas.
-                  </p>
-                </section>
-              </fieldset>
-              <fieldset>
                 <legend>Display Settings</legend>
-                <section>
+                <section className="full-width">
                   <label htmlFor="scaleFactor">Interface Scale</label>
                   <input
                     type="range"
@@ -219,6 +161,64 @@ class SettingsMenu extends PureComponent {
                   <p>
                     The full screen node form is optimized for smaller devices, or devices with
                     no physical keyboard.
+                  </p>
+                </section>
+              </fieldset>
+              <fieldset>
+                <legend>Device Options</legend>
+                <section>
+                  <label htmlFor="deviceName">Device Name</label>
+                  <Text
+                    input={{
+                      value: deviceDescription,
+                      onChange: e => setDeviceDescription(e.target.value),
+                    }}
+                    name="deviceName"
+                    label="Device name"
+                    fieldLabel=" "
+                  />
+                  <p>This is the name that your device will appear as when paring with Server.</p>
+                </section>
+                <section>
+                  <Button
+                    color="neon-coral"
+                    onClick={handleResetAppData}
+                  >
+                    Reset all Network Canvas data
+                  </Button>
+                  <p>
+                    Click the button above to reset all Network Canvas data. This will erase any
+                    in-progress interviews, and all application settings.
+                  </p>
+                </section>
+              </fieldset>
+              <fieldset>
+                <legend>Developer Options</legend>
+                {
+                  shouldShowMocksItem &&
+                  <section>
+                    <Button
+                      color="mustard"
+                      onClick={handleAddMockNodes}
+                    >
+                      Add mock nodes
+                    </Button>
+                    <p>
+                      During an active interview session, clicking this button will create
+                      mock nodes for testing purposes.
+                    </p>
+                  </section>
+                }
+                <section>
+                  <Button
+                    color="mustard"
+                    onClick={() => importProtocolFromURI('https://github.com/codaco/development-protocol/releases/download/20190529123247-7c1e58a/development-protocol.netcanvas')}
+                  >
+                    Import development protocol
+                  </Button>
+                  <p>
+                    Clicking this button will import the latest development protocol for this
+                    version of Network Canvas.
                   </p>
                 </section>
               </fieldset>

--- a/src/components/Scroller.js
+++ b/src/components/Scroller.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -23,11 +24,12 @@ class Scroller extends Component {
     const {
       className,
       children,
+      showScrollbars,
     } = this.props;
 
     return (
       <div
-        className={cx('scrollable', className)}
+        className={cx('scrollable', { 'scrollable--show-scrollbars': showScrollbars }, className)}
         onScroll={this.handleScroll}
         ref={this.scrollable}
       >
@@ -46,6 +48,13 @@ Scroller.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
   onScroll: PropTypes.func,
+  showScrollbars: PropTypes.bool.isRequired,
 };
 
-export default Scroller;
+function mapStateToProps(state) {
+  return {
+    showScrollbars: state.deviceSettings.showScrollbars,
+  };
+}
+
+export default connect(mapStateToProps)(Scroller);

--- a/src/components/__tests__/CardList-test.js
+++ b/src/components/__tests__/CardList-test.js
@@ -1,10 +1,54 @@
 /* eslint-env jest */
 
 import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import { shallow } from 'enzyme';
 import CardList from '../CardList';
 
 jest.mock('../../ui/utils/CSSVariables');
+
+const mockState = {
+  activeSessionId: '62415a79-cd46-409a-98b3-5a0a2fef1f97',
+  activeSessionWorkers: { nodeLabelWorker: 'blob:http://192.168.1.196:3000/b6cac5c5-1b4d-4db0-be86-fa55239fd62c' },
+  deviceSettings: {
+    description: 'Kirby (macOS)',
+    useDynamicScaling: true,
+    useFullScreenForms: false,
+    interfaceScale: 100,
+    showScrollbars: false,
+  },
+  dialogs: { dialogs: Array(0) },
+  form: {},
+  importProtocol: { status: 'inactive', step: 0 },
+  installedProtocols: {
+    'c67ae04d-e5d8-402a-9ded-49205bf6f290': {
+      name: 'Protocol Name',
+      codebook: {},
+      assetManifest: {},
+      description: '',
+      forms: {},
+      lastModified: '2018-10-01T00:00:00.000Z',
+      stages: [],
+    },
+  },
+  pairedServer: null,
+  search: {
+    collapsed: true,
+    selectedResults: [],
+  },
+  sessions: {
+    '62415a79-cd46-409a-98b3-5a0a2fef1f97': {
+      caseId: 'josh2',
+      network: { ego: {}, nodes: [], edges: [] },
+      promptIndex: 0,
+      protocolUID: 'c67ae04d-e5d8-402a-9ded-49205bf6f290',
+      stageIndex: 0,
+      updatedAt: 1554130548004,
+    },
+  },
+  ui: { isMenuOpen: false },
+};
 
 const nodes = [
   { uid: 'a', name: 'a name', age: '22' },
@@ -15,13 +59,15 @@ const nodes = [
 describe('CardList component', () => {
   it('renders cards with list', () => {
     const component = shallow(
-      <CardList
-        nodes={nodes}
-        label={node => node.name}
-        details={node => [{ age: `${node.age}` }]}
-        onToggleCard={() => {}}
-        selected={() => false}
-      />,
+      <Provider store={createStore(() => mockState)}>
+        <CardList
+          nodes={nodes}
+          label={node => node.name}
+          details={node => [{ age: `${node.age}` }]}
+          onToggleCard={() => {}}
+          selected={() => false}
+        />
+      </Provider>,
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/__tests__/__snapshots__/CardList-test.js.snap
+++ b/src/components/__tests__/__snapshots__/CardList-test.js.snap
@@ -3,11 +3,59 @@
 exports[`CardList component renders cards with list 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Scrollable
-    details={[Function]}
-    label={[Function]}
-    nodes={
-      Array [
+  Symbol(enzyme.__unrendered__): <Provider
+    store={
+      Object {
+        "dispatch": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+        Symbol(observable): [Function],
+      }
+    }
+  >
+    <Connect(Scrollable)
+      details={[Function]}
+      label={[Function]}
+      nodes={
+        Array [
+          Object {
+            "age": "22",
+            "name": "a name",
+            "uid": "a",
+          },
+          Object {
+            "age": "88",
+            "name": "b name",
+            "uid": "b",
+          },
+          Object {
+            "age": "33",
+            "name": "c name",
+            "uid": "c",
+          },
+        ]
+      }
+      onToggleCard={[Function]}
+      selected={[Function]}
+    />
+  </Provider>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "details": [Function],
+      "label": [Function],
+      "nodes": Array [
         Object {
           "age": "22",
           "name": "a name",
@@ -23,68 +71,21 @@ ShallowWrapper {
           "name": "c name",
           "uid": "c",
         },
-      ]
-    }
-    onToggleCard={[Function]}
-    selected={[Function]}
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateError": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": <CardList
-        className=""
-        details={[Function]}
-        getKey={[Function]}
-        isItemSelected={[Function]}
-        items={Array []}
-        label={[Function]}
-        nodes={
-          Array [
-            Object {
-              "age": "22",
-              "name": "a name",
-              "uid": "a",
-            },
-            Object {
-              "age": "88",
-              "name": "b name",
-              "uid": "b",
-            },
-            Object {
-              "age": "33",
-              "name": "c name",
-              "uid": "c",
-            },
-          ]
-        }
-        onItemClick={[Function]}
-        onToggleCard={[Function]}
-        selected={[Function]}
-      />,
-      "className": "scrollable",
-      "onScroll": undefined,
+      ],
+      "onToggleCard": [Function],
+      "selected": [Function],
     },
     "ref": null,
-    "rendered": Object {
+    "rendered": null,
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
       "instance": null,
       "key": undefined,
-      "nodeType": "function",
+      "nodeType": "class",
       "props": Object {
-        "className": "",
         "details": [Function],
-        "getKey": [Function],
-        "isItemSelected": [Function],
-        "items": Array [],
         "label": [Function],
         "nodes": Array [
           Object {
@@ -103,93 +104,12 @@ ShallowWrapper {
             "uid": "c",
           },
         ],
-        "onItemClick": [Function],
         "onToggleCard": [Function],
         "selected": [Function],
       },
       "ref": null,
       "rendered": null,
       "type": [Function],
-    },
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <CardList
-          className=""
-          details={[Function]}
-          getKey={[Function]}
-          isItemSelected={[Function]}
-          items={Array []}
-          label={[Function]}
-          nodes={
-            Array [
-              Object {
-                "age": "22",
-                "name": "a name",
-                "uid": "a",
-              },
-              Object {
-                "age": "88",
-                "name": "b name",
-                "uid": "b",
-              },
-              Object {
-                "age": "33",
-                "name": "c name",
-                "uid": "c",
-              },
-            ]
-          }
-          onItemClick={[Function]}
-          onToggleCard={[Function]}
-          selected={[Function]}
-        />,
-        "className": "scrollable",
-        "onScroll": undefined,
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "className": "",
-          "details": [Function],
-          "getKey": [Function],
-          "isItemSelected": [Function],
-          "items": Array [],
-          "label": [Function],
-          "nodes": Array [
-            Object {
-              "age": "22",
-              "name": "a name",
-              "uid": "a",
-            },
-            Object {
-              "age": "88",
-              "name": "b name",
-              "uid": "b",
-            },
-            Object {
-              "age": "33",
-              "name": "c name",
-              "uid": "c",
-            },
-          ],
-          "onItemClick": [Function],
-          "onToggleCard": [Function],
-          "selected": [Function],
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/src/containers/AlterForms/__tests__/__snapshots__/SlideFormEdge.test.js.snap
+++ b/src/containers/AlterForms/__tests__/__snapshots__/SlideFormEdge.test.js.snap
@@ -58,10 +58,7 @@ ShallowWrapper {
         <div
           className="alter-form__form-container"
         >
-          <Scroller
-            className=""
-            onScroll={[Function]}
-          >
+          <Connect(Scroller)>
             <Connect(AutoInitialisedForm)
               autoFocus={false}
               className="alter-form__form"
@@ -73,7 +70,7 @@ ShallowWrapper {
               title="alpha"
               type="friend"
             />
-          </Scroller>
+          </Connect(Scroller)>
         </div>
       </div>,
       "className": "swiper-slide",
@@ -98,10 +95,7 @@ ShallowWrapper {
           <div
             className="alter-form__form-container"
           >
-            <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -113,7 +107,7 @@ ShallowWrapper {
                 title="alpha"
                 type="friend"
               />
-            </Scroller>
+            </Connect(Scroller)>
           </div>,
         ],
         "className": "slide-content",
@@ -157,10 +151,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            "children": <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -172,7 +163,7 @@ ShallowWrapper {
                 title="alpha"
                 type="friend"
               />
-            </Scroller>,
+            </Connect(Scroller)>,
             "className": "alter-form__form-container",
           },
           "ref": null,
@@ -192,8 +183,6 @@ ShallowWrapper {
                 title="alpha"
                 type="friend"
               />,
-              "className": "",
-              "onScroll": [Function],
             },
             "ref": null,
             "rendered": Object {
@@ -246,10 +235,7 @@ ShallowWrapper {
           <div
             className="alter-form__form-container"
           >
-            <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -261,7 +247,7 @@ ShallowWrapper {
                 title="alpha"
                 type="friend"
               />
-            </Scroller>
+            </Connect(Scroller)>
           </div>
         </div>,
         "className": "swiper-slide",
@@ -286,10 +272,7 @@ ShallowWrapper {
             <div
               className="alter-form__form-container"
             >
-              <Scroller
-                className=""
-                onScroll={[Function]}
-              >
+              <Connect(Scroller)>
                 <Connect(AutoInitialisedForm)
                   autoFocus={false}
                   className="alter-form__form"
@@ -301,7 +284,7 @@ ShallowWrapper {
                   title="alpha"
                   type="friend"
                 />
-              </Scroller>
+              </Connect(Scroller)>
             </div>,
           ],
           "className": "slide-content",
@@ -345,10 +328,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <Scroller
-                className=""
-                onScroll={[Function]}
-              >
+              "children": <Connect(Scroller)>
                 <Connect(AutoInitialisedForm)
                   autoFocus={false}
                   className="alter-form__form"
@@ -360,7 +340,7 @@ ShallowWrapper {
                   title="alpha"
                   type="friend"
                 />
-              </Scroller>,
+              </Connect(Scroller)>,
               "className": "alter-form__form-container",
             },
             "ref": null,
@@ -380,8 +360,6 @@ ShallowWrapper {
                   title="alpha"
                   type="friend"
                 />,
-                "className": "",
-                "onScroll": [Function],
               },
               "ref": null,
               "rendered": Object {

--- a/src/containers/AlterForms/__tests__/__snapshots__/SlideFormNode.test.js.snap
+++ b/src/containers/AlterForms/__tests__/__snapshots__/SlideFormNode.test.js.snap
@@ -41,10 +41,7 @@ ShallowWrapper {
         <div
           className="alter-form__form-container"
         >
-          <Scroller
-            className=""
-            onScroll={[Function]}
-          >
+          <Connect(Scroller)>
             <Connect(AutoInitialisedForm)
               autoFocus={false}
               className="alter-form__form"
@@ -56,7 +53,7 @@ ShallowWrapper {
               title="alpha"
               type="person"
             />
-          </Scroller>
+          </Connect(Scroller)>
         </div>
       </div>,
       "className": "swiper-slide",
@@ -74,10 +71,7 @@ ShallowWrapper {
           <div
             className="alter-form__form-container"
           >
-            <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -89,7 +83,7 @@ ShallowWrapper {
                 title="alpha"
                 type="person"
               />
-            </Scroller>
+            </Connect(Scroller)>
           </div>,
         ],
         "className": "slide-content",
@@ -112,10 +106,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            "children": <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -127,7 +118,7 @@ ShallowWrapper {
                 title="alpha"
                 type="person"
               />
-            </Scroller>,
+            </Connect(Scroller)>,
             "className": "alter-form__form-container",
           },
           "ref": null,
@@ -147,8 +138,6 @@ ShallowWrapper {
                 title="alpha"
                 type="person"
               />,
-              "className": "",
-              "onScroll": [Function],
             },
             "ref": null,
             "rendered": Object {
@@ -194,10 +183,7 @@ ShallowWrapper {
           <div
             className="alter-form__form-container"
           >
-            <Scroller
-              className=""
-              onScroll={[Function]}
-            >
+            <Connect(Scroller)>
               <Connect(AutoInitialisedForm)
                 autoFocus={false}
                 className="alter-form__form"
@@ -209,7 +195,7 @@ ShallowWrapper {
                 title="alpha"
                 type="person"
               />
-            </Scroller>
+            </Connect(Scroller)>
           </div>
         </div>,
         "className": "swiper-slide",
@@ -227,10 +213,7 @@ ShallowWrapper {
             <div
               className="alter-form__form-container"
             >
-              <Scroller
-                className=""
-                onScroll={[Function]}
-              >
+              <Connect(Scroller)>
                 <Connect(AutoInitialisedForm)
                   autoFocus={false}
                   className="alter-form__form"
@@ -242,7 +225,7 @@ ShallowWrapper {
                   title="alpha"
                   type="person"
                 />
-              </Scroller>
+              </Connect(Scroller)>
             </div>,
           ],
           "className": "slide-content",
@@ -265,10 +248,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <Scroller
-                className=""
-                onScroll={[Function]}
-              >
+              "children": <Connect(Scroller)>
                 <Connect(AutoInitialisedForm)
                   autoFocus={false}
                   className="alter-form__form"
@@ -280,7 +260,7 @@ ShallowWrapper {
                   title="alpha"
                   type="person"
                 />
-              </Scroller>,
+              </Connect(Scroller)>,
               "className": "alter-form__form-container",
             },
             "ref": null,
@@ -300,8 +280,6 @@ ShallowWrapper {
                   title="alpha"
                   type="person"
                 />,
-                "className": "",
-                "onScroll": [Function],
               },
               "ref": null,
               "rendered": Object {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -39,6 +39,7 @@ class App extends PureComponent {
 
     root.style.setProperty('--base-font-size', newFontSize);
   }
+
   render() {
     const { children } = this.props;
     return (

--- a/src/containers/MainMenu/SettingsMenu.js
+++ b/src/containers/MainMenu/SettingsMenu.js
@@ -44,6 +44,7 @@ const mapDispatchToProps = dispatch => ({
   setDeviceDescription: name => dispatch(deviceSettingsActions.setDescription(name)),
   toggleUseFullScreenForms: () => dispatch(deviceSettingsActions.toggleSetting('useFullScreenForms')),
   toggleUseDynamicScaling: () => dispatch(deviceSettingsActions.toggleSetting('useDynamicScaling')),
+  toggleShowScrollbars: () => dispatch(deviceSettingsActions.toggleSetting('showScrollbars')),
   setInterfaceScale: scale => dispatch(deviceSettingsActions.setInterfaceScale(scale)),
 });
 
@@ -54,6 +55,7 @@ const mapStateToProps = state => ({
   additionalMockAttributes: getAdditionalAttributesForCurrentPrompt(state),
   useFullScreenForms: state.deviceSettings.useFullScreenForms,
   useDynamicScaling: state.deviceSettings.useDynamicScaling,
+  showScrollbars: state.deviceSettings.showScrollbars,
   deviceDescription: state.deviceSettings.description,
   interfaceScale: state.deviceSettings.interfaceScale,
 });

--- a/src/containers/Search/__tests__/Search.test.js
+++ b/src/containers/Search/__tests__/Search.test.js
@@ -2,6 +2,8 @@
 
 import React from 'react';
 import { mount, render } from 'enzyme';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import { Search } from '../Search';
 import SearchResults from '../SearchResults';
 import Card from '../../../components/Card';
@@ -25,6 +27,48 @@ const mockProps = {
   },
 };
 
+const mockState = {
+  activeSessionId: '62415a79-cd46-409a-98b3-5a0a2fef1f97',
+  activeSessionWorkers: { nodeLabelWorker: 'blob:http://192.168.1.196:3000/b6cac5c5-1b4d-4db0-be86-fa55239fd62c' },
+  deviceSettings: {
+    description: 'Kirby (macOS)',
+    useDynamicScaling: true,
+    useFullScreenForms: false,
+    interfaceScale: 100,
+    showScrollbars: false,
+  },
+  dialogs: { dialogs: Array(0) },
+  form: {},
+  importProtocol: { status: 'inactive', step: 0 },
+  installedProtocols: {
+    'c67ae04d-e5d8-402a-9ded-49205bf6f290': {
+      name: 'Protocol Name',
+      codebook: {},
+      assetManifest: {},
+      description: '',
+      forms: {},
+      lastModified: '2018-10-01T00:00:00.000Z',
+      stages: [],
+    },
+  },
+  pairedServer: null,
+  search: {
+    collapsed: true,
+    selectedResults: [],
+  },
+  sessions: {
+    '62415a79-cd46-409a-98b3-5a0a2fef1f97': {
+      caseId: 'josh2',
+      network: { ego: {}, nodes: [], edges: [] },
+      promptIndex: 0,
+      protocolUID: 'c67ae04d-e5d8-402a-9ded-49205bf6f290',
+      stageIndex: 0,
+      updatedAt: 1554130548004,
+    },
+  },
+  ui: { isMenuOpen: false },
+};
+
 describe('<Search />', () => {
   it('renders a search input', () => {
     const component = render(<Search {...mockProps} />);
@@ -32,12 +76,14 @@ describe('<Search />', () => {
   });
 
   it('renders searchResults', () => {
-    const component = mount(<Search {...mockProps} />);
+    const component =
+      mount(<Provider store={createStore(() => mockState)}><Search {...mockProps} /></Provider>);
     expect(component.find(SearchResults).length).toBe(1);
   });
 
   it('populates searchResults', () => {
-    const component = mount(<Search {...mockProps} />);
+    const component =
+      mount(<Provider store={createStore(() => mockState)}><Search {...mockProps} /></Provider>);
     expect(component.find(Card).length).toBe(0);
     component.find('input[type="search"]').simulate('change', { target: { value: 'query' } });
     expect(component.find(Card).length).toBe(1);

--- a/src/ducks/modules/__tests__/deviceSettings.test.js
+++ b/src/ducks/modules/__tests__/deviceSettings.test.js
@@ -6,6 +6,7 @@ const initialState = {
   useFullScreenForms: true,
   useDynamicScaling: undefined,
   interfaceScale: 100,
+  showScrollbars: false,
 };
 const mockDescription = 'My Android Tablet';
 const mockSettingToToggle = 'useDynamicScaling';

--- a/src/ducks/modules/deviceSettings.js
+++ b/src/ducks/modules/deviceSettings.js
@@ -13,6 +13,7 @@ const initialState = {
   // useFullScrenForms should be false for most larger devices, and true for most tablets
   useFullScreenForms: !(window.matchMedia('screen and (min-device-aspect-ratio: 8/5), (min-device-height: 1800px)').matches),
   interfaceScale: 100,
+  showScrollbars: false,
 };
 
 // This provides additional default state based on information unavailable before 'deviceready'.
@@ -30,6 +31,7 @@ const getDeviceReadyState = (state) => {
     ...state,
     description,
     useDynamicScaling,
+    showScrollbars: state.showScrollbars,
   };
 };
 

--- a/src/styles/components/_card-list.scss
+++ b/src/styles/components/_card-list.scss
@@ -1,6 +1,6 @@
 .card-list {
   flex-wrap: wrap;
-  padding-bottom: 10em;
+  padding-bottom: 2rem;
   padding-top: calc(#{$scroller-top-padding});
   display: grid;
   grid-template-columns: 1fr;

--- a/src/styles/components/_panels.scss
+++ b/src/styles/components/_panels.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   opacity: 1;
   margin-right: 0;
-  width: 23rem;
+  width: 24rem;
   transform: translateZ(0);
   will-change: transform;
 

--- a/src/styles/components/_scrollable.scss
+++ b/src/styles/components/_scrollable.scss
@@ -1,7 +1,7 @@
 @mixin scroller-mask($top-height: $scroller-top-padding) {
-  $bottom-height: 1rem;
+  $bottom-height: 2rem;
   $opaque: rgba(0, 0, 0, 1);
-  mask-image: linear-gradient(180deg, transparent, $opaque $bottom-height, $opaque calc(100% - #{$bottom-height}), transparent 100%);
+  mask-image: linear-gradient(180deg, transparent, $opaque $top-height, $opaque calc(100% - #{$bottom-height}), transparent 100%);
 }
 
 .scrollable {
@@ -13,33 +13,40 @@
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
 
-  $scrollbar-height: 1.25rem;
-  $scrollbar-padding: 1rem;
-
   &::-webkit-scrollbar {
-    width: (($scrollbar-padding * 2) + $scrollbar-height);
-    background-color: rgba(255,255,255,0);
-  }
-
-  &::-webkit-scrollbar-track,
-  &::-webkit-scrollbar-thumb {
-    border: $scrollbar-padding solid rgba(255,255,255,0);
-    background-clip: padding-box;
-  }
-
-  &::-webkit-scrollbar-track {
-    background-color: rgba(0, 0, 0, 0.1);
-    border-radius: 5rem;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--color-cyber-grape);
-    border-radius: 5rem;
-    min-height: 10rem;
-  }
-
-
-  &::-webkit-scrollbar-button {
     display: none;
   }
+
+  &--show-scrollbars {
+    $scrollbar-height: 1.25rem;
+    $scrollbar-padding: 1rem;
+
+    &::-webkit-scrollbar {
+      display: block;
+      width: (($scrollbar-padding * 2) + $scrollbar-height);
+      background-color: rgba(255, 255, 255, 0); //sass-lint:disable-line no-color-literals
+    }
+
+    &::-webkit-scrollbar-track,
+    &::-webkit-scrollbar-thumb {
+      border: $scrollbar-padding solid rgba(255, 255, 255, 0); //sass-lint:disable-line no-color-literals
+      background-clip: padding-box;
+    }
+
+    &::-webkit-scrollbar-track {
+      background-color: rgba(0, 0, 0, 0.1); //sass-lint:disable-line no-color-literals
+      border-radius: 5rem;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--color-cyber-grape);
+      border-radius: 5rem;
+      min-height: 10rem;
+    }
+
+    &::-webkit-scrollbar-button {
+      display: none;
+    }
+  }
+
 }

--- a/src/styles/components/_scrollable.scss
+++ b/src/styles/components/_scrollable.scss
@@ -1,19 +1,45 @@
 @mixin scroller-mask($top-height: $scroller-top-padding) {
-  $bottom-height: 2rem;
+  $bottom-height: 1rem;
   $opaque: rgba(0, 0, 0, 1);
-  mask-image: linear-gradient(180deg, transparent, $opaque $top-height, $opaque calc(100% - #{$bottom-height}), transparent 100%);
+  mask-image: linear-gradient(180deg, transparent, $opaque $bottom-height, $opaque calc(100% - #{$bottom-height}), transparent 100%);
 }
 
 .scrollable {
   @include scroller-mask;
   flex: 1;
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   // sass-lint:disable no-vendor-prefixes
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
 
+  $scrollbar-height: 1.5rem;
+  $scrollbar-padding: 1rem;
+
   &::-webkit-scrollbar {
+    width: (($scrollbar-padding * 2) + $scrollbar-height);
+    background-color: rgba(255,255,255,0);
+  }
+
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-thumb {
+    border: $scrollbar-padding solid rgba(255,255,255,0);
+    background-clip: padding-box;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--light-background);
+    border-radius: 5rem;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--transparent-light);
+    border-radius: 5rem;
+    min-height: 10rem;
+  }
+
+
+  &::-webkit-scrollbar-button {
     display: none;
   }
 }

--- a/src/styles/components/_scrollable.scss
+++ b/src/styles/components/_scrollable.scss
@@ -13,7 +13,7 @@
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
 
-  $scrollbar-height: 1.5rem;
+  $scrollbar-height: 1.25rem;
   $scrollbar-padding: 1rem;
 
   &::-webkit-scrollbar {
@@ -28,12 +28,12 @@
   }
 
   &::-webkit-scrollbar-track {
-    background-color: var(--light-background);
+    background-color: rgba(0, 0, 0, 0.1);
     border-radius: 5rem;
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: var(--transparent-light);
+    background-color: var(--color-cyber-grape);
     border-radius: 5rem;
     min-height: 10rem;
   }

--- a/src/styles/components/main-menu/_settings-menu.scss
+++ b/src/styles/components/main-menu/_settings-menu.scss
@@ -17,7 +17,8 @@
   fieldset {
     border: .1rem solid var(--color-platinum);
     border-radius: .75rem;
-    padding: 0 spacing(medium) spacing(small);
+    padding: spacing(medium);
+    margin: spacing(medium);
 
     legend {
       padding: 1rem;
@@ -31,14 +32,19 @@
   }
 
   section {
-    padding: 1rem;
+    padding: 0 1rem;
+    width: 50%;
+    float: left;
+
+    &.full-width {
+      width: 100%;
+    }
   }
 
   &__form {
     margin-top: 0.5em;
     margin-bottom: 1.5rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-gap: 1rem;
+    display: flex;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
Adds scrollbars to the app to help with the discoverability of scrollable containers. These are custom styled, and so not as obtrusive as native scrollbars.

<img width="1920" alt="Screen Shot 2019-05-30 at 11 50 10 PM" src="https://user-images.githubusercontent.com/1387940/58692894-7fd50000-8387-11e9-867a-44a39dde8838.png">

Outstanding issues:

- The use of `-webkit-overflow-scrolling: touch;` disables custom scrollbars entirely on iOS, but without it, there is no momentum scrolling (native feeling) on iOS.
- If the above were acceptable, removing the property does show the custom scrollbar, but iOS uses reverse direction scrolling, so attempting to drag the scrollbar down will scroll the container down (opposite behavior of windows, android, linux). 

Mitigating factors:
- Scrolling is probably best on iOS devices. 


For now, the plan would be to have custom scrollbars for all platforms apart from iOS.