### PR TITLE
Fix convex hull color sequencing

### DIFF
--- a/src/components/Canvas/ConvexHulls.js
+++ b/src/components/Canvas/ConvexHulls.js
@@ -4,6 +4,11 @@ import { findIndex } from 'lodash';
 import getAbsoluteBoundingRect from '../../utils/getAbsoluteBoundingRect';
 import { ConvexHull } from './ConvexHull';
 
+const getColor = (group, options) => {
+  const colorIndex = findIndex(options, ['value', group]) + 1 || 1;
+  const color = `cat-color-seq-${colorIndex}`;
+  return color;
+};
 
 class ConvexHulls extends Component {
   constructor() {
@@ -46,14 +51,13 @@ class ConvexHulls extends Component {
 
     return (
       <div style={{ width: '100%', height: '100%' }} ref={this.hullComponent}>
-        {Object.keys(nodesByGroup).map((group, index) => {
-          const colorIndex = findIndex(categoricalOptions, ['value', group]) + 1 || 1;
-          const color = `cat-color-seq-${colorIndex}`;
+        {Object.values(nodesByGroup).map(({ group, nodes }, index) => {
+          const color = getColor(group, categoricalOptions);
           return (
             <ConvexHull
               windowDimensions={this.state.size}
               color={color}
-              nodePoints={nodesByGroup[group]}
+              nodePoints={nodes}
               key={index}
               layoutVariable={layoutVariable}
             />

--- a/src/selectors/__tests__/canvas.test.js
+++ b/src/selectors/__tests__/canvas.test.js
@@ -12,7 +12,7 @@ const node1 = { _uid: 1, type: 'person', [entityAttributesProperty]: { role: ['a
 const node2 = { _uid: 2, type: 'person', [entityAttributesProperty]: { role: ['a'], name: 'foxtrot', closeness: null } };
 const node3 = { _uid: 3, type: 'person', [entityAttributesProperty]: { role: ['a'], name: 'bravo', closeness: null } };
 const node4 = { _uid: 4, type: 'person', [entityAttributesProperty]: { role: ['a'], name: 'echo', closeness: [1, 1] } };
-const node5 = { _uid: 5, type: 'person', [entityAttributesProperty]: { role: ['b'], name: 'charlie', closeness: [1, 1] } };
+const node5 = { _uid: 5, type: 'person', [entityAttributesProperty]: { role: [2], name: 'charlie', closeness: [1, 1] } };
 
 
 const mockState = {
@@ -65,8 +65,8 @@ describe('canvas selectors', () => {
     };
     it('groups placed nodes based on groupVariable', () => {
       const groups = getNodesByCategorical(mockState, props);
-      expect(groups.a).toEqual([node1, node4]);
-      expect(groups.b).toEqual([node5]);
+      expect(groups.a).toEqual({ group: 'a', nodes: [node1, node4] });
+      expect(groups['2']).toEqual({ group: 2, nodes: [node5] });
     });
   });
 

--- a/src/selectors/canvas.js
+++ b/src/selectors/canvas.js
@@ -79,20 +79,16 @@ export const makeGetNodesByCategorical = () => {
         const categoricalValues = node[entityAttributesProperty][categoricalVariable];
 
         // Filter out nodes with no value for this variable.
-        if (!categoricalValues) {
-          return false;
-        }
+        if (!categoricalValues) { return; }
 
         categoricalValues.forEach((categoricalValue) => {
           if (groupedList[categoricalValue]) {
-            groupedList[categoricalValue].push(node);
+            groupedList[categoricalValue].nodes.push(node);
           } else {
-            groupedList[categoricalValue] = [];
-            groupedList[categoricalValue].push(node);
+            groupedList[categoricalValue] = { group: categoricalValue, nodes: [] };
+            groupedList[categoricalValue].nodes.push(node);
           }
         });
-
-        return true;
       });
 
       return groupedList;


### PR DESCRIPTION
Nodes are grouped by categorical variables in the `makeGetNodesByCategorical()` selector, meaning that numerical values are considered as strings. When the group value was searched for in the schema options they didn't match.

Have updated the selector to return in the format:
```js
const nodesByGroup = {
  [groupName]: {
    group: groupName,
    nodes: [ ... ],
  },
  ...
}
```

**Please note**

This PR fixes tests relevant to the changes, but there are pre-existing failing tests on master.

Resolves #1020