### PR TITLE
Fix navigation to take into account lack of finish screen

### DIFF
--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -10,8 +10,9 @@ import { actionCreators as sessionsActions } from '../../ducks/modules/sessions'
  * @param {number} direction A positive or negative number indicating
  * forwards or backwards respectively.
  */
-const getStep = direction =>
-  Math.abs(direction) / direction;
+const getStep = direction => Math.abs(direction) / direction;
+const isBackwards = direction => direction < 0;
+const isForwards = direction => direction > 0;
 
 /**
  * Go to the stage at the index provided
@@ -100,19 +101,17 @@ const goToNext = (direction = 1) =>
       isFirstPrompt,
       isLastPrompt,
       isFirstStage,
-      isLastStage,
       isLastScreen,
     } = getSessionProgress(state);
 
-    const isFinishScreen = isLastScreen && !isLastStage;
-    const isLastScreenAndPrompt = isLastScreen && !promptCount || isLastPrompt;
+    const isLastPromptOrHasNone = !promptCount || isLastPrompt;
+    const isLastScreenAndLastPrompt = isLastScreen && isLastPromptOrHasNone;
 
     if (
       // first screen:
-      (direction < 0 && isFirstStage) ||
-      (direction > 0 && isFinishScreen) ||
-      // when finish screen is absent we need to check prompts:
-      (direction > 0 && !isFinishScreen && isLastScreenAndPrompt)
+      (isBackwards(direction) && isFirstStage) ||
+      // when finish screen is absent we need to also check prompts:
+      (isForwards(direction) && isLastScreenAndLastPrompt)
     ) {
       return null;
     }
@@ -122,7 +121,10 @@ const goToNext = (direction = 1) =>
     }
 
     // At the end of the prompts it's time to go to the next stage
-    if ((direction < 0 && isFirstPrompt) || (direction > 0 && isLastPrompt)) {
+    if (
+      (isBackwards(direction) && isFirstPrompt) ||
+      (isForwards(direction) && isLastPrompt)
+    ) {
       return dispatch(goToNextStage(direction));
     }
 

--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -49,7 +49,7 @@ const getNextStage = (direction = 1) =>
       nextIndex += step;
 
       // If we're at either end of the inteview, stop and stay where we are
-      if (nextIndex > stageCount || nextIndex < 0) {
+      if (nextIndex > stageCount - 1 || nextIndex < 0) {
         return null;
       }
     }

--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -100,11 +100,18 @@ const goToNext = (direction = 1) =>
       isFirstPrompt,
       isLastPrompt,
       isFirstStage,
-      isFinish,
+      isLastStage,
+      isLastScreen,
     } = getSessionProgress(state);
 
-    if ((direction < 0 && isFirstStage) || (direction > 0 && isFinish)) {
-      // TODO: handle finish stage & start stage
+    if (
+        // first screen:
+        (direction < 0 && isFirstStage) ||
+        // finish screen:
+        (direction > 0 && isLastScreen && !isLastStage) ||
+        // when finish screen is absent we need to check prompts:
+        (direction > 0 && isLastScreen && isLastStage && isLastPrompt)
+    ) {
       return null;
     }
 

--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -105,14 +105,14 @@ const goToNext = (direction = 1) =>
     } = getSessionProgress(state);
 
     const isFinishScreen = isLastScreen && !isLastStage;
-    const lastScreenAndPrompt = isLastScreen && !promptCount || isLastPrompt;
+    const isLastScreenAndPrompt = isLastScreen && !promptCount || isLastPrompt;
 
     if (
-        // first screen:
-        (direction < 0 && isFirstStage) ||
-        (direction > 0 && isFinishScreen) ||
-        // when finish screen is absent we need to check prompts:
-        (direction > 0 && !isFinishScreen && lastScreenAndPrompt)
+      // first screen:
+      (direction < 0 && isFirstStage) ||
+      (direction > 0 && isFinishScreen) ||
+      // when finish screen is absent we need to check prompts:
+      (direction > 0 && !isFinishScreen && isLastScreenAndPrompt)
     ) {
       return null;
     }

--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -104,13 +104,15 @@ const goToNext = (direction = 1) =>
       isLastScreen,
     } = getSessionProgress(state);
 
+    const isFinishScreen = isLastScreen && !isLastStage;
+    const lastScreenAndPrompt = isLastScreen && !promptCount || isLastPrompt;
+
     if (
         // first screen:
         (direction < 0 && isFirstStage) ||
-        // finish screen:
-        (direction > 0 && isLastScreen && !isLastStage) ||
+        (direction > 0 && isFinishScreen) ||
         // when finish screen is absent we need to check prompts:
-        (direction > 0 && isLastScreen && isLastStage && isLastPrompt)
+        (direction > 0 && !isFinishScreen && lastScreenAndPrompt)
     ) {
       return null;
     }

--- a/src/ducks/modules/navigate.js
+++ b/src/ducks/modules/navigate.js
@@ -36,7 +36,7 @@ const getNextStage = (direction = 1) =>
 
     const {
       currentStage,
-      stageCount,
+      screenCount,
     } = getSessionProgress(state);
 
     const step = getStep(direction);
@@ -49,7 +49,7 @@ const getNextStage = (direction = 1) =>
       nextIndex += step;
 
       // If we're at either end of the inteview, stop and stay where we are
-      if (nextIndex > stageCount - 1 || nextIndex < 0) {
+      if (nextIndex >= screenCount || nextIndex < 0) {
         return null;
       }
     }

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -39,23 +39,24 @@ export const getSessionProgress = (state) => {
   const currentStage = session.stageIndex;
   const stageCount = protocol.stages.length;
   // includes finish screen if present
-  const stageCountWithFinish = stages.length;
+  const screenCount = stages.length;
   const promptCount = get(stages, [currentStage, 'prompts', 'length'], 0);
-  const stageProgress = currentStage / (stageCountWithFinish - 1);
+  const stageProgress = currentStage / (screenCount - 1);
   const promptProgress = promptCount ? currentPrompt / promptCount : 0;
   // This can go over 100% when finish screen is not present,
   // so it needs to be clamped
-  const percentProgress = clamp((stageProgress + (promptProgress / (stageCountWithFinish - 1))) * 100, 0, 100);
+  const percentProgress = clamp((stageProgress + (promptProgress / (screenCount - 1))) * 100, 0, 100);
   const isFirstPrompt = promptCount > 0 && currentPrompt === 0;
   const isLastPrompt = promptCount > 0 && currentPrompt === promptCount - 1;
   const isFirstStage = currentStage === 0;
   const isLastStage = currentStage === stageCount - 1;
   // includes finish screen if present
-  const isLastScreen = currentStage === stageCountWithFinish - 1;
+  const isLastScreen = currentStage === screenCount - 1;
 
   return {
     currentStage,
     stageCount,
+    screenCount,
     currentPrompt,
     promptCount,
     isFirstPrompt,

--- a/src/selectors/session.js
+++ b/src/selectors/session.js
@@ -45,7 +45,8 @@ export const getSessionProgress = (state) => {
   const promptProgress = promptCount ? currentPrompt / promptCount : 0;
   // This can go over 100% when finish screen is not present,
   // so it needs to be clamped
-  const percentProgress = clamp((stageProgress + (promptProgress / (screenCount - 1))) * 100, 0, 100);
+  const percentProgress =
+    clamp((stageProgress + (promptProgress / (screenCount - 1))) * 100, 0, 100);
   const isFirstPrompt = promptCount > 0 && currentPrompt === 0;
   const isLastPrompt = promptCount > 0 && currentPrompt === promptCount - 1;
   const isFirstStage = currentStage === 0;


### PR DESCRIPTION
New navigation changes didn't take into a potential account lack of finish screen (which is omited in preview mode).

This change adds a `screenCount` which is separate from `stageCount` to take into account the additional screen.