### PR TITLE
Remove fallback node label handling, and display instructive label to users

### DIFF
--- a/src/selectors/network.js
+++ b/src/selectors/network.js
@@ -69,14 +69,8 @@ const labelLogic = (codebookForNodeType, nodeAttributes) => {
     return nodeAttributes[nodeVariableCalledName];
   }
 
-  // First available string variable with a value
-  const fallbackVariable = Object.keys(nodeAttributes).filter(attribute => typeof nodeAttributes[attribute] === 'string').sort();
-  if (fallbackVariable) {
-    return nodeAttributes[fallbackVariable[0]];
-  }
-
   // Last resort!
-  return 'No label available';
+  return 'No \'name\' variable!';
 };
 
 // Gets the node label variable and returns its value, or "No label".

--- a/src/selectors/network.js
+++ b/src/selectors/network.js
@@ -70,7 +70,7 @@ const labelLogic = (codebookForNodeType, nodeAttributes) => {
   }
 
   // First available string variable with a value
-  const fallbackVariable = Object.keys(nodeAttributes).filter(attribute => typeof nodeAttributes[attribute] === 'string');
+  const fallbackVariable = Object.keys(nodeAttributes).filter(attribute => typeof nodeAttributes[attribute] === 'string').sort();
   if (fallbackVariable) {
     return nodeAttributes[fallbackVariable[0]];
   }


### PR DESCRIPTION
This PR sorts fallback variables used for node labelling, to ensure the one that is picked is consistent.

Fixes a bug a user reported where, when previewing a protocol in Architect, a gender variable was being used as a label. However, when the same protocol was viewed in NC the variable they had intended was being used for labels instead.

It turned out that the root cause of this was that the user had no variable called `name` in the codebook, and the sequence of the fallback variables was different between NC and Architect. Thus, NC in preview mode was selecting a different fallback variable than NC standalone. We believe this to be due to non-deterministic ordering of object properties in JS.

Initially we used `sort()` on the filtered fallback variables list, ensuring consistency. 

However we subsequently decided that removing this feature in favor of pointing the user to the source of the problem was a better approach.