### PR TITLE
Update electron-log to fix ipc warnings

### DIFF
--- a/config/jest/automock.js
+++ b/config/jest/automock.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 jest.mock('electron');
+jest.mock('electron-log');
 jest.mock('fs');
 jest.mock('redux-logger');
 jest.mock('../../src/utils/Environment');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14869,9 +14869,9 @@
       }
     },
     "electron-log": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.9.tgz",
-      "integrity": "sha512-kfV4riUqW8uooYLAfrlB3EJW66W29ePipJU4/Fm8UxQekVNcR2qHI/0tiJX3oWM79VdAUiiYqL9V49lhnSIO8g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.2.tgz",
+      "integrity": "sha512-lBpLh1Q8qayrTxFIrTPcNjSHsosvUfOYyZ8glhiLcx7zCNPDGuj8+nXlEaaSS6LRiQQbLgLG+wKpuvztNzBIrA==",
       "dev": true
     },
     "electron-publish": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "dotenv": "4.0.0",
     "electron": "^9.0.0",
     "electron-builder": "^22.7.0",
-    "electron-log": "^3.0.7",
+    "electron-log": "^4.2.2",
     "electron-updater": "^4.1.2",
     "electron-winstaller": "^4.0.0",
     "emoji-dictionary": "^1.0.9",

--- a/src/__mocks__/electron-log.js
+++ b/src/__mocks__/electron-log.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+
+module.exports = {
+  transports: {
+    console: {
+    },
+    file: {
+    },
+  },
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+};


### PR DESCRIPTION
Version 9.0.0 of electron changes IPC behaviour which requires an electron-log update.