### PR TITLE
Deemphasise outdated protocol notice

### DIFF
--- a/src/components/Setup/ProtocolCard.js
+++ b/src/components/Setup/ProtocolCard.js
@@ -20,8 +20,8 @@ class ProtocolCard extends React.Component {
 
   handleSchemaOutdatedInfo = () => {
     this.props.openDialog({
-      type: 'Warning',
-      title: 'Out of Date Schema',
+      type: 'Notice',
+      title: 'Schema can be updated',
       canCancel: false,
       message: (
         <React.Fragment>
@@ -79,7 +79,7 @@ class ProtocolCard extends React.Component {
 
   modifierClasses = cx(
     'protocol-card',
-    { 'protocol-card--warning': !this.isObsoleteProtocol() && this.isOutdatedProtocol() },
+    { 'protocol-card--info': !this.isObsoleteProtocol() && this.isOutdatedProtocol() },
     { 'protocol-card--error': this.isObsoleteProtocol() },
   );
 
@@ -88,8 +88,8 @@ class ProtocolCard extends React.Component {
   renderCardIcon() {
     if (this.isOutdatedProtocol()) {
       return (
-        <div className="protocol-card__warning" onClick={this.handleSchemaOutdatedInfo}>
-          <Icon name="warning" />
+        <div className="protocol-card__info" onClick={this.handleSchemaOutdatedInfo}>
+          <Icon name="info" />
         </div>
       );
     }

--- a/src/components/Setup/ProtocolCard.js
+++ b/src/components/Setup/ProtocolCard.js
@@ -29,12 +29,11 @@ class ProtocolCard extends React.Component {
             This protocol uses an older version of the protocol file format, or &quot;schema&quot;.
           </p>
           <p>
-            Newer schema versions support additional features in Network Canvas, and may be
-            required in order to use this protocol in the future. To avoid losing the ability
-            to conduct interviews, you are strongly advised to migrate this protocol to the
-            latest schema version. To do this, open the protocol file it in the latest version
-            of Architect, and follow the migration instructions. Once migrated, install the
-            new version of the protocol on this device.
+            Newer schema versions support additional features in Network Canvas. During the beta
+            phase, we kindly request that you update your protocols to the latest version, and
+            evaluate the newest features as we implement them. To do this, open the original
+            protocol file it in the latest version of Architect, and follow the migration
+            instructions. Once migrated, install the new version of the protocol on this device.
           </p>
           <p>
             For documentation on this issue, please see our documentation site.

--- a/src/styles/components/_protocol-card.scss
+++ b/src/styles/components/_protocol-card.scss
@@ -13,6 +13,10 @@ $component: 'protocol-card';
     border-bottom-color: var(--warning);
   }
 
+  &--info {
+    border-bottom-color: var(--info);
+  }
+
   &--error {
     border-bottom-color: var(--error);
   }
@@ -88,20 +92,34 @@ $component: 'protocol-card';
     }
   }
 
+  &__info,
   &__warning,
   &__error {
     position: absolute;
     top: unit(-2);
     left: unit(-2);
-    padding: 1.5rem;
-    background: var(--warning);
+    height: unit(8);
+    width: unit(8);
     border-radius: 50%;
     cursor: pointer;
 
     .icon {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
       height: unit(4);
       width: unit(4);
     }
+  }
+
+  &__info {
+    background: var(--info);
+  }
+
+  &__warning,
+  &__error {
+    background: var(--warning);
   }
 
   &__error {


### PR DESCRIPTION
- Uses info/notice colouring/icon on the outdated protocol card.
- Downgrades dialog to a notice, reframes the title, and rewording of the text.

<img width="616" alt="Screenshot 2019-10-17 at 12 01 34" src="https://user-images.githubusercontent.com/776599/67003701-7221dc00-f0d6-11e9-98ba-6c0e8744cf2d.png">

<img width="781" alt="Screenshot 2019-10-17 at 12 14 45" src="https://user-images.githubusercontent.com/776599/67004233-beb9e700-f0d7-11e9-8b17-ffd221e6edee.png">

Resolves https://github.com/codaco/Network-Canvas/issues/981