### PR TITLE
freeze button should not show when no freeDraw

### DIFF
--- a/src/containers/Interfaces/Narrative.js
+++ b/src/containers/Interfaces/Narrative.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import { getProtocolStages } from '../../selectors/protocol';
@@ -106,7 +107,7 @@ class Narrative extends Component {
     const concentricCircles = stage.background && stage.background.concentricCircles;
     const skewedTowardCenter = stage.background && stage.background.skewedTowardCenter;
     const allowRepositioning = stage.behaviours && stage.behaviours.allowRepositioning;
-    const freeDraw = stage.behaviours && stage.behaviours.freeDraw;
+    const freeDraw = get(stage, 'behaviours.freeDraw', false);
 
     const showResetButton = this.state.activeAnnotations || this.state.activeFocusNodes;
 


### PR DESCRIPTION
Fixes #879. To check, create a protocol with no behaviors toggled (so freeDraw is undefined, not false). The "freeze" button (snowflake) should not display. With a protocol like development protocol that has freeDraw toggled true, the snowflake should display still.