### PR TITLE
keep sessions as an object

### DIFF
--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -90,7 +90,7 @@ describe('sessions reducer', () => {
       },
     );
 
-    expect(newState).toEqual([]);
+    expect(newState).toEqual(mockState);
   });
 
 

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -1,4 +1,4 @@
-import { omit, map, filter } from 'lodash';
+import { omit, map, reduce } from 'lodash';
 import uuidv4 from '../../utils/uuid';
 import ApiClient from '../../utils/ApiClient';
 import { actionCreators as SessionWorkerActions } from './sessionWorkers';
@@ -25,10 +25,12 @@ const withTimestamp = session => ({
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case installedProtocolsActionTypes.DELETE_PROTOCOL:
-      return filter(
-        state,
-        session => session.protocolUID !== action.protocolUID,
-      );
+      return reduce(state, (result, sessionData, sessionId) => {
+        if (sessionData.protocolUID !== action.protocolUID) {
+          return { ...result, [sessionId]: sessionData };
+        }
+        return result;
+      }, {});
     case networkActionTypes.ADD_NODE:
     case networkActionTypes.BATCH_ADD_NODES:
     case networkActionTypes.REMOVE_NODE:


### PR DESCRIPTION
Fixes #960. Makes sure we keep `sessions` as an object in redux, not converting it to an array. To test, add two protocols with sessions for each. Delete one of the protocols, and make sure `sessions` still is an object with the uuids as keys. You could also verify by exporting a remaining session and ensuring the overview for sessions lists the expected uuids.