### PR TITLE
Skip logic not to skip past the first or last stage

### DIFF
--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -45,6 +45,9 @@ class Protocol extends Component {
       while (this.props.isSkipped(skipToIndex)) {
         skipToIndex += 1;
       }
+      if (skipToIndex > this.props.maxLength - 1) {
+        skipToIndex = this.props.stageIndex;
+      }
 
       this.props.changeStage(`${this.props.pathPrefix}/${skipToIndex}`);
     } else {
@@ -67,6 +70,10 @@ class Protocol extends Component {
       while (this.props.isSkipped(skipToIndex)) {
         skipToIndex -= 1;
       }
+      if (skipToIndex < 0) {
+        skipToIndex = this.props.stageIndex;
+      }
+
       this.props.changeStage(`${this.props.pathPrefix}/${skipToIndex}`);
     } else {
       this.props.promptBackward();
@@ -150,6 +157,7 @@ Protocol.propTypes = {
   isLastPrompt: PropTypes.func.isRequired,
   isSkipped: PropTypes.func.isRequired,
   isSessionLoaded: PropTypes.bool.isRequired,
+  maxLength: PropTypes.number,
   nextIndex: PropTypes.number.isRequired,
   pathPrefix: PropTypes.string,
   percentProgress: PropTypes.number,
@@ -168,6 +176,7 @@ Protocol.defaultProps = {
   promptId: 0,
   stageBackward: false,
   stageIndex: 0,
+  maxLength: 1,
 };
 
 function mapStateToProps(state, ownProps) {
@@ -192,6 +201,7 @@ function mapStateToProps(state, ownProps) {
     promptId,
     stage,
     stageIndex,
+    maxLength,
   };
 }
 

--- a/src/selectors/skip-logic.js
+++ b/src/selectors/skip-logic.js
@@ -57,6 +57,16 @@ export const isStageSkipped = index => createSelector(
   (logic, action, results) => {
     if (!logic) return false;
 
+    // Handle skipLogic with no rules defined differently depending on action.
+    // skipLogic.action === SHOW <- always show the stage
+    // skipLogic.action === SKIP <- always skip the stage
+    // Allows for a quick way to disable a stage by setting SKIP if, and then
+    // not defining rules.
+    // Should be changed with https://github.com/codaco/Architect/issues/517
+    if (!logic.filter.rules || !logic.filter.rules.length === 0) {
+      console.warn('Encountered skip logic with no rules defined at index', index); // eslint-disable-line no-console
+      return !!action;
+    }
     const outerQuery = results.nodes.length > 0;
     return !!logic && ((action && outerQuery) || (!action && !outerQuery));
   },


### PR DESCRIPTION
This ensures we don't skip past the beginning or end of a protocol, stopping at the current index if there are no more unskipped stages remaining.