### PR TITLE
correct typo in onCancel handler

### DIFF
--- a/src/ducks/modules/__tests__/dialogs.test.js
+++ b/src/ducks/modules/__tests__/dialogs.test.js
@@ -44,4 +44,53 @@ describe('dialogs', () => {
       });
     });
   });
+
+  describe('openDialog', () => {
+    let store;
+    const getDialog = () => ({
+      foo: 'bar',
+      onCancel: jest.fn(),
+      onConfirm: jest.fn(),
+    });
+
+    beforeEach(() => {
+      store = createStore(reducer, undefined, applyMiddleware(thunks));
+    });
+
+    it('Returns a promise', () => {
+      const dialog = getDialog();
+
+      expect.assertions(1);
+
+      expect(store.dispatch(actionCreators.openDialog(dialog))).toBeInstanceOf(Promise);
+    });
+
+    it('Promise resolves to `false` when onCancel is called', () => {
+      const dialog = getDialog();
+
+      expect.assertions(1);
+
+      const subject = expect(store.dispatch(actionCreators.openDialog(dialog)))
+        .resolves.toBe(false);
+
+      const state = store.getState();
+      state.dialogs[0].onCancel();
+
+      return subject;
+    });
+
+    it('Promise resolves to `true` when onConfirm is called', () => {
+      const dialog = getDialog();
+
+      expect.assertions(1);
+
+      const subject = expect(store.dispatch(actionCreators.openDialog(dialog)))
+        .resolves.toBe(true);
+
+      const state = store.getState();
+      state.dialogs[0].onConfirm();
+
+      return subject;
+    });
+  });
 });

--- a/src/ducks/modules/dialogs.js
+++ b/src/ducks/modules/dialogs.js
@@ -48,7 +48,7 @@ const openDialog = dialog =>
       };
 
       const onCancel = () => {
-        if (dialog.onConfirm) { dialog.onCancel(); }
+        if (dialog.onCancel) { dialog.onCancel(); }
         resolve(false);
       };
 


### PR DESCRIPTION
This PR fixes an issue that causes the app to crash when clicking the cancel button if an `onCancel` event handler is not present in a Dialog.