### PR TITLE
handle null list items

### DIFF
--- a/src/components/FilterableListWrapper.js
+++ b/src/components/FilterableListWrapper.js
@@ -54,7 +54,7 @@ class FilterableListWrapper extends Component {
         // Include in filtered list if any of the attribute property values
         // include the filter value
         return nodeDetails.some(
-          item => item.toString().toLowerCase().includes(filterValue),
+          item => item && item.toString().toLowerCase().includes(filterValue),
         );
       },
     );


### PR DESCRIPTION
Fixes #1034. The error when trying to filter sessions is just from items in the session parameters being null or undefined, so this just makes sure we don't choke on those comparisons. 