### PR TITLE
fix faulty assumption on batchAddNodes

### DIFF
--- a/src/ducks/modules/network.js
+++ b/src/ducks/modules/network.js
@@ -131,7 +131,11 @@ export default function reducer(state = initialState, action = {}) {
         nodes: (() =>
           state.nodes.concat(action.nodeList.map(node => nodeWithModelandAttributeData(
             node,
-            action.attributeData,
+            {
+              ...action.defaultAttributesForType,
+              ...node[entityAttributesProperty],
+              ...action.attributeData,
+            },
           )))
         )(),
       };

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -166,13 +166,14 @@ const batchAddNodes = (nodeList, attributeData, type) => (dispatch, getState) =>
   const nodeRegistry = activeProtocol.codebook.node;
 
   const registryForType = nodeRegistry[type].variables;
-
   dispatch({
     type: networkActionTypes.BATCH_ADD_NODES,
     sessionId: activeSessionId,
     nodeList,
-    attributeData: {
+    defaultAttribtutesForType: {
       ...getDefaultAttributesForEntityType(registryForType),
+    },
+    attributeData: {
       ...attributeData,
     },
   });


### PR DESCRIPTION
Fixes an issue causing nodes created from the large roster interface not to have correct attribute data.