### PR TITLE
fix form empty initialValues

### DIFF
--- a/src/containers/ProtocolScreen.js
+++ b/src/containers/ProtocolScreen.js
@@ -111,7 +111,6 @@ class Protocol extends Component {
               promptId={promptId}
               pathPrefix={pathPrefix}
               stageIndex={stageIndex}
-              foo="bar"
               registerBeforeNext={this.registerBeforeNext}
               onComplete={this.onComplete}
             />

--- a/src/containers/SlidesForm/SlidesForm.js
+++ b/src/containers/SlidesForm/SlidesForm.js
@@ -4,14 +4,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { submit, isValid } from 'redux-form';
 import ReactMarkdown from 'react-markdown';
-import uuid from 'uuid';
 import Swiper from 'react-id-swiper';
 import { getCSSVariableAsNumber } from '@codaco/ui/lib/utils/CSSVariables';
+import useGetFormName from '../../hooks/useGetFormName';
 import { ProgressBar } from '../../components';
 import defaultMarkdownRenderers from '../../utils/markdownRenderers';
 import { actionCreators as dialogActions } from '../../ducks/modules/dialogs';
 import { ALLOWED_MARKDOWN_TAGS } from '../../config';
-
 
 const confirmDialog = {
   type: 'Confirm',
@@ -19,8 +18,6 @@ const confirmDialog = {
   message: 'This form contains invalid data, so it cannot be saved. If you continue it will be reset and your changes will be lost. Do you want to discard your changes?',
   confirmLabel: 'Discard changes',
 };
-
-const formPrefix = uuid();
 
 const SlidesForm = (props) => {
   const {
@@ -37,8 +34,7 @@ const SlidesForm = (props) => {
     updateItem,
   } = props;
 
-  const getFormName = uid =>
-    `${formPrefix}_${uid}`;
+  const getFormName = useGetFormName(stage);
 
   const [pendingDirection, setPendingDirection] = useState(null);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -181,7 +177,6 @@ const SlidesForm = (props) => {
             ...form,
             form: formName,
           };
-
 
           return (
             <SlideForm

--- a/src/hooks/__test__/useGetFormName.test.js
+++ b/src/hooks/__test__/useGetFormName.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+import React from 'react';
+import { mount } from 'enzyme';
+import useGetFormName from '../useGetFormName';
+
+describe('useGetFormName', () => {
+  /**
+   * formName should be in the format:
+   * const formName = getFormName(uid); // `${prefix}_$uid`
+   * where prefix is generated on intial render and when stage id changes
+   */
+
+  it('form name prefix does not change unless stage id changes', () => {
+    const MockComponent = ({ stage, uid }) => {
+      const getFormName = useGetFormName(stage);
+      return getFormName(uid);
+    };
+
+    const result = mount(<MockComponent uid={1} stage={{ id: 'foo' }} />);
+
+    const formName1 = result.text();
+    const formName2 = result.setProps({ uid: 2 }).text();
+    const formName3 = result.setProps({ uid: 1, stage: { id: 'bazz' } }).text();
+
+    expect(formName1.slice(0, -2)).toEqual(formName2.slice(0, -2));
+    expect(formName3.slice(0, -2)).not.toEqual(formName1.slice(0, -2));
+  });
+
+  it('form name uid is set when calling getFormName', () => {
+    const MockComponent = ({ stage, uid }) => {
+      const getFormName = useGetFormName(stage);
+      return getFormName(uid);
+    };
+
+    const result = mount(<MockComponent uid={1} stage={{ id: 'foo' }} />);
+
+    const formName1 = result.text();
+    const formName2 = result.setProps({ uid: 2 }).text();
+    const formName3 = result.setProps({ uid: 3, stage: { id: 'bazz' } }).text();
+
+    expect(formName1.slice(-2)).toEqual('_1');
+    expect(formName2.slice(-2)).toEqual('_2');
+    expect(formName3.slice(-2)).toEqual('_3');
+  });
+
+  it('form uid is optional', () => {
+    const MockComponent = ({ stage, uid }) => {
+      const getFormName = useGetFormName(stage);
+      return getFormName(uid);
+    };
+
+
+    const result = mount(<MockComponent uid={null} stage={{ id: 'foo' }} />);
+
+    const formName1 = result.text();
+    const formName2 = result.setProps({ miscProp: 'foo' }).text();
+
+    expect(formName1).toEqual(formName2);
+  });
+});

--- a/src/hooks/useGetFormName.js
+++ b/src/hooks/useGetFormName.js
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import uuid from 'uuid';
+
+const useGetFormName = (stage) => {
+  const formPrefix = useMemo(() => uuid(), [stage.id]);
+
+  const getFormName = uid =>
+    (uid ? `${formPrefix}_${uid}` : formPrefix);
+
+  return getFormName;
+};
+
+export default useGetFormName;


### PR DESCRIPTION
Generates new form name based on changing `stage.id`

When navigating between AlterForms (and AlterEdgeForms), form names clashed.

When the interface changed, the new forms were initialized properly (with initialValues), but were subsequently being destroyed as the forms from the previous stage were deinitialised.