### PR TITLE
Fix startscreen bug in iOS 10

### DIFF
--- a/src/styles/containers/_app.scss
+++ b/src/styles/containers/_app.scss
@@ -47,7 +47,6 @@
     height: 100%;
     overflow: hidden;
     width: 100vw;
-    display: flex;
     position: relative; // do not remove this!
   }
 


### PR DESCRIPTION
User reported an error when opening the app on an older iPad running iOS 10.3.3. Was able to repro:

<img width="1320" alt="Screen Shot 2019-10-09 at 6 02 08 PM" src="https://user-images.githubusercontent.com/1387940/66503382-0d0b2c80-eabf-11e9-8d9a-7081c58547bd.png">

After fix:

<img width="1276" alt="Screen Shot 2019-10-09 at 6 02 14 PM" src="https://user-images.githubusercontent.com/1387940/66503390-109eb380-eabf-11e9-8112-edd8680d038c.png">


Fix was to remove display:flex from `app__content`. Unclear on why this is the cause of the issue, and the property should be required. This will need testing cross platform to ensure it doesn't break things for other users.