### PR TITLE
Fix/protocol loading cordova

### DIFF
--- a/src/utils/protocol/__tests__/protocolPath.test.js
+++ b/src/utils/protocol/__tests__/protocolPath.test.js
@@ -27,4 +27,24 @@ describe('protocolPath', () => {
       expect(() => protocolPath()).toThrow();
     });
   });
+
+  describe('Cordova', () => {
+    beforeAll(() => {
+      getEnvironment.mockReturnValue(environments.CORDOVA);
+    });
+
+    it('Generates an asset path for the file', () => {
+      expect(
+        protocolPath('foo.canvas', 'protocol.json'),
+      ).toEqual('tmp/mock/user/path/protocols/foo.canvas/protocol.json');
+
+      expect(
+        protocolPath('foo.canvas'),
+      ).toEqual('tmp/mock/user/path/protocols/foo.canvas/');
+    });
+
+    it('Thows an error if the protocol is not specified', () => {
+      expect(() => protocolPath()).toThrow();
+    });
+  });
 });

--- a/src/utils/protocol/protocolPath.js
+++ b/src/utils/protocol/protocolPath.js
@@ -7,8 +7,8 @@ import { userDataPath, appPath } from '../filesystem';
 
 const isValidProtocolUID = protocolUID => (isString(protocolUID) && protocolUID.length > 0);
 
-const ensureArray = (filePath) => {
-  if (isString(filePath)) {
+const ensureArray = (filePath = []) => {
+  if (!isArray(filePath)) {
     return [filePath];
   }
 
@@ -49,6 +49,11 @@ const protocolPath = (environment) => {
   if (environment === environments.CORDOVA) {
     return (protocolUID, filePath) => {
       if (!isValidProtocolUID(protocolUID)) throw Error('Protocol name is not valid');
+
+      if (!filePath) {
+        // Cordova expects a trailing slash:
+        return [userDataPath(), 'protocols', protocolUID, undefined].join('/');
+      }
 
       return [userDataPath(), 'protocols', protocolUID].concat(ensureArray(filePath)).join('/');
     };

--- a/src/utils/protocol/protocolPath.js
+++ b/src/utils/protocol/protocolPath.js
@@ -7,8 +7,8 @@ import { userDataPath, appPath } from '../filesystem';
 
 const isValidProtocolUID = protocolUID => (isString(protocolUID) && protocolUID.length > 0);
 
-const ensureArray = (filePath = []) => {
-  if (!isArray(filePath)) {
+const ensureArray = (filePath) => {
+  if (isString(filePath)) {
     return [filePath];
   }
 


### PR DESCRIPTION
The previous update made `ensureArray()` work as expected, but broke the quirky behaviour of protocolPath.

This fix keeps the as expected ensureArray, but documents and keeps the quirky behaviour of protocolPath.

note: this is using git flow, so we are now merging into `develop`