### PR TITLE
Fix/typo sessions selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8618,7 +8618,7 @@
                 },
                 "shelljs": {
                     "version": "0.5.3",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
                     "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
                 }
             }
@@ -8712,7 +8712,7 @@
                 },
                 "shelljs": {
                     "version": "0.5.3",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
                     "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM="
                 }
             }
@@ -24017,7 +24017,7 @@
         },
         "react-redux": {
             "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+            "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
             "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
             "dev": true,
             "requires": {
@@ -27172,7 +27172,7 @@
                 },
                 "onetime": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
                     "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
                     "dev": true
                 },

--- a/src/ducks/modules/__mocks__/network.js
+++ b/src/ducks/modules/__mocks__/network.js
@@ -2,7 +2,11 @@
 
 import uuidv4 from '../../../utils/uuid';
 
-const { actionTypes, entityPrimaryKeyProperty } = jest.requireActual('../network');
+const {
+  actionTypes,
+  actionCreators: networkActionCreators,
+  entityPrimaryKeyProperty,
+} = jest.requireActual('../network');
 
 const reducer = jest.fn(() => ({
   nodes: [],
@@ -12,8 +16,14 @@ const reducer = jest.fn(() => ({
   },
 }));
 
+const actionCreators = {
+  ...networkActionCreators,
+  batchAddNodes: jest.fn(networkActionCreators.batchAddNodes),
+};
+
 export default reducer;
 
 export {
   actionTypes,
+  actionCreators,
 };

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -2,6 +2,7 @@
 
 import reducer,
 { actionTypes,
+  actionCreators,
   entityPrimaryKeyProperty as PK,
   entityAttributesProperty,
 } from '../network';
@@ -27,6 +28,8 @@ describe('network reducer', () => {
         _uid: 'b868f61155ce8b570ae5f40337a6f64f5a72f199',
         attributes: {
           name: 'Jacqueline',
+          overwriteInNode: 15,
+          overwriteInStage: 57,
         },
       },
       {
@@ -96,25 +99,29 @@ describe('network reducer', () => {
 
     const mockProtocolAttributes = {
       protocolAttribute: 33,
+      overwriteInNode: 10,
+      overwriteInStage: 50,
     };
 
     const mockStageAttributes = {
       myStageAttribute: 45,
+      overwriteInStage: 55,
     };
+
+    const action = actionCreators.batchAddNodes(
+      mockNodeList,
+      mockStageAttributes,
+      mockProtocolAttributes,
+    );
 
     const newState = reducer(
       {
         ...mockState,
       },
-      {
-        type: actionTypes.BATCH_ADD_NODES,
-        nodeList: mockNodeList,
-        defaultAttributesForType: mockProtocolAttributes,
-        attributeData: mockStageAttributes,
-      },
+      action,
     );
 
-    expect(newState.nodes.length).toBe(8);
+    expect(newState.nodes).toHaveLength(8);
 
     // Contains stage attributes and default code attributes
     const newNode = newState.nodes[0];
@@ -128,6 +135,8 @@ describe('network reducer', () => {
         attributes: {
           myStageAttribute: 45,
           protocolAttribute: 33,
+          overwriteInNode: 15,
+          overwriteInStage: 55,
           name: 'Jacqueline',
         },
       },

--- a/src/ducks/modules/__tests__/network.test.js
+++ b/src/ducks/modules/__tests__/network.test.js
@@ -18,6 +18,123 @@ const mockState = {
 };
 
 describe('network reducer', () => {
+  it('should handle BATCH_ADD_NODE', () => {
+    const mockNodeList = [
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: 'b868f61155ce8b570ae5f40337a6f64f5a72f199',
+        attributes: {
+          name: 'Jacqueline',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '369927e6e432e609ffe921d8bca8d153cb9ba030',
+        attributes: {
+          name: 'Anthony',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '55cc9b1e72354d1d762003535a231e7b573a0360',
+        attributes: {
+          name: 'Benjamin',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '2fc08cfdd0a6a769b542af289acce07231464910',
+        attributes: {
+          name: 'Jerreed',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '5027f94a028494f8ac6e33f0b5cbc909a94a13f9',
+        attributes: {
+          name: 'John',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '2fc265eb45462d153cbf5401fa1783636ab1a8aa',
+        attributes: {
+          name: 'José Luis',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '8b40666afa3ff97ea2f593d9cbea3094450d837e',
+        attributes: {
+          name: 'Laura',
+        },
+      },
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptId: 'ebf658e7-e969-45c4-8a74-af3a2d653e55',
+        _uid: '43d93f49167ebc142efa0aef127152ddad614c74',
+        attributes: {
+          name: 'John',
+        },
+      },
+    ];
+
+    const mockProtocolAttributes = {
+      protocolAttribute: 33,
+    };
+
+    const mockStageAttributes = {
+      myStageAttribute: 45,
+    };
+
+    const newState = reducer(
+      {
+        ...mockState,
+      },
+      {
+        type: actionTypes.BATCH_ADD_NODES,
+        nodeList: mockNodeList,
+        defaultAttributesForType: mockProtocolAttributes,
+        attributeData: mockStageAttributes,
+      },
+    );
+
+    expect(newState.nodes.length).toBe(8);
+
+    // Contains stage attributes and default code attributes
+    const newNode = newState.nodes[0];
+    expect(newNode).toEqual(
+      {
+        type: 'ffcd1f42-3c9e-4e51-9a0e-305194a3e601',
+        stageId: '0036b700-9050-11e9-8c88-ff1bcaf707d9',
+        promptIDs: ['ebf658e7-e969-45c4-8a74-af3a2d653e55'],
+        itemType: undefined,
+        _uid: 'b868f61155ce8b570ae5f40337a6f64f5a72f199',
+        attributes: {
+          myStageAttribute: 45,
+          protocolAttribute: 33,
+          name: 'Jacqueline',
+        },
+      },
+    );
+  });
+
+
   it('should handle ADD_NODE', () => {
     const newState = reducer(
       {

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -3,7 +3,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import uuidv4 from '../../../utils/uuid';
 import reducer, { actionCreators, actionTypes } from '../sessions';
-import networkReducer, { actionTypes as networkActionTypes } from '../network';
+import networkReducer, { actionTypes as networkActionTypes, actionCreators as networkActions } from '../network';
 import { actionTypes as installedProtocolsActionTypes } from '../installedProtocols';
 
 jest.mock('../network');
@@ -152,6 +152,53 @@ describe('sessions', () => {
   });
 
   describe('actions', () => {
+    it('batchAddNodes should dispatch network.batchAddNodes action with sessionId', () => {
+      const nodeList = [{ bazz: 'buzz' }];
+      const attributeData = { foo: 'bar' };
+      const type = 'mockType';
+      const defaultProperties = {
+        a: null,
+        b: false,
+        c: null,
+      };
+
+      const store = mockStore({
+        activeSessionId: 'mockSession',
+        sessions: {
+          mockSession: {
+            protocolUID: 'mockProtocol',
+          },
+        },
+        installedProtocols: {
+          mockProtocol: {
+            codebook: {
+              node: {
+                mockType: {
+                  variables: {
+                    a: { type: 'string' },
+                    b: { type: 'boolean' },
+                    c: { type: 'categorical' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      store.dispatch(actionCreators.batchAddNodes(nodeList, attributeData, type));
+
+      expect(networkActions.batchAddNodes.mock.calls).toEqual([[
+        nodeList,
+        attributeData,
+        defaultProperties,
+      ]]);
+
+      const dispatchedActions = store.getActions();
+      expect(dispatchedActions).toHaveLength(1);
+      expect(dispatchedActions[0]).toMatchObject({ sessionId: 'mockSession' });
+    });
+
     it('should add an UPDATE_PROMPT action', () => {
       const store = mockStore({ activeSessionId: 'a', sessions: { a: {} } });
 

--- a/src/ducks/modules/sessions.js
+++ b/src/ducks/modules/sessions.js
@@ -170,7 +170,7 @@ const batchAddNodes = (nodeList, attributeData, type) => (dispatch, getState) =>
     type: networkActionTypes.BATCH_ADD_NODES,
     sessionId: activeSessionId,
     nodeList,
-    defaultAttribtutesForType: {
+    defaultAttributesForType: {
       ...getDefaultAttributesForEntityType(registryForType),
     },
     attributeData: {

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -35,7 +35,6 @@ export const makeGetNextUnplacedNode = () =>
           (has(attributes, layoutVariable) && isNil(attributes[layoutVariable]))
         );
       });
-
       const sorter = sortOrder(sortOptions);
       return first(sorter(unplacedNodes));
     },


### PR DESCRIPTION
 Kate found a bug in NC that I tracked down to a typo in `/Users/joshua/Projects/Network-Canvas/src/ducks/modules/sessions.js`. The action creator has a typo in the property (`defaultAttribtutesForType` instead of `defaultAttributesForType`).

I added test tests to the network reducer to cover `BATCH_ADD_NODES`. Need to add a test for the action creator itself.