### PR TITLE
Fix/roster protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,8 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>[/\\\\](www|docs|node_modules|scripts|test)[/\\\\]",
-      "<rootDir>/src/utils/networkQuery"
+      "<rootDir>/src/utils/networkQuery",
+      "<rootDir>/integration-tests"
     ],
     "testEnvironment": "node",
     "testURL": "http://localhost",

--- a/src/containers/Setup/ProtocolList.js
+++ b/src/containers/Setup/ProtocolList.js
@@ -101,7 +101,7 @@ class ProtocolList extends Component {
                 click the button in the bottom right to pair with an instance of Server,
                 import a protocol from a URL, or add a local .netcanvas file.
               </p>
-              <p>Alternatively, click <a onClick={() => this.props.importProtocolFromURI('https://documentation.networkcanvas.com/protocols/Public%20Health%20Protocol.netcanvas')}>here</a> to download and install a sample public health protocol (requires network access).</p>
+              <p>Alternatively, click <a onClick={() => this.props.importProtocolFromURI('https://documentation.networkcanvas.com/protocols/Public%20Health%20Protocol%20schema%202.netcanvas')}>here</a> to download and install a sample public health protocol (requires network access).</p>
             </div>
           </div>
         }

--- a/src/ducks/modules/__tests__/sessions.test.js
+++ b/src/ducks/modules/__tests__/sessions.test.js
@@ -129,7 +129,7 @@ describe('sessions', () => {
     });
 
     it('network actions defer to network reducer', () => {
-      const networkActions = [
+      const networkActionList = [
         networkActionTypes.ADD_NODE,
         networkActionTypes.BATCH_ADD_NODES,
         networkActionTypes.REMOVE_NODE,
@@ -143,7 +143,7 @@ describe('sessions', () => {
         networkActionTypes.UPDATE_EGO,
       ];
 
-      networkActions.forEach((actionType) => {
+      networkActionList.forEach((actionType) => {
         reducer({ a: { network: {} } }, { type: actionType, sessionId: 'a' });
       });
 


### PR DESCRIPTION
Updates the roster protocol link to one with schema version 2.

Also fixes a couple of linting / test issues.

Resolves https://github.com/codaco/Network-Canvas/issues/980