### PR TITLE
fix useSteps for dyadCensus

### DIFF
--- a/src/containers/Interfaces/DyadCensus/DyadCensus.js
+++ b/src/containers/Interfaces/DyadCensus/DyadCensus.js
@@ -233,7 +233,7 @@ const DyadCensus = ({
                     animate="show"
                   >
                     <div className="dyad-interface__progress">
-                      <ProgressBar orientation="horizontal" percentProgress={((stepsState.substep + 1) / stepsState.steps[stepsState.prompt]) * 100} />
+                      <ProgressBar orientation="horizontal" percentProgress={((stepsState.substep + 1) / stepsState.steps[stepsState.stage]) * 100} />
                     </div>
                     <div className="dyad-interface__options">
                       <AnimatePresence exitBeforeEnter>

--- a/src/containers/Interfaces/DyadCensus/useSteps.js
+++ b/src/containers/Interfaces/DyadCensus/useSteps.js
@@ -63,12 +63,15 @@ const useSteps = (
   };
 
   const [state, setState] = useState(
-    stateReducer({
-      step: 0,
-      substep: 0,
-      stage: 0,
-      direction: 'forward',
-    })(initialValues),
+    stateReducer(
+      initialValues,
+      {
+        step: 0,
+        substep: 0,
+        stage: 0,
+        direction: 'forward',
+      },
+    ),
   );
 
   const next = () => {
@@ -80,12 +83,15 @@ const useSteps = (
 
     const substep = getSubStep(steps, nextStep);
 
-    setState(stateReducer({
-      step: nextStep,
-      substep: substep.step,
-      stage: substep.stage,
-      direction: 'forward',
-    }));
+    setState(stateReducer(
+      state,
+      {
+        step: nextStep,
+        substep: substep.step,
+        stage: substep.stage,
+        direction: 'forward',
+      },
+    ));
   };
 
   const previous = () => {
@@ -97,12 +103,15 @@ const useSteps = (
 
     const substep = getSubStep(steps, nextStep);
 
-    setState(stateReducer({
-      step: nextStep,
-      substep: substep.step,
-      stage: substep.stage,
-      direction: 'backward',
-    }));
+    setState(stateReducer(
+      state,
+      {
+        step: nextStep,
+        substep: substep.step,
+        stage: substep.stage,
+        direction: 'backward',
+      },
+    ));
   };
 
   return [state, next, previous];

--- a/src/containers/Interfaces/DyadCensus/useSteps.js
+++ b/src/containers/Interfaces/DyadCensus/useSteps.js
@@ -18,31 +18,29 @@ const getSubStep = (steps, nextStep) => {
 };
 
 // state reducer for steps state
-const stateReducer = (
-  state,
-  {
-    step,
-    substep,
-    stage,
-    direction,
-  },
-) => {
-  const progress = step > state.progress ? step : state.progress;
+const stateReducer = ({
+  step,
+  substep,
+  stage,
+  direction,
+}) =>
+  (state) => {
+    const progress = step > state.progress ? step : state.progress;
 
-  return ({
-    ...state,
-    step,
-    progress,
-    substep,
-    stage,
-    direction,
-    isCompletedStep: progress > step,
-    isStageStart: substep === 0,
-    isStageEnd: substep >= state.steps[stage] - 1,
-    isStart: step === 0,
-    isEnd: step >= state.totalSteps - 1,
-  });
-};
+    return ({
+      ...state,
+      step,
+      progress,
+      substep,
+      stage,
+      direction,
+      isCompletedStep: progress > step,
+      isStageStart: substep === 0,
+      isStageEnd: substep >= state.steps[stage] - 1,
+      isStart: step === 0,
+      isEnd: step >= state.totalSteps - 1,
+    });
+  };
 
 /**
  * Models 'substeps' in prompts, which allows us to keep track
@@ -63,15 +61,12 @@ const useSteps = (
   };
 
   const [state, setState] = useState(
-    stateReducer(
-      initialValues,
-      {
-        step: 0,
-        substep: 0,
-        stage: 0,
-        direction: 'forward',
-      },
-    ),
+    stateReducer({
+      step: 0,
+      substep: 0,
+      stage: 0,
+      direction: 'forward',
+    })(initialValues),
   );
 
   const next = () => {
@@ -83,15 +78,12 @@ const useSteps = (
 
     const substep = getSubStep(steps, nextStep);
 
-    setState(stateReducer(
-      state,
-      {
-        step: nextStep,
-        substep: substep.step,
-        stage: substep.stage,
-        direction: 'forward',
-      },
-    ));
+    setState(stateReducer({
+      step: nextStep,
+      substep: substep.step,
+      stage: substep.stage,
+      direction: 'forward',
+    }));
   };
 
   const previous = () => {
@@ -103,15 +95,12 @@ const useSteps = (
 
     const substep = getSubStep(steps, nextStep);
 
-    setState(stateReducer(
-      state,
-      {
-        step: nextStep,
-        substep: substep.step,
-        stage: substep.stage,
-        direction: 'backward',
-      },
-    ));
+    setState(stateReducer({
+      step: nextStep,
+      substep: substep.step,
+      stage: substep.stage,
+      direction: 'backward',
+    }));
   };
 
   return [state, next, previous];

--- a/src/styles/containers/_dyad-interface.scss
+++ b/src/styles/containers/_dyad-interface.scss
@@ -123,13 +123,19 @@ $choice-padding: 2rem;
     display: flex;
     justify-content: center;
     align-items: center;
+
+    .node {
+      position: relative;
+      z-index: 2;
+    }
   }
 
   &__edge {
+    position: relative;
     height: 0.5rem;
     z-index: 1;
     width: 11rem;
-    margin: 0 -1rem;
+    margin: 0 -1.5rem;
     background: linear-gradient(to right, transparent 50%, var(--background) 50%);
     background-size: 200% 100%;
     transition: background var(--animation-duration-standard) var(--animation-easing);


### PR DESCRIPTION
This is a fix for an error on the DyadCensus stage. After resetting App Data, I saw this error on the DyadCensus stage of the development protocol: `TypeError: Cannot destructure property 'step' of 'undefined' as it is undefined`. This seems to fix it for me, unless someone has a better solution.