### PR TITLE
Fix/multiple ego forms not submitting

### DIFF
--- a/src/containers/Form.js
+++ b/src/containers/Form.js
@@ -155,6 +155,7 @@ export default compose(
   connect(makeMapStateToProps),
   autoInitialisedForm,
   reduxForm({
+    enableReinitialize: true, // form could have ego out of sync because submit is in progress
     touchOnChange: true,
     touchOnBlur: false,
     onSubmitFail: scrollToFirstError,

--- a/src/containers/Interfaces/EgoForm.js
+++ b/src/containers/Interfaces/EgoForm.js
@@ -26,7 +26,7 @@ const TAGS = [
   'thematicBreak',
 ];
 
-const FORM_NAME = 'EGO_FORM';
+const getFormName = index => `EGO_FORM_${index}`;
 
 class EgoForm extends Component {
   constructor(props) {
@@ -37,22 +37,22 @@ class EgoForm extends Component {
   }
 
   formSubmitAllowed = () => (
-    this.props.formEnabled(this.props.form)
+    this.props.formEnabled(getFormName(this.props.stageIndex))
   );
 
   isStageBeginning = () => (
     this.state.scrollProgress === 0
   );
 
-  isStageEnding = () => this.props.formEnabled();
+  isStageEnding = () => this.props.formEnabled(getFormName(this.props.stageIndex));
 
   clickNext = () => {
-    this.props.submitForm();
+    this.props.submitForm(this.props.stageIndex);
   };
 
   clickPrevious = () => {
     if (this.formSubmitAllowed()) {
-      this.props.submitForm();
+      this.props.submitForm(this.props.stageIndex);
     }
   };
 
@@ -98,7 +98,7 @@ class EgoForm extends Component {
             <Form
               {...form}
               initialValues={ego[entityAttributesProperty]}
-              form={FORM_NAME}
+              form={getFormName(this.props.stageIndex)}
               subject={{ entity: 'ego' }}
               onSubmit={this.handleSubmitForm}
             />
@@ -121,6 +121,7 @@ EgoForm.propTypes = {
   introductionPanel: PropTypes.object.isRequired,
   ego: PropTypes.object,
   formEnabled: PropTypes.func.isRequired,
+  stageIndex: PropTypes.number.isRequired,
   submitForm: PropTypes.func.isRequired,
   updateEgo: PropTypes.func.isRequired,
 };
@@ -135,13 +136,13 @@ function mapStateToProps(state, props) {
     form: props.stage.form,
     introductionPanel: props.stage.introductionPanel,
     ego,
-    formEnabled: () => isValid(FORM_NAME)(state) && !isSubmitting(FORM_NAME)(state),
+    formEnabled: formName => isValid(formName)(state) && !isSubmitting(formName)(state),
   };
 }
 
 const mapDispatchToProps = dispatch => ({
   updateEgo: bindActionCreators(sessionsActions.updateEgo, dispatch),
-  submitForm: bindActionCreators(() => submit(FORM_NAME), dispatch),
+  submitForm: bindActionCreators(index => submit(getFormName(index)), dispatch),
 });
 
 export { EgoForm };

--- a/src/containers/Stage.js
+++ b/src/containers/Stage.js
@@ -8,7 +8,7 @@ import StageErrorBoundary from '../components/StageErrorBoundary';
   * Render a protocol interface based on protocol info and id
   * @extends Component
   */
-const Stage = React.forwardRef(({ stage, promptId }, ref) => {
+const Stage = React.forwardRef(({ stage, promptId, stageIndex }, ref) => {
   const CurrentInterface = getInterface(stage.type);
 
   let interfaceRef = ref;
@@ -22,7 +22,12 @@ const Stage = React.forwardRef(({ stage, promptId }, ref) => {
       <div className="stage__interface">
         <StageErrorBoundary>
           { CurrentInterface &&
-            <CurrentInterface stage={stage} promptId={promptId} ref={interfaceRef} />
+            <CurrentInterface
+              stage={stage}
+              stageIndex={stageIndex}
+              promptId={promptId}
+              ref={interfaceRef}
+            />
           }
         </StageErrorBoundary>
       </div>

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -239,7 +239,7 @@ const updateEgo = (modelData = {}, attributeData = {}) => (dispatch, getState) =
   const { activeSessionId, sessions, installedProtocols } = getState();
 
   const activeProtocol = installedProtocols[sessions[activeSessionId].protocolUID];
-  const egoRegistry = activeProtocol.codebook.node;
+  const egoRegistry = activeProtocol.codebook.ego;
 
   dispatch({
     type: networkActionTypes.UPDATE_EGO,

--- a/src/utils/Validations.js
+++ b/src/utils/Validations.js
@@ -1,4 +1,4 @@
-import { keys, pickBy } from 'lodash';
+import { isNil, keys, pickBy } from 'lodash';
 
 const coerceArray = (value) => {
   if (value instanceof Object) {
@@ -12,7 +12,7 @@ const coerceArray = (value) => {
 
 export const required = () =>
   value =>
-    (value ? undefined : 'You must answer this question before continuing.');
+    (isNil(value) ? 'You must answer this question before continuing.' : undefined);
 export const maxLength = max =>
   value =>
     (value && value.length > max ? `Your answer must be ${max} characters or less` : undefined);


### PR DESCRIPTION
Fixes #946. The issue was not with exporting, but rather with multiple consecutive ego forms. This ensures that consecutive ego forms aren't a problem, and fixes an issue with ego default values not populating correctly.

Also fixes #947. We had [updated protocol validation to allow it](https://github.com/codaco/Network-Canvas/pull/925/), but had not updated field validation to accept `0` as valid.